### PR TITLE
Add support for context managers

### DIFF
--- a/tests/unit/rules/python/third_party/httpx/examples/httpx_async_client_as_context_verify_false.py
+++ b/tests/unit/rules/python/third_party/httpx/examples/httpx_async_client_as_context_verify_false.py
@@ -1,0 +1,5 @@
+import httpx
+
+
+async with httpx.AsyncClient(verify=False) as client:
+    response = await client.get("https://localhost")

--- a/tests/unit/rules/python/third_party/httpx/examples/httpx_client_as_context_verify_false.py
+++ b/tests/unit/rules/python/third_party/httpx/examples/httpx_client_as_context_verify_false.py
@@ -1,0 +1,5 @@
+import httpx
+
+
+with httpx.Client(verify=False) as client:
+    response = client.get("https://localhost")

--- a/tests/unit/rules/python/third_party/httpx/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/third_party/httpx/test_no_certificate_verify.py
@@ -30,6 +30,22 @@ class NoCertificateVerifyTests(test_case.TestCase):
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("295", rule.cwe.cwe_id)
 
+    def test_httpx_async_client_as_context_verify_false(self):
+        results = self.parser.parse(
+            os.path.join(
+                self.base_path, "httpx_async_client_as_context_verify_false.py"
+            )
+        )
+        self.assertEqual(1, len(results))
+        result = results[0]
+        self.assertEqual("PRE303", result.rule_id)
+        self.assertEqual(4, result.location.start_line)
+        self.assertEqual(4, result.location.end_line)
+        self.assertEqual(11, result.location.start_column)
+        self.assertEqual(42, result.location.end_column)
+        self.assertEqual(Level.ERROR, result.level)
+        self.assertEqual(-1.0, result.rank)
+
     def test_httpx_async_client_verify_false(self):
         results = self.parser.parse(
             os.path.join(self.base_path, "httpx_async_client_verify_false.py")
@@ -41,6 +57,22 @@ class NoCertificateVerifyTests(test_case.TestCase):
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(9, result.location.start_column)
         self.assertEqual(40, result.location.end_column)
+        self.assertEqual(Level.ERROR, result.level)
+        self.assertEqual(-1.0, result.rank)
+
+    def test_httpx_client_as_context_verify_false(self):
+        results = self.parser.parse(
+            os.path.join(
+                self.base_path, "httpx_client_as_context_verify_false.py"
+            )
+        )
+        self.assertEqual(1, len(results))
+        result = results[0]
+        self.assertEqual("PRE303", result.rule_id)
+        self.assertEqual(4, result.location.start_line)
+        self.assertEqual(4, result.location.end_line)
+        self.assertEqual(5, result.location.start_column)
+        self.assertEqual(31, result.location.end_column)
         self.assertEqual(Level.ERROR, result.level)
         self.assertEqual(-1.0, result.rank)
 

--- a/tests/unit/rules/python/third_party/requests/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/third_party/requests/test_no_certificate_verify.py
@@ -161,8 +161,15 @@ class NoCertificateVerifyTests(test_case.TestCase):
                 "requests_session_as_context_get_verify_false.py",
             )
         )
-        # TODO(ericwb): false negative
-        self.assertEqual(0, len(results))
+        self.assertEqual(1, len(results))
+        result = results[0]
+        self.assertEqual("PRE312", result.rule_id)
+        self.assertEqual(5, result.location.start_line)
+        self.assertEqual(5, result.location.end_line)
+        self.assertEqual(4, result.location.start_column)
+        self.assertEqual(50, result.location.end_column)
+        self.assertEqual(Level.ERROR, result.level)
+        self.assertEqual(-1.0, result.rank)
 
     def test_requests_session_delete_verify_false(self):
         results = self.parser.parse(


### PR DESCRIPTION
Some code can have context managers such as requests Session().
This change allows parsing of a with_clause to be treated much like an assignment
statement.