### PR TITLE
Remove official macOS support for now

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,7 +49,7 @@ jobs:
         python-version: [
           ["3.11", "311"]
         ]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (${{ matrix.python-version[0] }})
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifier =
     Intended Audience :: System Administrators
     Intended Audience :: Developers
     Operating System :: POSIX :: Linux
-    Operating System :: MacOS :: MacOS X
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.11


### PR DESCRIPTION
Should speed up the CI since the macOS GitHub Action tends to be very slow.