### PR TITLE
Add support of suppressions

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -149,7 +149,6 @@ def run_checks(parsers: dict, file_list: list[str]) -> list[Result]:
 
     results = []
     lines = 0
-    lines_skipped = 0
     for fname in files:
         LOG.debug("working on file : %s", fname)
 
@@ -174,7 +173,6 @@ def run_checks(parsers: dict, file_list: list[str]) -> list[Result]:
         files=len(new_file_list),
         files_skipped=len(files_skipped),
         lines=lines,
-        lines_skipped=lines_skipped,
         errors=sum(result.level == Level.ERROR for result in results),
         warnings=sum(result.level == Level.WARNING for result in results),
         notes=sum(result.level == Level.NOTE for result in results),

--- a/precli/core/metrics.py
+++ b/precli/core/metrics.py
@@ -7,7 +7,6 @@ class Metrics:
         files: int,
         files_skipped: int,
         lines: int,
-        lines_skipped: int,
         errors: int = 0,
         warnings: int = 0,
         notes: int = 0,
@@ -15,7 +14,6 @@ class Metrics:
         self._files = files
         self._files_skipped = files_skipped
         self._lines = lines
-        self._lines_skipped = lines_skipped
         self._errors = errors
         self._warnings = warnings
         self._notes = notes
@@ -49,16 +47,6 @@ class Metrics:
         :rtype: int
         """
         return self._lines
-
-    @property
-    def lines_skipped(self) -> int:
-        """
-        Total number of lines skipped due to a suppression.
-
-        :return: number of lines skipped
-        :rtype: int
-        """
-        return self._lines_skipped
 
     @property
     def errors(self) -> int:

--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -16,7 +16,7 @@ class Result:
         location: Location = None,
         message: str = None,
         fixes: list[Fix] = None,
-        suppressions: list[Suppression] = None,
+        suppression: Suppression = None,
     ):
         self._rule_id = rule_id
         self._kind = kind
@@ -32,7 +32,7 @@ class Result:
         else:
             self._message = Rule.get_by_id(self._rule_id).message
         self._fixes = fixes if fixes is not None else []
-        self._suppressions = suppressions if suppressions is not None else []
+        self._suppression = suppression
 
     @property
     def rule_id(self) -> str:
@@ -77,10 +77,12 @@ class Result:
         """
         The result severity level.
 
+        If the result is being supporessed, then the level is set to NOTE.
+
         :return: severity level
         :rtype: Level
         """
-        return self._level
+        return self._level if self._suppression is None else Level.NOTE
 
     @property
     def message(self) -> str:
@@ -90,7 +92,10 @@ class Result:
         :return: issue message
         :rtype: str
         """
-        return self._message
+        if self._suppression is None:
+            return self._message
+        else:
+            return "This issue is being supporessed via an inline comment."
 
     @property
     def rank(self) -> float:
@@ -116,11 +121,20 @@ class Result:
         return self._fixes
 
     @property
-    def suppressions(self) -> list[Suppression]:
+    def suppression(self) -> Suppression:
         """
         Possible suppressions of the result.
 
-        :return: list of suppressions
-        :rtype: list
+        :return: suppression or None
+        :rtype: Suppression
         """
-        return self._suppressions
+        return self._suppression
+
+    @suppression.setter
+    def suppression(self, suppression):
+        """
+        Set the suppression of this result
+
+        :param Suppression suppression: suppression
+        """
+        self._suppression = suppression

--- a/precli/core/suppression.py
+++ b/precli/core/suppression.py
@@ -6,15 +6,37 @@ from precli.core.status import Status
 class Suppression:
     def __init__(
         self,
-        kind: str,
-        status: Status = None,
-        location: Location = None,
+        location: Location,
+        rules: set[str],
+        kind: str = "inSource",
+        status: Status = Status.ACCEPTED,
         justification: str = None,
     ):
+        self._location = location
+        self._rules = rules
         self._kind = kind
         self._status = status
-        self._location = location
         self._justification = justification
