### PR TITLE
Fix for traceback on with statement

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -71,20 +71,20 @@ class Python(Parser):
         self.context["func_call_args"] = None
         self.context["func_call_kwargs"] = None
 
-    def visit_with_statement(self, nodes: list[Node]):
-        with_clause = nodes[2] if nodes[0].type == "async" else nodes[1]
-        with_item = with_clause.children[0]
-        as_pattern = with_item.children[0]
-        statement = as_pattern.children[0]
-        as_pattern_target = as_pattern.children[2]
+    def visit_with_item(self, nodes: list[Node]):
+        as_pattern = nodes[0] if nodes[0].type == "as_pattern" else None
 
-        if as_pattern_target.children[0].type == "identifier" and (
-            statement.type in ("call", "attribute", "identifier")
-        ):
-            identifier = as_pattern_target.children[0]
-            identifier = self.literal_value(identifier, default=identifier)
-            statement = self.literal_value(statement, default=statement)
-            self.current_symtab.put(identifier, "identifier", statement)
+        if as_pattern is not None:
+            statement = as_pattern.children[0]
+            as_pattern_target = as_pattern.children[2]
+
+            if as_pattern_target.children[0].type == "identifier" and (
+                statement.type in ("call", "attribute", "identifier")
+            ):
+                identifier = as_pattern_target.children[0]
+                identifier = self.literal_value(identifier, default=identifier)
+                statement = self.literal_value(statement, default=statement)
+                self.current_symtab.put(identifier, "identifier", statement)
         self.visit(nodes)
 
     def child_by_type(self, node: Node, type: str) -> Node:


### PR DESCRIPTION
Fixes a problem in parsing with statements. In particular such as:

```
def setUp(self):
    # Integration tests need a higher default - big repos can be slow to
    # clone, particularly under guest load.
    env = fixtures.EnvironmentVariable(
        'OS_TEST_TIMEOUT', os.environ.get('OS_TEST_TIMEOUT', '600'))
    with env:
        super(TestIntegration, self).setUp()
    base._config_git()
```

```
Traceback (most recent call last):
  File "/Users/ericwb/workspace/precli/precli/cli/main.py", line 168, in parse_file
    return parser.parse(fname, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ericwb/workspace/precli/precli/core/parser.py", line 59, in parse
    self.visit([tree.root_node])
  File "/Users/ericwb/workspace/precli/precli/core/parser.py", line 74, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/python.py", line 19, in visit_module
    self.visit(nodes)
  File "/Users/ericwb/workspace/precli/precli/core/parser.py", line 74, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/core/parser.py", line 74, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/python.py", line 39, in 
visit_function_definition
    self.visit(nodes)
  File "/Users/ericwb/workspace/precli/precli/core/parser.py", line 74, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/core/parser.py", line 74, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/core/parser.py", line 74, in visit
    visitor_fn(node.children)
  [Previous line repeated 1 more time]
  File "/Users/ericwb/workspace/precli/precli/parsers/python.py", line 77, in visit_with_item
    as_pattern_target = as_pattern.children[2]
                        ~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```
