### PR TITLE
Add ability to analyze call history

### DIFF
--- a/examples/complex.py
+++ b/examples/complex.py
@@ -1,9 +1,16 @@
+import getpass
+import imaplib
 
 
-def init_nntp(n):
-    n.starttls()
+M = imaplib.IMAP4()
 
+#M.starttls()
 
-nntp = nntplib.NNTP('news.gmane.io')
-init_nntp(nntp)
-nntp.login()
+M.login(getpass.getuser(), getpass.getpass())
+M.select()
+typ, data = M.search(None, 'ALL')
+for num in data[0].split():
+    typ, data = M.fetch(num, '(RFC822)')
+    print('Message %s\n%s\n' % (num, data[0][1]))
+M.close()
+M.logout()

--- a/precli/core/symtab.py
+++ b/precli/core/symtab.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Secure Saurce LLC
 from typing import Self
 
+from precli.core.call import Call
+
 
 class SymbolTable:
     def __init__(self, name, parent=None):
@@ -38,6 +40,7 @@ class Symbol:
         self._name = name
         self._type = type
         self._value = value
+        self._call_history = []
 
     @property
     def name(self) -> str:
@@ -50,6 +53,13 @@ class Symbol:
     @property
     def value(self) -> str:
         return self._value
+
+    def push_call(self, call: Call):
+        self._call_history.append(call)
+
+    @property
+    def call_history(self) -> list[Call]:
+        return self._call_history
 
     def __repr__(self) -> str:
         return f"Symbol (type: {self._type}, value: {self._value})"

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -115,6 +115,15 @@ class Python(Parser):
             left_hand = self.literal_value(nodes[0], default=nodes[0])
             right_hand = self.literal_value(nodes[2], default=nodes[2])
             self.current_symtab.put(left_hand, "identifier", right_hand)
+            if nodes[2].type == "call":
+                call = Call(
+                    node=nodes[2],
+                    name=right_hand,
+                    name_qual=right_hand,
+                )
+                symbol = self.current_symtab.get(left_hand)
+                symbol.push_call(call)
+
         self.visit(nodes)
 
     def visit_call(self, nodes: list[Node]):
@@ -140,6 +149,15 @@ class Python(Parser):
             self.current_symtab.put(identifier, "import", module)
 
         self.process_rules("call", call=call)
+
+        if call.var_node is not None:
+            symbol = self.current_symtab.get(call.var_node.text.decode())
+            if symbol is not None and symbol.type == "identifier":
+                symbol.push_call(call)
+        else:
+            # TODO: why is var_node None?
+            pass
+
         self.visit(nodes)
 
     def visit_with_item(self, nodes: list[Node]):

--- a/precli/rules/python/stdlib/ftplib/ftp_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib/ftp_cleartext.py
@@ -90,19 +90,13 @@ from precli.rules import Rule
 
 
 class FtpCleartext(Rule):
