### PR TITLE
Use the function call qualified name in message

### DIFF
--- a/precli/rules/python/lang/marshal/marshal_load.py
+++ b/precli/rules/python/lang/marshal/marshal_load.py
@@ -31,5 +31,5 @@ class MarshalLoad(Rule):
                 file_name=context["file_name"],
                 start_point=context["node"].start_point,
                 end_point=context["node"].end_point,
-                message=self.message.format("marshal"),
+                message=self.message.format(context["func_call_qual"]),
             )

--- a/precli/rules/python/lang/pickle/pickle_load.py
+++ b/precli/rules/python/lang/pickle/pickle_load.py
@@ -32,5 +32,5 @@ class PickleLoad(Rule):
                 file_name=context["file_name"],
                 start_point=context["node"].start_point,
                 end_point=context["node"].end_point,
-                message=self.message.format("pickle"),
+                message=self.message.format(context["func_call_qual"]),
             )

--- a/precli/rules/python/lang/shelve/shelve_open.py
+++ b/precli/rules/python/lang/shelve/shelve_open.py
@@ -31,5 +31,5 @@ class ShelveOpen(Rule):
                 file_name=context["file_name"],
                 start_point=context["node"].start_point,
                 end_point=context["node"].end_point,
-                message=self.message.format("shelve"),
+                message=self.message.format(context["func_call_qual"]),
             )

--- a/precli/rules/python/third_party/PyYAML/yaml_load.py
+++ b/precli/rules/python/third_party/PyYAML/yaml_load.py
@@ -38,5 +38,5 @@ class YamlLoad(Rule):
                 file_name=context["file_name"],
                 start_point=context["node"].start_point,
                 end_point=context["node"].end_point,
-                message=self.message.format("yaml.load"),
+                message=self.message.format(context["func_call_qual"]),
             )

--- a/precli/rules/python/third_party/dill/dill_load.py
+++ b/precli/rules/python/third_party/dill/dill_load.py
@@ -32,5 +32,5 @@ class DillLoad(Rule):
                 file_name=context["file_name"],
                 start_point=context["node"].start_point,
                 end_point=context["node"].end_point,
-                message=self.message.format("dill"),
+                message=self.message.format(context["func_call_qual"]),
             )

--- a/precli/rules/python/third_party/jsonpickle/jsonpickle_decode.py
+++ b/precli/rules/python/third_party/jsonpickle/jsonpickle_decode.py
@@ -32,5 +32,5 @@ class JsonpickleDecode(Rule):
                 file_name=context["file_name"],
                 start_point=context["node"].start_point,
                 end_point=context["node"].end_point,
-                message=self.message.format("jsonpickle"),
+                message=self.message.format(context["func_call_qual"]),
             )

--- a/precli/rules/python/third_party/pandas/pandas_read_pickle.py
+++ b/precli/rules/python/third_party/pandas/pandas_read_pickle.py
@@ -26,5 +26,5 @@ class PandasReadPickle(Rule):
                 file_name=context["file_name"],
                 start_point=context["node"].start_point,
                 end_point=context["node"].end_point,
-                message=self.message.format("pandas.read_pickle"),
+                message=self.message.format(context["func_call_qual"]),
             )


### PR DESCRIPTION
This change makes use of the function call name in the string substitution in the message string.