### PR TITLE
Redo symbol table to more polished solution

### DIFF
--- a/precli/core/symtab.py
+++ b/precli/core/symtab.py
@@ -1,0 +1,48 @@
+# Copyright 2023 Secure Saurce LLC
+from typing import Self
+
+
+class SymbolTable:
+    def __init__(self, parent=None):
+        self._symbols = {}
+        self._parent = parent
+
+    def parent(self) -> Self:
+        return self._parent
+
+    def put(self, name: str, type: str, value: str):
+        self._symbols[name] = Symbol(name, type, value)
+
+    def get(self, name: str):
+        if name in self._symbols:
+            return self._symbols[name]
+        elif self._parent is not None:
+            return self._parent.get(name)
+        else:
+            return None
+
+    def remove(self, name: str):
+        if name in self._symbols:
+            del self._symbols[name]
+
+    def __str__(self) -> str:
+        return str(self._symbols)
+
+
+class Symbol:
+    def __init__(self, name, type, value):
+        self._name = name
+        self._type = type
+        self._value = value
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def type(self) -> str:
+        return self._type
+
+    @property
+    def value(self) -> str:
+        return self._value

--- a/tests/unit/rules/python/third_party/paramiko/examples/host_key_auto_add_policy.py
+++ b/tests/unit/rules/python/third_party/paramiko/examples/host_key_auto_add_policy.py
@@ -1,10 +1,4 @@
 from paramiko import client
 
 ssh_client = client.SSHClient()
-
-
-def test_func(ssh):
-    ssh.set_missing_host_key_policy(client.AutoAddPolicy)
-
-
-test_func(ssh)
+ssh_client.set_missing_host_key_policy(client.AutoAddPolicy)


### PR DESCRIPTION
* Use symbol table class
* Use references to parent instead of lists of tables
* Use a symbol class to represent name, type, value and possibly more in the future