### PR TITLE
Handle syntax errors in code

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -101,6 +101,19 @@ class Parser(ABC):
             visitor_fn = getattr(self, f"visit_{node.type}", self.visit)
             visitor_fn(node.children)
 
+    def visit_ERROR(self, nodes: list[Node]):
+        raise SyntaxError(
+            "Syntax error while parsing file.",
+            (
+                self.context["file_name"],
+                self.context["node"].start_point[0] + 1,
+                self.context["node"].start_point[1] + 1,
+                self.context["node"].text.decode(),
+                self.context["node"].end_point[0] + 1,
+                self.context["node"].end_point[1] + 1,
+            ),
+        )
+
     def process_rules(self, target: str, **kwargs: dict) -> list[Result]:
         """
         Process the rules based on target.

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -32,8 +32,6 @@ class Python(Parser):
     def visit_module(self, nodes: list[Node]):
         self.suppressions = {}
         self.current_symtab = SymbolTable("<module>")
-        for builtin in dir(builtins):
-            self.current_symtab.put(builtin, "import", builtin)
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
@@ -324,9 +322,12 @@ class Python(Parser):
         return args, kwargs
 
     def get_qual_name(self, node: Node) -> Symbol:
-        symbol = self.current_symtab.get(node.text.decode())
+        nodetext = node.text.decode()
+        symbol = self.current_symtab.get(nodetext)
         if symbol is not None:
             return symbol
+        if nodetext in dir(builtins):
+            return Symbol(nodetext, "identifier", nodetext)
         for child in node.children:
             return self.get_qual_name(child)
 

--- a/precli/rules/python/stdlib/tempfile/mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile/mktemp_race_condition.py
@@ -83,7 +83,6 @@ class MktempRaceCondition(Rule):
     def analyze(self, context: dict, **kwargs: dict) -> Result:
         call = kwargs.get("call")
 
-        # TODO: the builtin open can't be found because not imported
         if call.name_qualified in ["open"]:
             file_arg = call.get_argument(position=0, name="file")
 

--- a/tests/unit/rules/python/stdlib/tempfile/examples/tempfile_mktemp_walrus_open.py
+++ b/tests/unit/rules/python/stdlib/tempfile/examples/tempfile_mktemp_walrus_open.py
@@ -1,0 +1,6 @@
+import tempfile
+
+
+if filename := tempfile.mktemp():
+    with open(filename, "w+") as f:
+        f.write(b"Hello World!\n")


### PR DESCRIPTION
The code being analyzed potentially can have syntax errors. Precli needs to robustly handle these errors and continue to the next file.

* New visit_ERROR() function added to handle parsing errors
* Metrics updated with number of files skipped due to syntax errors