### PR TITLE
Add ability to enable or disable rules

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -64,6 +64,22 @@ def setup_arg_parser():
         help="find and process files in subdirectories",
     )
     parser.add_argument(
+        "--enable",
+        dest="enable",
+        action="store",
+        default=None,
+        type=str,
+        help="comma-separated list of rule IDs or names to enable",
+    )
+    parser.add_argument(
+        "--disable",
+        dest="disable",
+        action="store",
+        default=None,
+        type=str,
+        help="comma-separated list of rule IDs or names to disable",
+    )
+    parser.add_argument(
         "--json",
         dest="json",
         action="store_true",
@@ -195,9 +211,12 @@ def main():
     # Setup the command line arguments
     args = setup_arg_parser()
 
+    enabled = args.enable.split(",") if args.enable else []
+    disabled = args.disable.split(",") if args.disable else []
+
     discovered_plugins = entry_points(group="precli.parsers")
     for plugin in discovered_plugins:
-        parser = plugin.load()()
+        parser = plugin.load()(enabled, disabled)
         parsers[parser.file_extension()] = parser
 
     # Compile a list of the targets

--- a/precli/core/config.py
+++ b/precli/core/config.py
@@ -23,6 +23,15 @@ class Config:
         """
         return self._enabled
 
+    @enabled.setter
+    def enabled(self, enabled):
+        """
+        Set whether the rule is enabled
+
+        :param bool enabled: True to enable
+        """
+        self._enabled = enabled
+
     @property
     def level(self) -> Level:
         """

--- a/precli/core/rule.py
+++ b/precli/core/rule.py
@@ -35,8 +35,7 @@ class Rule(ABC):
         self._message = message
         self._targets = targets
         self._wildcards = wildcards
-        if not config:
-            self._config = Config()
+        self._config = Config() if not config else config
         if not help_url:
             # TDOO: generate URL based on rule
             self._help_url = ""
@@ -47,9 +46,7 @@ class Rule(ABC):
         """
         The ID of the rule.
 
-        The IDs match a of PREXXX where XXX is a unique number. 001-299
-        correspond to stdlib rules, whereas 300-999 corresponds to third-party
-        rules.
+        The IDs match a of PREXXXX where XXXX is a unique number.
 
         :return: rule ID
         :rtype: str

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -3,8 +3,8 @@ from precli.core.parser import Parser
 
 
 class Java(Parser):
-    def __init__(self):
-        super().__init__("java")
+    def __init__(self, enabled: list = None, disabled: list = None):
+        super().__init__("java", enabled, disabled)
 
     def file_extension(self) -> str:
         return ".java"

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -13,8 +13,8 @@ Import = namedtuple("Import", "module alias")
 
 
 class Python(Parser):
-    def __init__(self):
-        super().__init__("python")
+    def __init__(self, enabled: list = None, disabled: list = None):
+        super().__init__("python", enabled, disabled)
 
     def file_extension(self) -> str:
         return ".py"

--- a/precli/rules/python/third_party/PyYAML/yaml_load.py
+++ b/precli/rules/python/third_party/PyYAML/yaml_load.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.core.rule import Rule
@@ -21,6 +22,7 @@ class YamlLoad(Rule):
                     "CSafeLoader",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/cryptography/cryptography_weak_hash.py
+++ b/precli/rules/python/third_party/cryptography/cryptography_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -25,6 +26,7 @@ class CryptographyWeakHash(Rule):
                     "hashes.SHA1",
                 ],
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/dill/dill_load.py
+++ b/precli/rules/python/third_party/dill/dill_load.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.core.rule import Rule
@@ -21,6 +22,7 @@ class DillLoad(Rule):
                     "Unpickler",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/httpx/no_certificate_verify.py
+++ b/precli/rules/python/third_party/httpx/no_certificate_verify.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -29,6 +30,7 @@ class NoCertificateVerify(Rule):
                     "stream",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/jsonpickle/jsonpickle_decode.py
+++ b/precli/rules/python/third_party/jsonpickle/jsonpickle_decode.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.core.rule import Rule
@@ -22,6 +23,7 @@ class JsonpickleDecode(Rule):
                     "decode",
                 ],
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/pandas/pandas_read_pickle.py
+++ b/precli/rules/python/third_party/pandas/pandas_read_pickle.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.core.rule import Rule
@@ -19,6 +20,7 @@ class PandasReadPickle(Rule):
                     "read_pickle",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/paramiko/paramiko_no_host_key_verify.py
+++ b/precli/rules/python/third_party/paramiko/paramiko_no_host_key_verify.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -22,6 +23,7 @@ class ParamikoNoHostKeyVerify(Rule):
                     "WarningPolicy",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/pycrypto/pycrypto_weak_hash.py
+++ b/precli/rules/python/third_party/pycrypto/pycrypto_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -31,6 +32,7 @@ class PycryptoWeakHash(Rule):
                     "SHA.new",
                 ],
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/pycryptodomex/pycryptodomex_weak_hash.py
+++ b/precli/rules/python/third_party/pycryptodomex/pycryptodomex_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -35,6 +36,7 @@ class PycryptodomexWeakHash(Rule):
                     "SHA1.new",
                 ],
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/pyghmi/pyghmi_cleartext.py
+++ b/precli/rules/python/third_party/pyghmi/pyghmi_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -21,6 +22,7 @@ class PyghmiCleartext(Rule):
                     "Console",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/pyopenssl/insecure_tls_method.py
+++ b/precli/rules/python/third_party/pyopenssl/insecure_tls_method.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -38,6 +39,7 @@ class InsecureTlsMethod(Rule):
                     "SSL.TLSv1_1_METHOD",
                 ],
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/precli/rules/python/third_party/requests/no_certificate_verify.py
+++ b/precli/rules/python/third_party/requests/no_certificate_verify.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Saurce LLC
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -27,6 +28,7 @@ class NoCertificateVerify(Rule):
                     "Session",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/tests/unit/rules/python/third_party/PyYAML/test_yaml_load.py
+++ b/tests/unit/rules/python/third_party/PyYAML/test_yaml_load.py
@@ -4,12 +4,14 @@ import textwrap
 
 from precli.core.level import Level
 from precli.core.rule import Rule
+from precli.parsers import python
 from tests.unit.rules.python import test_case
 
 
 class YamlLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
+        self.parser = python.Python(enabled=["PRE0024"])
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/third_party/httpx/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/third_party/httpx/test_no_certificate_verify.py
@@ -4,12 +4,14 @@ import textwrap
 
 from precli.core.level import Level
 from precli.core.rule import Rule
+from precli.parsers import python
 from tests.unit.rules.python import test_case
 
 
 class NoCertificateVerifyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
+        self.parser = python.Python(enabled=["PRE0016"])
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/third_party/jsonpickle/test_jsonpickle_decode.py
+++ b/tests/unit/rules/python/third_party/jsonpickle/test_jsonpickle_decode.py
@@ -3,12 +3,14 @@ import textwrap
 
 from precli.core.level import Level
 from precli.core.rule import Rule
+from precli.parsers import python
 from tests.unit.rules.python import test_case
 
 
 class JsonPickleDecodeTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
+        self.parser = python.Python(enabled=["PRE0017"])
 
     def test_jsonpickle_decode_rule_meta(self):
         rule = Rule.get_by_id("PRE0017")

--- a/tests/unit/rules/python/third_party/paramiko/test_host_key_policy.py
+++ b/tests/unit/rules/python/third_party/paramiko/test_host_key_policy.py
@@ -4,12 +4,14 @@ import textwrap
 
 from precli.core.level import Level
 from precli.core.rule import Rule
+from precli.parsers import python
 from tests.unit.rules.python import test_case
 
 
 class HostKeyPolicyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
+        self.parser = python.Python(enabled=["PRE0019"])
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/third_party/pyopenssl/test_ssl_context.py
+++ b/tests/unit/rules/python/third_party/pyopenssl/test_ssl_context.py
@@ -4,12 +4,14 @@ import textwrap
 
 from precli.core.level import Level
 from precli.core.rule import Rule
+from precli.parsers import python
 from tests.unit.rules.python import test_case
 
 
 class SslContextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
+        self.parser = python.Python(enabled=["PRE0023"])
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/third_party/requests/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/third_party/requests/test_no_certificate_verify.py
@@ -4,12 +4,14 @@ import textwrap
 
 from precli.core.level import Level
 from precli.core.rule import Rule
+from precli.parsers import python
 from tests.unit.rules.python import test_case
 
 
 class NoCertificateVerifyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
+        self.parser = python.Python(enabled=["PRE0025"])
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,4 @@ commands = -pylint --rcfile=pylintrc precli
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt
 commands=
-    sphinx-build -b html docs/source docs/build
+    sphinx-build -b json docs/source docs/build


### PR DESCRIPTION
* Added --enable CLI argument. Can take a comma seperated list of rule IDs, names, or special value of just "all"
* Also added --disable CLI argument that does the opposite of enable.
* The third-party rules are now by default off.
* Generates doc output as JSON instead of HTML