-    """
-    .. seealso::
-
-     - https://docs.python.org/3/library/ftplib.html
-    """
-
     def __init__(self, id: str):
         super().__init__(
             id=id,
             name="cleartext_transmission",
             full_descr=__doc__,
             cwe_id=319,
-            message="The FTP protocol transmits data in cleartext without "
+            message="The FTP protocol can transmit data in cleartext without "
             "encryption.",
             targets=("call"),
             wildcards={

--- a/precli/rules/python/stdlib/imaplib/imap_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib/imap_cleartext.py
@@ -1,0 +1,128 @@
+# Copyright 2023 Secure Saurce LLC
+r"""
+=====================================================================
+Cleartext Transmission of Sensitive Information in the Imaplib Module
+=====================================================================
+
+The Python module ``imaplib`` provides a number of functions for accessing
+IMAP servers. However, the default behavior of the module does not provide
+utilize secure connections. This means that data transmitted over the network,
+including passwords, is sent in cleartext. This makes it possible for attackers
+to intercept and read this data.
+
+The Python module imaplib should only in a secure mannner to protect sensitive
+data when accessing IMAP servers.
+
+-------
+Example
+-------
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 5
+
+    import getpass
+    import imaplib
+
+
+    M = imaplib.IMAP4()
+    M.login(getpass.getuser(), getpass.getpass())
+    M.select()
+    typ, data = M.search(None, 'ALL')
+    for num in data[0].split():
+        typ, data = M.fetch(num, '(RFC822)')
+        print('Message %s\n%s\n' % (num, data[0][1]))
+    M.close()
+    M.logout()
+
+-----------
+Remediation
+-----------
+
+If the IMAP protocol must be used and sensitive data will be transferred, it
+is recommended to secure the connection using ``IMAP4_SSL`` class.
+Alternatively, the ``starttls`` function can be used to enter a secure session.
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 5
+
+    import getpass
+    import imaplib
+
+
+    M = imaplib.IMAP4_SSL()
+    M.login(getpass.getuser(), getpass.getpass())
+    M.select()
+    typ, data = M.search(None, 'ALL')
+    for num in data[0].split():
+        typ, data = M.fetch(num, '(RFC822)')
+        print('Message %s\n%s\n' % (num, data[0][1]))
+    M.close()
+    M.logout()
+
+.. seealso::
+
+ - `imaplib — IMAP4 protocol client <https://docs.python.org/3/library/imaplib.html>`_
+ - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
+
+.. versionadded:: 1.0.0
+
+"""  # noqa: E501
+from precli.core.level import Level
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class ImapCleartext(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="cleartext_transmission",
+            full_descr=__doc__,
+            cwe_id=319,
+            message="The IMAP protocol can transmit data in cleartext without "
+            "encryption.",
+            targets=("call"),
+            wildcards={
+                "imaplib.*": [
+                    "IMAP4",
+                ]
+            },
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+
+        if call.name_qualified in [
+            "imaplib.IMAP4.authenticate",
+            "imaplib.IMAP4.login",
+            "imaplib.IMAP4.login_cram_md5",
+        ]:
+            symbol = context["symtab"].get(call.var_node.text.decode())
+
+            if "starttls" not in [
+                x.identifier_node.text.decode() for x in symbol.call_history
+            ]:
+                init_call = symbol.call_history[0]
+                fixes = Rule.get_fixes(
+                    context=context,
+                    deleted_location=Location(node=init_call.identifier_node),
+                    description="Use the 'IMAP4_SSL' module to secure the "
+                    "connection.",
+                    inserted_content="IMAP4_SSL",
+                )
+
+                return Result(
+                    rule_id=self.id,
+                    location=Location(
+                        file_name=context["file_name"],
+                        node=call.identifier_node,
+                    ),
+                    level=Level.ERROR,
+                    message=f"The '{call.name_qualified}' function will "
+                    f"transmit authentication information such as a user, "
+                    "password in cleartext.",
+                    fixes=fixes,
+                )

--- a/precli/rules/python/stdlib/nntplib/nntp_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib/nntp_cleartext.py
@@ -1,0 +1,109 @@
+# Copyright 2023 Secure Saurce LLC
+r"""
+=====================================================================
+Cleartext Transmission of Sensitive Information in the Nntplib Module
+=====================================================================
+
+The Python module ``nntplib`` provides a number of functions for accessing
+NNTP servers. However, the default behavior of the module does not provide
+utilize secure connections. This means that data transmitted over the network,
+including passwords, is sent in cleartext. This makes it possible for attackers
+to intercept and read this data.
+
+The Python module nntplib should only in a secure mannner to protect sensitive
+data when accessing NNTP servers.
+
+-------
+Example
+-------
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 4
+
+    from nntplib import NNTP
+
+
+    with NNTP('news.gmane.io') as n:
+        n.group('gmane.comp.python.committers')
+
+-----------
+Remediation
+-----------
+
+If the NNTP protocol must be used and sensitive data will be transferred, it
+is recommended to secure the connection using ``NNTP_SSL`` class.
+Alternatively, the ``starttls`` function can be used to enter a secure session.
+
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 4
+
+    from nntplib import NNTP
+
+
+    with NNTP_SSL('news.gmane.io') as n:
+        n.group('gmane.comp.python.committers')
+
+.. seealso::
+
+ - `nntplib — NNTP protocol client <https://docs.python.org/3/library/nntplib.html>`_
+ - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
+
+.. versionadded:: 1.0.0
+
+"""  # noqa: E501
+from precli.core.level import Level
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class NntpCleartext(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="cleartext_transmission",
+            full_descr=__doc__,
+            cwe_id=319,
+            message="The NNTP protocol can transmit data in cleartext without "
+            "encryption.",
+            targets=("call"),
+            wildcards={
+                "nntplib.*": [
+                    "NNTP",
+                ]
+            },
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+
+        if call.name_qualified in ["nntplib.NNTP.login"]:
+            symbol = context["symtab"].get(call.var_node.text.decode())
+
+            if "starttls" not in [
+                x.identifier_node.text.decode() for x in symbol.call_history
+            ]:
+                init_call = symbol.call_history[0]
+                fixes = Rule.get_fixes(
+                    context=context,
+                    deleted_location=Location(node=init_call.identifier_node),
+                    description="Use the 'NNTP_SSL' module to secure the "
+                    "connection.",
+                    inserted_content="NNTP_SSL",
+                )
+
+                return Result(
+                    rule_id=self.id,
+                    location=Location(
+                        file_name=context["file_name"],
+                        node=call.identifier_node,
+                    ),
+                    level=Level.ERROR,
+                    message=f"The '{call.name_qualified}' function will "
+                    f"transmit authentication information such as a user, "
+                    "password in cleartext.",
+                    fixes=fixes,
+                )

--- a/precli/rules/python/stdlib/poplib/pop_cleartext.py
+++ b/precli/rules/python/stdlib/poplib/pop_cleartext.py
@@ -1,0 +1,125 @@
+# Copyright 2023 Secure Saurce LLC
+r"""
+====================================================================
+Cleartext Transmission of Sensitive Information in the Poplib Module
+====================================================================
+
+The Python module ``poplib`` provides a number of functions for accessing
+POP servers. However, the default behavior of the module does not provide
+utilize secure connections. This means that data transmitted over the network,
+including passwords, is sent in cleartext. This makes it possible for attackers
+to intercept and read this data.
+
+The Python module poplib should only in a secure mannner to protect sensitive
+data when accessing NNTP servers.
+
+-------
+Example
+-------
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 5
+
+    import getpass
+    import poplib
+
+
+    M = poplib.POP3('localhost')
+    M.user(getpass.getuser())
+    M.pass_(getpass.getpass())
+    numMessages = len(M.list()[1])
+    for i in range(numMessages):
+        for j in M.retr(i+1)[1]:
+            print(j)
+
+-----------
+Remediation
+-----------
+
+If the POP protocol must be used and sensitive data will be transferred, it
+is recommended to secure the connection using ``POP3_SSL`` class.
+Alternatively, the ``stls`` function can be used to enter a secure session.
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 5
+
+    import getpass
+    import poplib
+
+
+    M = poplib.POP3_SSL('localhost')
+    M.user(getpass.getuser())
+    M.pass_(getpass.getpass())
+    numMessages = len(M.list()[1])
+    for i in range(numMessages):
+        for j in M.retr(i+1)[1]:
+            print(j)
+
+.. seealso::
+
+ - `poplib — POP3 protocol client <https://docs.python.org/3/library/poplib.html>`_
+ - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
+
+.. versionadded:: 1.0.0
+
+"""  # noqa: E501
+from precli.core.level import Level
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class PopCleartext(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="cleartext_transmission",
+            full_descr=__doc__,
+            cwe_id=319,
+            message="The POP protocol can transmit data in cleartext without "
+            "encryption.",
+            targets=("call"),
+            wildcards={
+                "poplib.*": [
+                    "POP3",
+                ]
+            },
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+
+        if call.name_qualified in [
+            "poplib.POP3.user",
+            "poplib.POP3.pass_",
+            "poplib.POP3.apop",
+            "poplib.POP3.rpop",
+        ]:
+            symbol = context["symtab"].get(call.var_node.text.decode())
+
+            if "stls" not in [
+                x.identifier_node.text.decode() for x in symbol.call_history
+            ]:
+                init_call = symbol.call_history[0]
+                fixes = Rule.get_fixes(
+                    context=context,
+                    deleted_location=Location(node=init_call.identifier_node),
+                    description="Use the 'POP3_SSL' module to secure the "
+                    "connection.",
+                    inserted_content="POP3_SSL",
+                )
+
+                return Result(
+                    rule_id=self.id,
+                    location=Location(
+                        file_name=context["file_name"],
+                        node=call.identifier_node,
+                    ),
+                    level=Level.ERROR,
+                    message=f"The '{call.name_qualified}' function will "
+                    f"transmit authentication information such as a user, "
+                    "password in cleartext.",
+                    fixes=fixes,
+                )

--- a/precli/rules/python/stdlib/smtplib/smtp_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib/smtp_cleartext.py
@@ -1,0 +1,156 @@
+# Copyright 2023 Secure Saurce LLC
+r"""
+=====================================================================
+Cleartext Transmission of Sensitive Information in the Smtplib Module
+=====================================================================
+
+The Python module ``smtplib`` provides a number of functions for accessing
+SMTP servers. However, the default behavior of the module does not provide
+utilize secure connections. This means that data transmitted over the network,
+including passwords, is sent in cleartext. This makes it possible for attackers
+to intercept and read this data.
+
+The Python module smtplib should only in a secure mannner to protect sensitive
+data when accessing SMTP servers.
+
+-------
+Example
+-------
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 24
+
+    import smtplib
+
+
+    def prompt(prompt):
+        return input(prompt).strip()
+
+    fromaddr = prompt("From: ")
+    toaddrs  = prompt("To: ").split()
+    print("Enter message, end with ^D (Unix) or ^Z (Windows):")
+
+    # Add the From: and To: headers at the start!
+    msg = ("From: %s\r\nTo: %s\r\n\r\n" % (fromaddr, ", ".join(toaddrs)))
+    while True:
+        try:
+            line = input()
+        except EOFError:
+            break
+        if not line:
+            break
+        msg = msg + line
+
+    print("Message length is", len(msg))
+
+    server = smtplib.SMTP('localhost')
+    server.set_debuglevel(1)
+    server.sendmail(fromaddr, toaddrs, msg)
+    server.quit()
+
+-----------
+Remediation
+-----------
+
+If the SMTP protocol must be used and sensitive data will be transferred, it
+is recommended to secure the connection using ``SMTP_SSL`` class.
+Alternatively, the ``starttls`` function can be used to enter a secure session.
+
+
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 24
+
+    import smtplib
+
+
+    def prompt(prompt):
+        return input(prompt).strip()
+
+    fromaddr = prompt("From: ")
+    toaddrs  = prompt("To: ").split()
+    print("Enter message, end with ^D (Unix) or ^Z (Windows):")
+
+    # Add the From: and To: headers at the start!
+    msg = ("From: %s\r\nTo: %s\r\n\r\n" % (fromaddr, ", ".join(toaddrs)))
+    while True:
+        try:
+            line = input()
+        except EOFError:
+            break
+        if not line:
+            break
+        msg = msg + line
+
+    print("Message length is", len(msg))
+
+    server = smtplib.SMTP_SSL('localhost')
+    server.set_debuglevel(1)
+    server.sendmail(fromaddr, toaddrs, msg)
+    server.quit()
+
+.. seealso::
+
+ - `smtplib — SMTP protocol client <https://docs.python.org/3/library/smtplib.html>`_
+ - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
+
+.. versionadded:: 1.0.0
+
+"""  # noqa: E501
+from precli.core.level import Level
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class SmtpCleartext(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="cleartext_transmission",
+            full_descr=__doc__,
+            cwe_id=319,
+            message="The POP protocol can transmit data in cleartext without "
+            "encryption.",
+            targets=("call"),
+            wildcards={
+                "smtplib.*": [
+                    "SMTP",
+                ]
+            },
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+
+        if call.name_qualified in [
+            "smtplib.SMTP.login",
+            "smtplib.SMTP.auth",
+        ]:
+            symbol = context["symtab"].get(call.var_node.text.decode())
+
+            if "starttls" not in [
+                x.identifier_node.text.decode() for x in symbol.call_history
+            ]:
+                init_call = symbol.call_history[0]
+                fixes = Rule.get_fixes(
+                    context=context,
+                    deleted_location=Location(node=init_call.identifier_node),
+                    description="Use the 'SMTP_SSL' module to secure the "
+                    "connection.",
+                    inserted_content="SMTP_SSL",
+                )
+
+                return Result(
+                    rule_id=self.id,
+                    location=Location(
+                        file_name=context["file_name"],
+                        node=call.identifier_node,
+                    ),
+                    level=Level.ERROR,
+                    message=f"The '{call.name_qualified}' function will "
+                    f"transmit authentication information such as a user, "
+                    "password in cleartext.",
+                    fixes=fixes,
+                )

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,65 +48,77 @@ precli.rules.python =
     # precli/rules/python/stdlib/hmac/hmac_weak_hash.py
     PRE0006 = precli.rules.python.stdlib.hmac.hmac_weak_hash:HmacWeakHash
 
+    # precli/rules/python/stdlib/imaplib/imap_cleartext.py
+    PRE0007 = precli.rules.python.stdlib.imaplib.imap_cleartext:ImapCleartext
+
     # precli/rules/python/stdlib/json/json_load.py
-    PRE0007 = precli.rules.python.stdlib.json.json_load:JsonLoad
+    PRE0008 = precli.rules.python.stdlib.json.json_load:JsonLoad
 
     # precli/rules/python/stdlib/logging/insecure_listen_config.py
-    PRE0008 = precli.rules.python.stdlib.logging.insecure_listen_config:InsecureListenConfig
+    PRE0009 = precli.rules.python.stdlib.logging.insecure_listen_config:InsecureListenConfig
 
     # precli/rules/python/stdlib/marshal/marshal_load.py
-    PRE0009 = precli.rules.python.stdlib.marshal.marshal_load:MarshalLoad
+    PRE0010 = precli.rules.python.stdlib.marshal.marshal_load:MarshalLoad
+
+    # precli/rules/python/stdlib/nntplib/nntp_cleartext.py
+    PRE0011 = precli.rules.python.stdlib.nntplib.nntp_cleartext:NntpCleartext
 
     # precli/rules/python/stdlib/pickle/pickle_load.py
-    PRE0010 = precli.rules.python.stdlib.pickle.pickle_load:PickleLoad
+    PRE0012 = precli.rules.python.stdlib.pickle.pickle_load:PickleLoad
+
+    # precli/rules/python/stdlib/poplib/pop_cleartext.py
+    PRE0013 = precli.rules.python.stdlib.poplib.pop_cleartext:PopCleartext
 
     # precli/rules/python/stdlib/shelve/shelve_open.py
-    PRE0011 = precli.rules.python.stdlib.shelve.shelve_open:ShelveOpen
+    PRE0014 = precli.rules.python.stdlib.shelve.shelve_open:ShelveOpen
+
+    # precli/rules/python/stdlib/smtplib/smtp_cleartext.py
+    PRE0015 = precli.rules.python.stdlib.smtplib.smtp_cleartext:SmtpCleartext
 
     # precli/rules/python/stdlib/ssl/create_unverified_context.py
-    PRE0012 = precli.rules.python.stdlib.ssl.create_unverified_context:CreateUnverifiedContext
+    PRE0016 = precli.rules.python.stdlib.ssl.create_unverified_context:CreateUnverifiedContext
 
     # precli/rules/python/stdlib/ssl/insecure_tls_version.py
-    PRE0013 = precli.rules.python.stdlib.ssl.insecure_tls_version:InsecureTlsVersion
+    PRE0017 = precli.rules.python.stdlib.ssl.insecure_tls_version:InsecureTlsVersion
 
     # precli/rules/python/stdlib/telnetlib/telnetlib_cleartext.py
-    PRE0014 = precli.rules.python.stdlib.telnetlib.telnetlib_cleartext:TelnetlibCleartext
+    PRE0018 = precli.rules.python.stdlib.telnetlib.telnetlib_cleartext:TelnetlibCleartext
 
     # precli/rules/python/third_party/cryptography/cryptography_weak_hash.py
-    PRE0015 = precli.rules.python.third_party.cryptography.cryptography_weak_hash:CryptographyWeakHash
+    PRE0501 = precli.rules.python.third_party.cryptography.cryptography_weak_hash:CryptographyWeakHash
 
     # precli/rules/python/third_party/dill/dill_load.py
-    PRE0016 = precli.rules.python.third_party.dill.dill_load:DillLoad
+    PRE0502 = precli.rules.python.third_party.dill.dill_load:DillLoad
 
     # precli/rules/python/third_party/httpx/no_certificate_verify.py
-    PRE0017 = precli.rules.python.third_party.httpx.no_certificate_verify:NoCertificateVerify
+    PRE0503 = precli.rules.python.third_party.httpx.no_certificate_verify:NoCertificateVerify
 
     # precli/rules/python/third_party/jsonpickle/jsonpickle_decode.py
-    PRE0018 = precli.rules.python.third_party.jsonpickle.jsonpickle_decode:JsonpickleDecode
+    PRE0504 = precli.rules.python.third_party.jsonpickle.jsonpickle_decode:JsonpickleDecode
 
     # precli/rules/python/third_party/pandas/pandas_read_pickle.py
-    PRE0019 = precli.rules.python.third_party.pandas.pandas_read_pickle:PandasReadPickle
+    PRE0505 = precli.rules.python.third_party.pandas.pandas_read_pickle:PandasReadPickle
 
     # precli/rules/python/third_party/paramiko/paramiko_no_host_key_verify.py
-    PRE0020 = precli.rules.python.third_party.paramiko.paramiko_no_host_key_verify:ParamikoNoHostKeyVerify
+    PRE0506 = precli.rules.python.third_party.paramiko.paramiko_no_host_key_verify:ParamikoNoHostKeyVerify
 
     # precli/rules/python/third_party/pyghmi/pyghmi_cleartext.py
-    PRE0021 = precli.rules.python.third_party.pyghmi.pyghmi_cleartext:PyghmiCleartext
+    PRE0507 = precli.rules.python.third_party.pyghmi.pyghmi_cleartext:PyghmiCleartext
 
     # precli/rules/python/third_party/pycrypto/pycrypto_weak_hash.py
-    PRE0022 = precli.rules.python.third_party.pycrypto.pycrypto_weak_hash:PycryptoWeakHash
+    PRE0508 = precli.rules.python.third_party.pycrypto.pycrypto_weak_hash:PycryptoWeakHash
 
     # precli/rules/python/third_party/pycryptodomex/pycryptodomex_weak_hash.py
-    PRE0023 = precli.rules.python.third_party.pycryptodomex.pycryptodomex_weak_hash:PycryptodomexWeakHash
+    PRE0509 = precli.rules.python.third_party.pycryptodomex.pycryptodomex_weak_hash:PycryptodomexWeakHash
 
     # precli/rules/python/third_party/pyopenssl/insecure_tls_method.py
-    PRE0024 = precli.rules.python.third_party.pyopenssl.insecure_tls_method:InsecureTlsMethod
+    PRE0510 = precli.rules.python.third_party.pyopenssl.insecure_tls_method:InsecureTlsMethod
 
     # precli/rules/python/third_party/PyYAML/yaml_load.py
-    PRE0025 = precli.rules.python.third_party.PyYAML.yaml_load:YamlLoad
+    PRE0511 = precli.rules.python.third_party.PyYAML.yaml_load:YamlLoad
 
     # precli/rules/python/third_party/requests/no_certificate_verify.py
-    PRE0026 = precli.rules.python.third_party.requests.no_certificate_verify:NoCertificateVerify
+    PRE0512 = precli.rules.python.third_party.requests.no_certificate_verify:NoCertificateVerify
 
 [build_sphinx]
 all_files = 1

--- a/tests/unit/rules/python/stdlib/json/test_json_load.py
+++ b/tests/unit/rules/python/stdlib/json/test_json_load.py
@@ -20,8 +20,8 @@ class JsonLoadTests(test_case.TestCase):
         )
 
     def test_json_load_rule_meta(self):
-        rule = Rule.get_by_id("PRE0007")
-        self.assertEqual("PRE0007", rule.id)
+        rule = Rule.get_by_id("PRE0008")
+        self.assertEqual("PRE0008", rule.id)
         self.assertEqual("deserialization_of_untrusted_data", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class JsonLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0007", result.rule_id)
+        self.assertEqual("PRE0008", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -49,7 +49,7 @@ class JsonLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0007", result.rule_id)
+        self.assertEqual("PRE0008", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -63,7 +63,7 @@ class JsonLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0007", result.rule_id)
+        self.assertEqual("PRE0008", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/logging/test_insecure_listen_config.py
+++ b/tests/unit/rules/python/stdlib/logging/test_insecure_listen_config.py
@@ -20,8 +20,8 @@ class InsecureListenConfigTests(test_case.TestCase):
         )
 
     def test_insecure_listen_config_rule_meta(self):
-        rule = Rule.get_by_id("PRE0008")
-        self.assertEqual("PRE0008", rule.id)
+        rule = Rule.get_by_id("PRE0009")
+        self.assertEqual("PRE0009", rule.id)
         self.assertEqual("code_injection", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -37,7 +37,7 @@ class InsecureListenConfigTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0008", result.rule_id)
+        self.assertEqual("PRE0009", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(9, result.location.start_column)
@@ -53,7 +53,7 @@ class InsecureListenConfigTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0008", result.rule_id)
+        self.assertEqual("PRE0009", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(9, result.location.start_column)
@@ -69,7 +69,7 @@ class InsecureListenConfigTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0008", result.rule_id)
+        self.assertEqual("PRE0009", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(9, result.location.start_column)
@@ -83,7 +83,7 @@ class InsecureListenConfigTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0008", result.rule_id)
+        self.assertEqual("PRE0009", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(9, result.location.start_column)
@@ -99,7 +99,7 @@ class InsecureListenConfigTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0008", result.rule_id)
+        self.assertEqual("PRE0009", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(9, result.location.start_column)
@@ -115,7 +115,7 @@ class InsecureListenConfigTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0008", result.rule_id)
+        self.assertEqual("PRE0009", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(9, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
+++ b/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
@@ -20,8 +20,8 @@ class MarshalLoadTests(test_case.TestCase):
         )
 
     def test_marshal_load_rule_meta(self):
-        rule = Rule.get_by_id("PRE0009")
-        self.assertEqual("PRE0009", rule.id)
+        rule = Rule.get_by_id("PRE0010")
+        self.assertEqual("PRE0010", rule.id)
         self.assertEqual("deserialization_of_untrusted_data", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class MarshalLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0009", result.rule_id)
+        self.assertEqual("PRE0010", result.rule_id)
         self.assertEqual(10, result.location.start_line)
         self.assertEqual(10, result.location.end_line)
         self.assertEqual(18, result.location.start_column)
@@ -49,7 +49,7 @@ class MarshalLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0009", result.rule_id)
+        self.assertEqual("PRE0010", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(0, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
+++ b/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
@@ -20,8 +20,8 @@ class PickleLoadTests(test_case.TestCase):
         )
 
     def test_pickle_load_rule_meta(self):
-        rule = Rule.get_by_id("PRE0010")
-        self.assertEqual("PRE0010", rule.id)
+        rule = Rule.get_by_id("PRE0012")
+        self.assertEqual("PRE0012", rule.id)
         self.assertEqual("deserialization_of_untrusted_data", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class PickleLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0010", result.rule_id)
+        self.assertEqual("PRE0012", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(10, result.location.start_column)
@@ -49,7 +49,7 @@ class PickleLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0010", result.rule_id)
+        self.assertEqual("PRE0012", result.rule_id)
         self.assertEqual(9, result.location.start_line)
         self.assertEqual(9, result.location.end_line)
         self.assertEqual(10, result.location.start_column)
@@ -63,7 +63,7 @@ class PickleLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0010", result.rule_id)
+        self.assertEqual("PRE0012", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(10, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
+++ b/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
@@ -20,8 +20,8 @@ class ShelveOpenTests(test_case.TestCase):
         )
 
     def test_shelve_open_rule_meta(self):
-        rule = Rule.get_by_id("PRE0011")
-        self.assertEqual("PRE0011", rule.id)
+        rule = Rule.get_by_id("PRE0014")
+        self.assertEqual("PRE0014", rule.id)
         self.assertEqual("deserialization_of_untrusted_data", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class ShelveOpenTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0011", result.rule_id)
+        self.assertEqual("PRE0014", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(5, result.location.start_column)
@@ -49,7 +49,7 @@ class ShelveOpenTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0011", result.rule_id)
+        self.assertEqual("PRE0014", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(5, result.location.start_column)
@@ -63,7 +63,7 @@ class ShelveOpenTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0011", result.rule_id)
+        self.assertEqual("PRE0014", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(5, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/ssl/test_get_server_certificate.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_get_server_certificate.py
@@ -20,8 +20,8 @@ class GetServerCertificateTests(test_case.TestCase):
         )
 
     def test_get_server_certificate_rule_meta(self):
-        rule = Rule.get_by_id("PRE0013")
-        self.assertEqual("PRE0013", rule.id)
+        rule = Rule.get_by_id("PRE0017")
+        self.assertEqual("PRE0017", rule.id)
         self.assertEqual("inadequate_encryption_strength", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class GetServerCertificateTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(63, result.location.start_column)
@@ -55,7 +55,7 @@ class GetServerCertificateTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(63, result.location.start_column)
@@ -69,7 +69,7 @@ class GetServerCertificateTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(63, result.location.start_column)
@@ -83,7 +83,7 @@ class GetServerCertificateTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(40, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context.py
@@ -20,8 +20,8 @@ class SslSocketTests(test_case.TestCase):
         )
 
     def test_ssl_context_rule_meta(self):
-        rule = Rule.get_by_id("PRE0013")
-        self.assertEqual("PRE0013", rule.id)
+        rule = Rule.get_by_id("PRE0017")
+        self.assertEqual("PRE0017", rule.id)
         self.assertEqual("inadequate_encryption_strength", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class SslSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(28, result.location.start_column)
@@ -55,7 +55,7 @@ class SslSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(28, result.location.start_column)
@@ -69,7 +69,7 @@ class SslSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(28, result.location.start_column)
@@ -83,7 +83,7 @@ class SslSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(28, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
@@ -20,8 +20,8 @@ class SslCreateContextTests(test_case.TestCase):
         )
 
     def test_unverified_context_rule_meta(self):
-        rule = Rule.get_by_id("PRE0012")
-        self.assertEqual("PRE0012", rule.id)
+        rule = Rule.get_by_id("PRE0016")
+        self.assertEqual("PRE0016", rule.id)
         self.assertEqual("improper_certificate_validation", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class SslCreateContextTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0012", result.rule_id)
+        self.assertEqual("PRE0016", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(10, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/ssl/test_wrap_socket.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_wrap_socket.py
@@ -20,8 +20,8 @@ class WrapSocketTests(test_case.TestCase):
         )
 
     def test_wrap_socket_rule_meta(self):
-        rule = Rule.get_by_id("PRE0013")
-        self.assertEqual("PRE0013", rule.id)
+        rule = Rule.get_by_id("PRE0017")
+        self.assertEqual("PRE0017", rule.id)
         self.assertEqual("inadequate_encryption_strength", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -35,7 +35,7 @@ class WrapSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(40, result.location.start_column)
@@ -51,7 +51,7 @@ class WrapSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(40, result.location.start_column)
@@ -71,7 +71,7 @@ class WrapSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(40, result.location.start_column)
@@ -85,7 +85,7 @@ class WrapSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(40, result.location.start_column)
@@ -99,7 +99,7 @@ class WrapSocketTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0013", result.rule_id)
+        self.assertEqual("PRE0017", result.rule_id)
         self.assertEqual(6, result.location.start_line)
         self.assertEqual(6, result.location.end_line)
         self.assertEqual(40, result.location.start_column)

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
@@ -20,8 +20,8 @@ class TelnetlibCleartextTests(test_case.TestCase):
         )
 
     def test_telnetlib_cleartext_rule_meta(self):
-        rule = Rule.get_by_id("PRE0014")
-        self.assertEqual("PRE0014", rule.id)
+        rule = Rule.get_by_id("PRE0018")
+        self.assertEqual("PRE0018", rule.id)
         self.assertEqual("cleartext_transmission", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -33,7 +33,7 @@ class TelnetlibCleartextTests(test_case.TestCase):
         results = self.parser.parse(os.path.join(self.base_path, "telnet.py"))
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0014", result.rule_id)
+        self.assertEqual("PRE0018", result.rule_id)
         self.assertEqual(9, result.location.start_line)
         self.assertEqual(9, result.location.end_line)
         self.assertEqual(5, result.location.start_column)
@@ -47,7 +47,7 @@ class TelnetlibCleartextTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0014", result.rule_id)
+        self.assertEqual("PRE0018", result.rule_id)
         self.assertEqual(9, result.location.start_line)
         self.assertEqual(9, result.location.end_line)
         self.assertEqual(5, result.location.start_column)
@@ -61,7 +61,7 @@ class TelnetlibCleartextTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0014", result.rule_id)
+        self.assertEqual("PRE0018", result.rule_id)
         self.assertEqual(9, result.location.start_line)
         self.assertEqual(9, result.location.end_line)
         self.assertEqual(5, result.location.start_column)

--- a/tests/unit/rules/python/third_party/PyYAML/test_yaml_load.py
+++ b/tests/unit/rules/python/third_party/PyYAML/test_yaml_load.py
@@ -10,7 +10,7 @@ from tests.unit.rules.python import test_case
 class YamlLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.parser = python.Python(enabled=["PRE0025"])
+        self.parser = python.Python(enabled=["PRE0511"])
         self.base_path = os.path.join(
             "tests",
             "unit",
@@ -22,8 +22,8 @@ class YamlLoadTests(test_case.TestCase):
         )
 
     def test_yaml_load_rule_meta(self):
-        rule = Rule.get_by_id("PRE0025")
-        self.assertEqual("PRE0025", rule.id)
+        rule = Rule.get_by_id("PRE0511")
+        self.assertEqual("PRE0511", rule.id)
         self.assertEqual("deserialization_of_untrusted_data", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -37,7 +37,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(3, result.location.start_line)
         self.assertEqual(3, result.location.end_line)
         self.assertEqual(5, result.location.start_column)
@@ -53,7 +53,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(3, result.location.start_line)
         self.assertEqual(3, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -67,7 +67,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(3, result.location.start_line)
         self.assertEqual(3, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -81,7 +81,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(3, result.location.start_line)
         self.assertEqual(3, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -95,7 +95,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(3, result.location.start_line)
         self.assertEqual(3, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -109,7 +109,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(5, result.location.start_column)
@@ -159,7 +159,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(3, result.location.start_line)
         self.assertEqual(3, result.location.end_line)
         self.assertEqual(21, result.location.start_column)
@@ -173,7 +173,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(16, result.location.start_column)
@@ -199,7 +199,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(3, result.location.start_line)
         self.assertEqual(3, result.location.end_line)
         self.assertEqual(28, result.location.start_column)
@@ -225,7 +225,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(23, result.location.start_column)
@@ -239,7 +239,7 @@ class YamlLoadTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0025", result.rule_id)
+        self.assertEqual("PRE0511", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(28, result.location.start_column)

--- a/tests/unit/rules/python/third_party/httpx/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/third_party/httpx/test_no_certificate_verify.py
@@ -10,7 +10,7 @@ from tests.unit.rules.python import test_case
 class NoCertificateVerifyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.parser = python.Python(enabled=["PRE0017"])
+        self.parser = python.Python(enabled=["PRE0503"])
         self.base_path = os.path.join(
             "tests",
             "unit",
@@ -22,8 +22,8 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
 
     def test_no_certificate_verify_rule_meta(self):
-        rule = Rule.get_by_id("PRE0017")
-        self.assertEqual("PRE0017", rule.id)
+        rule = Rule.get_by_id("PRE0503")
+        self.assertEqual("PRE0503", rule.id)
         self.assertEqual("improper_certificate_validation", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -39,7 +39,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(36, result.location.start_column)
@@ -53,7 +53,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(34, result.location.start_column)
@@ -69,7 +69,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(25, result.location.start_column)
@@ -83,7 +83,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(29, result.location.start_column)
@@ -97,7 +97,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(41, result.location.start_column)
@@ -111,7 +111,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(38, result.location.start_column)
@@ -137,7 +137,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(39, result.location.start_column)
@@ -151,7 +151,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(42, result.location.start_column)
@@ -165,7 +165,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(40, result.location.start_column)
@@ -179,7 +179,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(39, result.location.start_column)
@@ -193,7 +193,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(38, result.location.start_column)
@@ -207,7 +207,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(48, result.location.start_column)
@@ -221,7 +221,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0017", result.rule_id)
+        self.assertEqual("PRE0503", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(41, result.location.start_column)

--- a/tests/unit/rules/python/third_party/jsonpickle/test_jsonpickle_decode.py
+++ b/tests/unit/rules/python/third_party/jsonpickle/test_jsonpickle_decode.py
@@ -10,11 +10,11 @@ from tests.unit.rules.python import test_case
 class JsonPickleDecodeTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.parser = python.Python(enabled=["PRE0018"])
+        self.parser = python.Python(enabled=["PRE0504"])
 
     def test_jsonpickle_decode_rule_meta(self):
-        rule = Rule.get_by_id("PRE0018")
-        self.assertEqual("PRE0018", rule.id)
+        rule = Rule.get_by_id("PRE0504")
+        self.assertEqual("PRE0504", rule.id)
         self.assertEqual("deserialization_of_untrusted_data", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -33,7 +33,7 @@ class JsonPickleDecodeTests(test_case.TestCase):
         results = self.parser.parse("test.py", str.encode(fdata))
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0018", result.rule_id)
+        self.assertEqual("PRE0504", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)

--- a/tests/unit/rules/python/third_party/paramiko/test_host_key_policy.py
+++ b/tests/unit/rules/python/third_party/paramiko/test_host_key_policy.py
@@ -10,7 +10,7 @@ from tests.unit.rules.python import test_case
 class HostKeyPolicyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.parser = python.Python(enabled=["PRE0020"])
+        self.parser = python.Python(enabled=["PRE0506"])
         self.base_path = os.path.join(
             "tests",
             "unit",
@@ -22,8 +22,8 @@ class HostKeyPolicyTests(test_case.TestCase):
         )
 
     def test_paramiko_no_host_key_verify_rule_meta(self):
-        rule = Rule.get_by_id("PRE0020")
-        self.assertEqual("PRE0020", rule.id)
+        rule = Rule.get_by_id("PRE0506")
+        self.assertEqual("PRE0506", rule.id)
         self.assertEqual("improper_certificate_validation", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -39,7 +39,7 @@ class HostKeyPolicyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0020", result.rule_id)
+        self.assertEqual("PRE0506", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(48, result.location.start_column)
@@ -53,7 +53,7 @@ class HostKeyPolicyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0020", result.rule_id)
+        self.assertEqual("PRE0506", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(46, result.location.start_column)
@@ -67,7 +67,7 @@ class HostKeyPolicyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0020", result.rule_id)
+        self.assertEqual("PRE0506", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(53, result.location.start_column)
@@ -90,7 +90,7 @@ class HostKeyPolicyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0020", result.rule_id)
+        self.assertEqual("PRE0506", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(54, result.location.start_column)
@@ -104,7 +104,7 @@ class HostKeyPolicyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0020", result.rule_id)
+        self.assertEqual("PRE0506", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(50, result.location.start_column)
@@ -120,7 +120,7 @@ class HostKeyPolicyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0020", result.rule_id)
+        self.assertEqual("PRE0506", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(54, result.location.start_column)

--- a/tests/unit/rules/python/third_party/pyopenssl/test_ssl_context.py
+++ b/tests/unit/rules/python/third_party/pyopenssl/test_ssl_context.py
@@ -10,7 +10,7 @@ from tests.unit.rules.python import test_case
 class SslContextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.parser = python.Python(enabled=["PRE0024"])
+        self.parser = python.Python(enabled=["PRE0510"])
         self.base_path = os.path.join(
             "tests",
             "unit",
@@ -22,8 +22,8 @@ class SslContextTests(test_case.TestCase):
         )
 
     def test_ssl_context_rule_meta(self):
-        rule = Rule.get_by_id("PRE0024")
-        self.assertEqual("PRE0024", rule.id)
+        rule = Rule.get_by_id("PRE0510")
+        self.assertEqual("PRE0510", rule.id)
         self.assertEqual("inadequate_encryption_strength", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -37,7 +37,7 @@ class SslContextTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0024", result.rule_id)
+        self.assertEqual("PRE0510", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(39, result.location.start_column)
@@ -57,7 +57,7 @@ class SslContextTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0024", result.rule_id)
+        self.assertEqual("PRE0510", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(39, result.location.start_column)
@@ -71,7 +71,7 @@ class SslContextTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0024", result.rule_id)
+        self.assertEqual("PRE0510", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(39, result.location.start_column)
@@ -85,7 +85,7 @@ class SslContextTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0024", result.rule_id)
+        self.assertEqual("PRE0510", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(39, result.location.start_column)

--- a/tests/unit/rules/python/third_party/requests/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/third_party/requests/test_no_certificate_verify.py
@@ -10,7 +10,7 @@ from tests.unit.rules.python import test_case
 class NoCertificateVerifyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.parser = python.Python(enabled=["PRE0026"])
+        self.parser = python.Python(enabled=["PRE0512"])
         self.base_path = os.path.join(
             "tests",
             "unit",
@@ -22,8 +22,8 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
 
     def test_no_certificate_verify_rule_meta(self):
-        rule = Rule.get_by_id("PRE0026")
-        self.assertEqual("PRE0026", rule.id)
+        rule = Rule.get_by_id("PRE0512")
+        self.assertEqual("PRE0512", rule.id)
         self.assertEqual("improper_certificate_validation", rule.name)
         self.assertEqual("", rule.help_url)
         self.assertEqual(True, rule.default_config.enabled)
@@ -37,7 +37,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(44, result.location.start_column)
@@ -51,7 +51,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(41, result.location.start_column)
@@ -65,7 +65,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(41, result.location.start_column)
@@ -91,7 +91,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(42, result.location.start_column)
@@ -105,7 +105,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(45, result.location.start_column)
@@ -119,7 +119,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(43, result.location.start_column)
@@ -133,7 +133,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(42, result.location.start_column)
@@ -147,7 +147,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(41, result.location.start_column)
@@ -161,7 +161,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(52, result.location.start_column)
@@ -178,7 +178,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(44, result.location.start_column)
@@ -194,7 +194,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(43, result.location.start_column)
@@ -210,7 +210,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(40, result.location.start_column)
@@ -226,7 +226,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(41, result.location.start_column)
@@ -242,7 +242,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(44, result.location.start_column)
@@ -258,7 +258,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(42, result.location.start_column)
@@ -274,7 +274,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(41, result.location.start_column)
@@ -290,7 +290,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(40, result.location.start_column)
@@ -306,7 +306,7 @@ class NoCertificateVerifyTests(test_case.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0026", result.rule_id)
+        self.assertEqual("PRE0512", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(51, result.location.start_column)


### PR DESCRIPTION
This change adds a call history as part of the symbol table of identifiers. This enables checks for libraries such as imaplib that initialize an insecure class and is only secure if starttls is later called.

* Symbol has push_call and call_history to track history
* Adds 4 new rules for modules imaplib, nntplib, poplib, smtplib