### PR TITLE
SSHClient can be imported from paramiko

### DIFF
--- a/precli/rules/python/third_party/paramiko/paramiko_no_host_key_verify.py
+++ b/precli/rules/python/third_party/paramiko/paramiko_no_host_key_verify.py
@@ -21,7 +21,12 @@ class ParamikoNoHostKeyVerify(Rule):
                     "SSHClient",
                     "AutoAddPolicy",
                     "WarningPolicy",
-                ]
+                ],
+                "paramiko.*": [
+                    "SSHClient",
+                    "AutoAddPolicy",
+                    "WarningPolicy",
+                ],
             },
             config=Config(enabled=False),
         )
@@ -30,7 +35,8 @@ class ParamikoNoHostKeyVerify(Rule):
         call = kwargs.get("call")
 
         if call.name_qualified in [
-            "paramiko.client.SSHClient.set_missing_host_key_policy"
+            "paramiko.SSHClient.set_missing_host_key_policy",
+            "paramiko.client.SSHClient.set_missing_host_key_policy",
         ]:
             argument = call.get_argument(position=0, name="policy")
             policy = argument.value
@@ -43,7 +49,10 @@ class ParamikoNoHostKeyVerify(Rule):
                 inserted_content="RejectPolicy",
             )
 
-            if policy == "paramiko.client.AutoAddPolicy":
+            if policy in [
+                "paramiko.AutoAddPolicy",
+                "paramiko.client.AutoAddPolicy",
+            ]:
                 return Result(
                     rule_id=self.id,
                     location=Location(
@@ -54,7 +63,10 @@ class ParamikoNoHostKeyVerify(Rule):
                     message=self.message.format("AutoAddPolicy"),
                     fixes=fixes,
                 )
-            if policy == "paramiko.client.WarningPolicy":
+            if policy in [
+                "paramiko.WarningPolicy",
+                "paramiko.client.WarningPolicy",
+            ]:
                 return Result(
                     rule_id=self.id,
                     location=Location(

--- a/tests/unit/rules/python/third_party/paramiko/examples/host_key_auto_add_policy_import_paramiko.py
+++ b/tests/unit/rules/python/third_party/paramiko/examples/host_key_auto_add_policy_import_paramiko.py
@@ -1,0 +1,5 @@
+import paramiko
+
+
+ssh_client = paramiko.SSHClient()
+ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy)

--- a/tests/unit/rules/python/third_party/paramiko/test_host_key_policy.py
+++ b/tests/unit/rules/python/third_party/paramiko/test_host_key_policy.py
@@ -31,6 +31,22 @@ class HostKeyPolicyTests(test_case.TestCase):
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("295", rule.cwe.cwe_id)
 
+    def test_host_key_auto_add_policy_import_paramiko(self):
+        results = self.parser.parse(
+            os.path.join(
+                self.base_path, "host_key_auto_add_policy_import_paramiko.py"
+            )
+        )
+        self.assertEqual(1, len(results))
+        result = results[0]
+        self.assertEqual("PRE0020", result.rule_id)
+        self.assertEqual(5, result.location.start_line)
+        self.assertEqual(5, result.location.end_line)
+        self.assertEqual(48, result.location.start_column)
+        self.assertEqual(61, result.location.end_column)
+        self.assertEqual(Level.ERROR, result.level)
+        self.assertEqual(-1.0, result.rank)
+
     def test_host_key_auto_add_policy(self):
         results = self.parser.parse(
             os.path.join(self.base_path, "host_key_auto_add_policy.py")


### PR DESCRIPTION
For example, in both of these imports, SSHClient can be imported.

from paramiko import client

import paramiko