+
+    @property
+    def location(self) -> Location:
+        """
+        Specifies the location of the suppression.
+
+        :return: location of suppression
+        :rtype: Location
+        """
+        return self._location
+
+    @property
+    def rules(self) -> set[str]:
+        """
+        What rules are being suppressed.
+
+        :return: set of rule ID/names
+        :rtype: set
+        """
+        return self._rules
 
     @property
     def kind(self) -> str:
@@ -26,7 +48,7 @@ class Suppression:
         :return: kind of suppression
         :rtype: str
         """
-        return "inSource"
+        return self._kind
 
     @property
     def status(self) -> Status:
@@ -39,15 +61,6 @@ class Suppression:
         return self._status
 
     @property
-    def location(self) -> Location:
-        """
-        Specifies the location of the suppression.
-
-        :return: location of suppression
-        :rtype: Location
-        """
-        return self._location
-
     def justification(self) -> str:
         """
         User-supplied string that explains why the result was suppressed.

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -1,17 +1,24 @@
 # Copyright 2023 Secure Saurce LLC
 import ast
+import re
 from collections import namedtuple
 
 from tree_sitter import Node
 
 from precli.core.call import Call
 from precli.core.comparison import Comparison
+from precli.core.location import Location
+from precli.core.suppression import Suppression
 from precli.core.symtab import Symbol
 from precli.core.symtab import SymbolTable
 from precli.parsers import Parser
+from precli.rules import Rule
 
 
 Import = namedtuple("Import", "module alias")
+
+SUPPRESS_COMMENT = re.compile(r"# suppress:? (?P<rules>[^#]+)?#?")
+SUPPRESSED_RULES = re.compile(r"(?:(PRE\d+|[a-z_]+),?)+", re.IGNORECASE)
 
 
 class Python(Parser):
@@ -22,6 +29,7 @@ class Python(Parser):
         return ".py"
 
     def visit_module(self, nodes: list[Node]):
+        self.suppressions = {}
         self.current_symtab = SymbolTable("<module>")
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
@@ -37,7 +45,41 @@ class Python(Parser):
             self.current_symtab.put(key, "import", value)
 
     def visit_comment(self, nodes: list[Node]):
-        pass
+        comment = self.context["node"].text.decode()
+
+        suppressed = SUPPRESS_COMMENT.search(comment)
+        if suppressed is None:
+            return
+
+        matches = suppressed.groupdict()
+        suppressed_rules = matches.get("rules")
+
+        if suppressed_rules is None:
+            return
+
+        rules = set()
+        for rule in SUPPRESSED_RULES.finditer(suppressed_rules):
+            rule_name_or_id = rule.group(1)
+            if Rule.get_by_id(rule_name_or_id) is not None:
+                rules.add(rule_name_or_id)
+
+        if not rules:
+            return
+
+        suppression = Suppression(
+            location=Location(node=self.context["node"]),
+            rules=rules,
+        )
+
+        prev_node = self.context["node"].prev_sibling
+        node = self.context["node"]
+
+        if prev_node.end_point[0] == node.start_point[0]:
+            self.suppressions[node.start_point[0] + 1] = suppression
+        else:
+            self.suppressions[node.start_point[0] + 2] = suppression
+
+        # TODO: add the justification to the suppression
 
     def visit_class_definition(self, nodes: list[Node]):
         class_id = self.first_match(self.context["node"], "identifier")

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -39,7 +39,6 @@ class Json(Renderer):
             "files": metrics.files,
             "files_skipped": metrics.files_skipped,
             "lines": metrics.lines,
-            "lines_skipped": metrics.lines_skipped,
             "errors": metrics.errors,
             "warnings": metrics.warnings,
             "notes": metrics.notes,


### PR DESCRIPTION
Suppressions allow a user to "suppress" the result of a rule on a piece of code. This is done by adding an inline comment of specific format. Namely:
```# suppress: PREXXXX```

A user can suppress a result using a trailing comment or a non-trailing comment on a previous line.