### PR TITLE
Add kind property to result

### DIFF
--- a/precli/core/kind.py
+++ b/precli/core/kind.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Secure Saurce LLC
+import enum
+
+
+class Kind(str, enum.Enum):
+    """
+    The nature of the result.
+
+    :var FAIL: A problem was found.
+    :vartype FAIL: str
+
+    :var REVIEW: Requires review to decide if it represents a problem.
+    :vartype REVIEW: str
+
+    :var NOT_APPLICABLE: Was not evaluated because it does not apply.
+    :vartype NOT_APPLICABLE: str
+
+    :var INFORMATIONAL: Info that does not indicate the presence of a problem.
+    :vartype INFORMATIONAL: str
+
+    :var OPEN: Insufficient information to decide whether a problem exists.
+    :vartype OPEN: str
+
+    :var PASS: No problem was found.
+    :vartype PASS: str
+    """
+
+    FAIL = "fail"
+    REVIEW = "review"
+    NOT_APPLICABLE = "notApplicable"
+    INFORMATIONAL = "informational"
+    OPEN = "open"
+    PASS = "pass"

--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Secure Saurce LLC
 from precli.core.fix import Fix
+from precli.core.kind import Kind
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.rule import Rule
@@ -10,6 +11,7 @@ class Result:
         self,
         rule_id: str,
         location: Location,
+        kind: Kind = Kind.FAIL,
         level: Level = None,
         message: str = None,
         fixes: list[Fix] = None,
@@ -18,6 +20,7 @@ class Result:
         self._location = location
         default_config = Rule.get_by_id(self._rule_id).default_config
         self._rank = default_config.rank
+        self._kind = kind
         if level:
             self._level = level
         else:
@@ -33,9 +36,7 @@ class Result:
         """
         The ID of the rule.
 
-        The IDs match a of PREXXX where XXX is a unique number. 001-299
-        correspond to stdlib rules, whereas 300-999 corresponds to third-party
-        rules.
+        The IDs match PREXXXX where XXXX is a unique number.
 
         :return: rule ID
         :rtype: str
@@ -54,6 +55,19 @@ class Result:
         :rtype: Location
         """
         return self._location
+
+    @property
+    def kind(self) -> Kind:
+        """
+        The nature of the result.
+
+        Typically having a value of pass or fail to indicate the nature of
+        the result.
+
+        :return: kind or nature of result
+        :rtype: Kind
+        """
+        return self._kind
 
     @property
     def level(self) -> Level:

--- a/precli/core/rule.py
+++ b/precli/core/rule.py
@@ -46,7 +46,7 @@ class Rule(ABC):
         """
         The ID of the rule.
 
-        The IDs match a of PREXXXX where XXXX is a unique number.
+        The IDs match PREXXXX where XXXX is a unique number.
 
         :return: rule ID
         :rtype: str


### PR DESCRIPTION
Kind indicates the nature of the result. Typically this is "fail" or "pass", but could also be any one of the values in the Kind enum.

See 3.27.9 kind property of:

https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317647