### PR TITLE
Fix errors when running against a lot of code

### DIFF
--- a/precli/core/symtab.py
+++ b/precli/core/symtab.py
@@ -46,3 +46,6 @@ class Symbol:
     @property
     def value(self) -> str:
         return self._value
+
+    def __repr__(self) -> str:
+        return f"Symbol (type: {self._type} value: {self._value})"


### PR DESCRIPTION
After implementing the recursive option, ran precli against the current directory which includes all the site-packages in .tox. Code was dumping tracebacks on various files due to infinite recursion.

* The symbol table lookup code has been changed significantly
* The handling of importlib.import_module was moved to visit_call
* Handling of importlib.import_module now removes its assignment from the symbol table after processing the child call node. Then adds back as an import type of symbol.