### PR TITLE
Add testcase of an import within a function

### DIFF
--- a/tests/unit/rules/python/third_party/PyYAML/test_yaml_load.py
+++ b/tests/unit/rules/python/third_party/PyYAML/test_yaml_load.py
@@ -123,6 +123,19 @@ class YamlLoadTests(test_case.TestCase):
         results = self.parser.parse("test.py", str.encode(fdata))
         self.assertEqual(0, len(results))
 
+    def test_import_in_func_yaml_load(self):
+        fdata = textwrap.dedent(
+            """
+            def test_func():
+                import yaml
+            yaml.load("{}")
+            """
+        )
+        results = self.parser.parse("test.py", str.encode(fdata))
+        # FIX(ericwb): false positive, shouldn't be able to find import due
+        # to scope.
+        self.assertEqual(1, len(results))
+
     def test_yaml_load_positional_loader(self):
         fdata = textwrap.dedent(
             """


### PR DESCRIPTION
Due to scope, an import shouldn't be found if defined in a function but accessed outside of that function.