### PR TITLE
Fix IndexError in _get_var_node

### DIFF
--- a/precli/core/call.py
+++ b/precli/core/call.py
@@ -16,8 +16,8 @@ class Call:
         self._node = node
         self._name = name
         self._name_qual = name_qual
-        self._args = args
-        self._kwargs = kwargs
+        self._args = args if args is not None else []
+        self._kwargs = kwargs if kwargs is not None else {}
 
         if self._node.children:
             # Assign nodes to the call attribute/identifier and argument
@@ -30,7 +30,7 @@ class Call:
     @staticmethod
     def _get_var_node(node: Node) -> Node:
         if (
-            node.named_children
+            len(node.named_children) >= 2
             and node.named_children[0].type in ("identifier", "attribute")
             and node.named_children[1].type == "identifier"
         ):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/ericwb/workspace/precli/precli/cli/main.py", line 192, in parse_file
    return parser.parse(fname, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ericwb/workspace/precli/precli/parsers/__init__.py", line 81, in parse
    self.visit([tree.root_node])
  File "/Users/ericwb/workspace/precli/precli/parsers/__init__.py", line 102, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/python.py", line 34, in visit_module
    self.visit(nodes)
  File "/Users/ericwb/workspace/precli/precli/parsers/__init__.py", line 102, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/__init__.py", line 102, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/python.py", line 127, in visit_assignment
    self.visit(nodes)
  File "/Users/ericwb/workspace/precli/precli/parsers/__init__.py", line 102, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/__init__.py", line 102, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/__init__.py", line 102, in visit
    visitor_fn(node.children)
  File "/Users/ericwb/workspace/precli/precli/parsers/python.py", line 133, in visit_call
    call = Call(
           ^^^^^
  File "/Users/ericwb/workspace/precli/precli/core/call.py", line 27, in __init__
    self._var_node = Call._get_var_node(self._func_node)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ericwb/workspace/precli/precli/core/call.py", line 35, in _get_var_node
    and node.named_children[1].type == "identifier"
        ~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```