### PR TITLE
Remap the rule IDs

### DIFF
--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -39,7 +39,8 @@ class Result:
         """
         The ID of the rule.
 
-        The IDs match PREXXXX where XXXX is a unique number.
+        The IDs match ??XXX where ?? is language identifier and XXX is a
+        unique number.
 
         :return: rule ID
         :rtype: str

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -19,7 +19,7 @@ from precli.rules import Rule
 Import = namedtuple("Import", "module alias")
 
 SUPPRESS_COMMENT = re.compile(r"# suppress:? (?P<rules>[^#]+)?#?")
-SUPPRESSED_RULES = re.compile(r"(?:(PRE\d\d\d\d|[a-z_]+),?)+")
+SUPPRESSED_RULES = re.compile(r"(?:(PY\d\d\d|[a-z_]+),?)+")
 
 
 class Python(Parser):

--- a/precli/rules/go/golang_org_x_crypto_ssh/ssh_insecure_ignore_hostkey.py
+++ b/precli/rules/go/golang_org_x_crypto_ssh/ssh_insecure_ignore_hostkey.py
@@ -129,7 +129,7 @@ host key is unknown to the client.
 
 .. seealso::
 
- - `Improper Hostkey Validation Using SSH <https://docs.securesauce.dev/rules/PRE1501>`_
+ - `Improper Hostkey Validation Using SSH <https://docs.securesauce.dev/rules/GO501>`_
  - `ssh package - golang.org_x_crypto_ssh - Go Packages <https://pkg.go.dev/golang.org/x/crypto/ssh#InsecureIgnoreHostKey>`_
  - `CWE-295: Improper Certificate Validation <https://cwe.mitre.org/data/definitions/295.html>`_
 

--- a/precli/rules/python/M2Crypto/m2crypto_weak_key.py
+++ b/precli/rules/python/M2Crypto/m2crypto_weak_key.py
@@ -74,7 +74,7 @@ algorithms.
 
 .. seealso::
 
- - `Inadequate Encryption Strength Using Weak Keys in M2Crypto Module <https://docs.securesauce.dev/rules/PRE0509>`_
+ - `Inadequate Encryption Strength Using Weak Keys in M2Crypto Module <https://docs.securesauce.dev/rules/PY509>`_
  - `m2crypto _ m2crypto · GitLab <https://gitlab.com/m2crypto/m2crypto>`_
  - `CWE-326: Inadequate Encryption Strength <https://cwe.mitre.org/data/definitions/326.html>`_
 

--- a/precli/rules/python/PyYAML/yaml_load.py
+++ b/precli/rules/python/PyYAML/yaml_load.py
@@ -44,7 +44,7 @@ to the ``Loader`` argument.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in the PyYAML Module <https://docs.securesauce.dev/rules/PRE0521>`_
+ - `Deserialization of Untrusted Data in the PyYAML Module <https://docs.securesauce.dev/rules/PY521>`_
  - `PyYAML Documentation <https://pyyaml.org/wiki/PyYAMLDocumentation>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
 

--- a/precli/rules/python/aiohttp/no_certificate_verify.py
+++ b/precli/rules/python/aiohttp/no_certificate_verify.py
@@ -49,7 +49,7 @@ argument accomplish the same effect of ensuring that certificates are verified.
 
 .. seealso::
 
- - `Improper Certificate Validation Using Requests Module <https://docs.securesauce.dev/rules/PRE0501>`_
+ - `Improper Certificate Validation Using Requests Module <https://docs.securesauce.dev/rules/PY501>`_
  - `Advanced Client Usage — aiohttp documentation <https://docs.aiohttp.org/en/stable/client_advanced.html#ssl-control-for-tcp-sockets>`_
  - `CWE-295: Improper Certificate Validation <https://cwe.mitre.org/data/definitions/295.html>`_
 

--- a/precli/rules/python/cryptography/cryptography_weak_cipher.py
+++ b/precli/rules/python/cryptography/cryptography_weak_cipher.py
@@ -107,7 +107,7 @@ AES.
 
 .. seealso::
 
- - `Use of a Broken or Risky Cryptographic Algorithm in Cryptography Module <https://docs.securesauce.dev/rules/PRE0502>`_
+ - `Use of a Broken or Risky Cryptographic Algorithm in Cryptography Module <https://docs.securesauce.dev/rules/PY502>`_
  - `Symmetric encryption — Cryptography documentation <https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#weak-ciphers>`_
  - `CWE-327: Use of a Broken or Risky Cryptographic Algorithm <https://cwe.mitre.org/data/definitions/327.html>`_
 

--- a/precli/rules/python/cryptography/cryptography_weak_cipher_mode.py
+++ b/precli/rules/python/cryptography/cryptography_weak_cipher_mode.py
@@ -77,7 +77,7 @@ It is advisable to use a secure cryptographic algorithms such as CBC.
 
 .. seealso::
 
- - `Use of a Risky Cryptographic Cipher Mode in Cryptography Module <https://docs.securesauce.dev/rules/PRE0503>`_
+ - `Use of a Risky Cryptographic Cipher Mode in Cryptography Module <https://docs.securesauce.dev/rules/PY503>`_
  - `Symmetric encryption — Cryptography documentation <https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#insecure-modes>`_
  - `CWE-327: Use of a Broken or Risky Cryptographic Algorithm <https://cwe.mitre.org/data/definitions/327.html>`_
 

--- a/precli/rules/python/cryptography/cryptography_weak_hash.py
+++ b/precli/rules/python/cryptography/cryptography_weak_hash.py
@@ -48,7 +48,7 @@ secure alternatives, ``SHA256`` or ``SHA512``.
 
 .. seealso::
 
- - `Reversible One Way Hash in Cryptography Module <https://docs.securesauce.dev/rules/PRE0504>`_
+ - `Reversible One Way Hash in Cryptography Module <https://docs.securesauce.dev/rules/PY504>`_
  - `Message digests (Hashing) — Cryptography <https://cryptography.io/en/latest/hazmat/primitives/cryptographic-hashes/>`_
  - `CWE-328: Use of Weak Hash <https://cwe.mitre.org/data/definitions/328.html>`_
  - `NIST Policy on Hash Functions <https://csrc.nist.gov/projects/hash-functions>`_

--- a/precli/rules/python/cryptography/cryptography_weak_key.py
+++ b/precli/rules/python/cryptography/cryptography_weak_key.py
@@ -74,7 +74,7 @@ algorithms.
 
 .. seealso::
 
- - `Inadequate Encryption Strength Using Weak Keys in Cryptography Module <https://docs.securesauce.dev/rules/PRE0505>`_
+ - `Inadequate Encryption Strength Using Weak Keys in Cryptography Module <https://docs.securesauce.dev/rules/PY505>`_
  - `Asymmetric algorithms — Cryptography documentation <https://cryptography.io/en/latest/hazmat/primitives/asymmetric/>`_
  - `CWE-326: Inadequate Encryption Strength <https://cwe.mitre.org/data/definitions/326.html>`_
 

--- a/precli/rules/python/dill/dill_load.py
+++ b/precli/rules/python/dill/dill_load.py
@@ -33,7 +33,7 @@ should first sanitize the data to remove any potential malicious code.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in the Dill Module <https://docs.securesauce.dev/rules/PRE0506>`_
+ - `Deserialization of Untrusted Data in the Dill Module <https://docs.securesauce.dev/rules/PY506>`_
  - `dill package documentation <https://dill.readthedocs.io/en/latest/index.html>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
 

--- a/precli/rules/python/httpx/no_certificate_verify.py
+++ b/precli/rules/python/httpx/no_certificate_verify.py
@@ -45,7 +45,7 @@ argument accomplish the same effect of ensuring that certificates are verified.
 
 .. seealso::
 
- - `Improper Certificate Validation Using Httpx Module <https://docs.securesauce.dev/rules/PRE0507>`_
+ - `Improper Certificate Validation Using Httpx Module <https://docs.securesauce.dev/rules/PY507>`_
  - `HTTPX <https://www.python-httpx.org/>`_
  - `CWE-295: Improper Certificate Validation <https://cwe.mitre.org/data/definitions/295.html>`_
 

--- a/precli/rules/python/jsonpickle/jsonpickle_decode.py
+++ b/precli/rules/python/jsonpickle/jsonpickle_decode.py
@@ -34,7 +34,7 @@ not been tampered with.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in JsonPickle Module <https://docs.securesauce.dev/rules/PRE0508>`_
+ - `Deserialization of Untrusted Data in JsonPickle Module <https://docs.securesauce.dev/rules/PY508>`_
  - `jsonpickle Documentation <https://jsonpickle.github.io/>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
  - `pickle — Python object serialization <https://docs.python.org/3/library/pickle.html>`_

--- a/precli/rules/python/pandas/pandas_read_pickle.py
+++ b/precli/rules/python/pandas/pandas_read_pickle.py
@@ -45,7 +45,7 @@ secure and cannot be used to execute malicious code.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in Pandas Module <https://docs.securesauce.dev/rules/PRE0510>`_
+ - `Deserialization of Untrusted Data in Pandas Module <https://docs.securesauce.dev/rules/PY510>`_
  - `Input_output — pandas <https://pandas.pydata.org/docs/reference/io.html#pickling>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
  - `pickle — Python object serialization <https://docs.python.org/3/library/pickle.html>`_

--- a/precli/rules/python/paramiko/paramiko_no_host_key_verify.py
+++ b/precli/rules/python/paramiko/paramiko_no_host_key_verify.py
@@ -48,7 +48,7 @@ connection if the host key is unknown to the client.
 
 .. seealso::
 
- - `Improper Certificate Validation Using Paramiko Module <https://docs.securesauce.dev/rules/PRE0511>`_
+ - `Improper Certificate Validation Using Paramiko Module <https://docs.securesauce.dev/rules/PY511>`_
  - `Paramiko’s documentation <https://docs.paramiko.org/en/latest/>`_
  - `CWE-295: Improper Certificate Validation <https://cwe.mitre.org/data/definitions/295.html>`_
 

--- a/precli/rules/python/pycrypto/pycrypto_weak_cipher.py
+++ b/precli/rules/python/pycrypto/pycrypto_weak_cipher.py
@@ -103,7 +103,7 @@ AES.
 
 .. seealso::
 
- - `Use of a Broken or Risky Cryptographic Algorithm in PyCrypto Module <https://docs.securesauce.dev/rules/PRE0512>`_
+ - `Use of a Broken or Risky Cryptographic Algorithm in PyCrypto Module <https://docs.securesauce.dev/rules/PY512>`_
  - `PyCrypto - The Python Cryptography Toolkit <https://www.pycrypto.org/>`_
  - `CWE-327: Use of a Broken or Risky Cryptographic Algorithm <https://cwe.mitre.org/data/definitions/327.html>`_
 

--- a/precli/rules/python/pycrypto/pycrypto_weak_hash.py
+++ b/precli/rules/python/pycrypto/pycrypto_weak_hash.py
@@ -63,7 +63,7 @@ secure alternatives, ``SHA256``, ``SHA384``, or ``SHA512``.
 
 .. seealso::
 
- - `Reversible One Way Hash in PyCrypto Module <https://docs.securesauce.dev/rules/PRE0513>`_
+ - `Reversible One Way Hash in PyCrypto Module <https://docs.securesauce.dev/rules/PY513>`_
  - `PyCrypto - The Python Cryptography Toolkit <https://www.pycrypto.org/>`_
  - `CWE-328: Use of Weak Hash <https://cwe.mitre.org/data/definitions/328.html>`_
  - `NIST Policy on Hash Functions <https://csrc.nist.gov/projects/hash-functions>`_

--- a/precli/rules/python/pycrypto/pycrypto_weak_key.py
+++ b/precli/rules/python/pycrypto/pycrypto_weak_key.py
@@ -62,7 +62,7 @@ algorithms.
 
 .. seealso::
 
- - `Inadequate Encryption Strength Using Weak Keys in PyCrypto Module <https://docs.securesauce.dev/rules/PRE0514>`_
+ - `Inadequate Encryption Strength Using Weak Keys in PyCrypto Module <https://docs.securesauce.dev/rules/PY514>`_
  - `PyCrypto - The Python Cryptography Toolkit <https://www.pycrypto.org/>`_
  - `CWE-326: Inadequate Encryption Strength <https://cwe.mitre.org/data/definitions/326.html>`_
 

--- a/precli/rules/python/pycryptodomex/pycryptodomex_weak_cipher.py
+++ b/precli/rules/python/pycryptodomex/pycryptodomex_weak_cipher.py
@@ -103,7 +103,7 @@ AES.
 
 .. seealso::
 
- - `Use of a Broken or Risky Cryptographic Algorithm in PyCrypto Module <https://docs.securesauce.dev/rules/PRE0515>`_
+ - `Use of a Broken or Risky Cryptographic Algorithm in PyCrypto Module <https://docs.securesauce.dev/rules/PY515>`_
  - `PyCryptodome <https://www.pycryptodome.org/>`_
  - `CWE-327: Use of a Broken or Risky Cryptographic Algorithm <https://cwe.mitre.org/data/definitions/327.html>`_
 

--- a/precli/rules/python/pycryptodomex/pycryptodomex_weak_hash.py
+++ b/precli/rules/python/pycryptodomex/pycryptodomex_weak_hash.py
@@ -63,7 +63,7 @@ secure alternatives, ``SHA256``, ``SHA384``, or ``SHA512``.
 
 .. seealso::
 
- - `Reversible One Way Hash in PyCryptodomex Module <https://docs.securesauce.dev/rules/PRE0516>`_
+ - `Reversible One Way Hash in PyCryptodomex Module <https://docs.securesauce.dev/rules/PY516>`_
  - `PyCryptodome <https://www.pycryptodome.org/>`_
  - `CWE-328: Use of Weak Hash <https://cwe.mitre.org/data/definitions/328.html>`_
  - `NIST Policy on Hash Functions <https://csrc.nist.gov/projects/hash-functions>`_

--- a/precli/rules/python/pycryptodomex/pycryptodomex_weak_key.py
+++ b/precli/rules/python/pycryptodomex/pycryptodomex_weak_key.py
@@ -62,7 +62,7 @@ algorithms.
 
 .. seealso::
 
- - `Inadequate Encryption Strength Using Weak Keys in PyCrypto Module <https://docs.securesauce.dev/rules/PRE0517>`_
+ - `Inadequate Encryption Strength Using Weak Keys in PyCrypto Module <https://docs.securesauce.dev/rules/PY517>`_
  - `PyCryptodome <https://www.pycryptodome.org/>`_
  - `CWE-326: Inadequate Encryption Strength <https://cwe.mitre.org/data/definitions/326.html>`_
 

--- a/precli/rules/python/pyghmi/pyghmi_cleartext.py
+++ b/precli/rules/python/pyghmi/pyghmi_cleartext.py
@@ -87,7 +87,7 @@ secure network.
 
 .. seealso::
 
- - `Cleartext Transmission of Sensitive Information in the Pyghmi Module <https://docs.securesauce.dev/rules/PRE0518>`_
+ - `Cleartext Transmission of Sensitive Information in the Pyghmi Module <https://docs.securesauce.dev/rules/PY518>`_
  - `Documentation — pyghmi documentation <https://docs.openstack.org/pyghmi/latest/>`_
  - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
  - `Risks of Using the Intelligent Platform Management Interface (IPMI) CISA <https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi>`_

--- a/precli/rules/python/pyopenssl/insecure_tls_method.py
+++ b/precli/rules/python/pyopenssl/insecure_tls_method.py
@@ -54,7 +54,7 @@ they negotiate a secure version of the method for you.
 
 .. seealso::
 
- - `Inadequate Encryption Strength Using Weak SSL Protocols <https://docs.securesauce.dev/rules/PRE0519>`_
+ - `Inadequate Encryption Strength Using Weak SSL Protocols <https://docs.securesauce.dev/rules/PY519>`_
  - `pyOpenSSL’s documentation <https://www.pyopenssl.org/en/latest/>`_
  - `CWE-326: Inadequate Encryption Strength <https://cwe.mitre.org/data/definitions/326.html>`_
 

--- a/precli/rules/python/pyopenssl/pyopenssl_weak_key.py
+++ b/precli/rules/python/pyopenssl/pyopenssl_weak_key.py
@@ -62,7 +62,7 @@ algorithms.
 
 .. seealso::
 
- - `Inadequate Encryption Strength Using Weak Keys in PyOpenSSL Module <https://docs.securesauce.dev/rules/PRE0520>`_
+ - `Inadequate Encryption Strength Using Weak Keys in PyOpenSSL Module <https://docs.securesauce.dev/rules/PY520>`_
  - `crypto — Generic cryptographic module — pyOpenSSL documentation <https://www.pyopenssl.org/en/latest/api/crypto.html#pkey-objects>`_
  - `CWE-326: Inadequate Encryption Strength <https://cwe.mitre.org/data/definitions/326.html>`_
 

--- a/precli/rules/python/requests/no_certificate_verify.py
+++ b/precli/rules/python/requests/no_certificate_verify.py
@@ -45,7 +45,7 @@ argument accomplish the same effect of ensuring that certificates are verified.
 
 .. seealso::
 
- - `Improper Certificate Validation Using Requests Module <https://docs.securesauce.dev/rules/PRE0522>`_
+ - `Improper Certificate Validation Using Requests Module <https://docs.securesauce.dev/rules/PY522>`_
  - `Requests HTTP for Humans™ <https://requests.readthedocs.io/en/latest/>`_
  - `CWE-295: Improper Certificate Validation <https://cwe.mitre.org/data/definitions/295.html>`_
 

--- a/precli/rules/python/stdlib/crypt/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt/crypt_weak_hash.py
@@ -89,7 +89,7 @@ alternatives include ``bcrypt``, ``pbkdf2``, and ``scrypt``.
 
 .. seealso::
 
- - `Reversible One Way Hash in Crypt Module <https://docs.securesauce.dev/rules/PRE0002>`_
+ - `Reversible One Way Hash in Crypt Module <https://docs.securesauce.dev/rules/PY002>`_
  - `crypt — Function to check Unix passwords <https://docs.python.org/3/library/crypt.html>`_
  - `CWE-328: Use of Weak Hash <https://cwe.mitre.org/data/definitions/328.html>`_
  - `NIST Policy on Hash Functions <https://csrc.nist.gov/projects/hash-functions>`_

--- a/precli/rules/python/stdlib/ftplib/ftp_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib/ftp_cleartext.py
@@ -75,7 +75,7 @@ These alternatives include:
 
 .. seealso::
 
- - `Cleartext Transmission of Sensitive Information in the Ftplib Module <https://docs.securesauce.dev/rules/PRE0003>`_
+ - `Cleartext Transmission of Sensitive Information in the Ftplib Module <https://docs.securesauce.dev/rules/PY003>`_
  - `ftplib — FTP protocol client <https://docs.python.org/3/library/ftplib.html>`_
  - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
  - https://www.paramiko.org/

--- a/precli/rules/python/stdlib/hashlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib/hashlib_weak_hash.py
@@ -75,7 +75,7 @@ constructor.
 
 .. seealso::
 
- - `Reversible One Way Hash in Hashlib Module <https://docs.securesauce.dev/rules/PRE0004>`_
+ - `Reversible One Way Hash in Hashlib Module <https://docs.securesauce.dev/rules/PY004>`_
  - `hashlib — Secure hashes and message digests <https://docs.python.org/3/library/hashlib.html>`_
  - `CWE-328: Use of Weak Hash <https://cwe.mitre.org/data/definitions/328.html>`_
  - `NIST Policy on Hash Functions <https://csrc.nist.gov/projects/hash-functions>`_

--- a/precli/rules/python/stdlib/hmac/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac/hmac_timing_attack.py
@@ -72,7 +72,7 @@ The recommendation is to replace the == operator with the function
 
 .. seealso::
 
- - `Observable Timing Discrepancy in Hmac Module <https://docs.securesauce.dev/rules/PRE0005>`_
+ - `Observable Timing Discrepancy in Hmac Module <https://docs.securesauce.dev/rules/PY005>`_
  - `hmac — Keyed-Hashing for Message Authentication <https://docs.python.org/3/library/hmac.html>`_
  - `CWE-208: Observable Timing Discrepancy <https://cwe.mitre.org/data/definitions/208.html>`_
 

--- a/precli/rules/python/stdlib/hmac/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac/hmac_weak_hash.py
@@ -67,7 +67,7 @@ secure alternatives, ``SHA256``, ``SHA-384``, or ``SHA512``.
 
 .. seealso::
 
- - `Reversible One Way Hash in Hmac Module <https://docs.securesauce.dev/rules/PRE0006>`_
+ - `Reversible One Way Hash in Hmac Module <https://docs.securesauce.dev/rules/PY006>`_
  - `hmac — Keyed-Hashing for Message Authentication <https://docs.python.org/3/library/hmac.html>`_
  - `CWE-328: Use of Weak Hash <https://cwe.mitre.org/data/definitions/328.html>`_
  - `NIST Policy on Hash Functions <https://csrc.nist.gov/projects/hash-functions>`_

--- a/precli/rules/python/stdlib/imaplib/imap_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib/imap_cleartext.py
@@ -63,7 +63,7 @@ Alternatively, the ``starttls`` function can be used to enter a secure session.
 
 .. seealso::
 
- - `Cleartext Transmission of Sensitive Information in the Imaplib Module <https://docs.securesauce.dev/rules/PRE0007>`_
+ - `Cleartext Transmission of Sensitive Information in the Imaplib Module <https://docs.securesauce.dev/rules/PY007>`_
  - `imaplib — IMAP4 protocol client <https://docs.python.org/3/library/imaplib.html>`_
  - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
 

--- a/precli/rules/python/stdlib/json/json_load.py
+++ b/precli/rules/python/stdlib/json/json_load.py
@@ -33,7 +33,7 @@ should first sanitize the data to remove any potential malicious code.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in the Json Module <https://docs.securesauce.dev/rules/PRE0008>`_
+ - `Deserialization of Untrusted Data in the Json Module <https://docs.securesauce.dev/rules/PY008>`_
  - `json — JSON encoder and decoder <https://docs.python.org/3/library/json.html>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
 

--- a/precli/rules/python/stdlib/logging/insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging/insecure_listen_config.py
@@ -48,7 +48,7 @@ verify the data is to use encryption and/or signing.
 
 .. seealso::
 
- - `Code Injection in Logging Config <https://docs.securesauce.dev/rules/PRE0009>`_
+ - `Code Injection in Logging Config <https://docs.securesauce.dev/rules/PY009>`_
  - `logging.config — Logging configuration <https://docs.python.org/3/library/logging.config.html#module-logging.config>`_
  - `CWE-94: Improper Control of Generation of Code ('Code Injection') <https://cwe.mitre.org/data/definitions/94.html>`_
 

--- a/precli/rules/python/stdlib/marshal/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal/marshal_load.py
@@ -38,7 +38,7 @@ you should first sanitize the data to remove any potential malicious code.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in the Marshal Module <https://docs.securesauce.dev/rules/PRE0010>`_
+ - `Deserialization of Untrusted Data in the Marshal Module <https://docs.securesauce.dev/rules/PY010>`_
  - `marshal — Internal Python object serialization <https://docs.python.org/3/library/marshal.html>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
 

--- a/precli/rules/python/stdlib/nntplib/nntp_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib/nntp_cleartext.py
@@ -48,7 +48,7 @@ Alternatively, the ``starttls`` function can be used to enter a secure session.
 
 .. seealso::
 
- - `Cleartext Transmission of Sensitive Information in the Nntplib Module <https://docs.securesauce.dev/rules/PRE0011>`_
+ - `Cleartext Transmission of Sensitive Information in the Nntplib Module <https://docs.securesauce.dev/rules/PY011>`_
  - `nntplib — NNTP protocol client <https://docs.python.org/3/library/nntplib.html>`_
  - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
 

--- a/precli/rules/python/stdlib/pickle/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle/pickle_load.py
@@ -49,7 +49,7 @@ to be secure and cannot be used to execute malicious code.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in Pickle Module <https://docs.securesauce.dev/rules/PRE0012>`_
+ - `Deserialization of Untrusted Data in Pickle Module <https://docs.securesauce.dev/rules/PY012>`_
  - `pickle — Python object serialization <https://docs.python.org/3/library/pickle.html>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
  - `json — JSON encoder and decoder <https://docs.python.org/3/library/json.html>`_

--- a/precli/rules/python/stdlib/poplib/pop_cleartext.py
+++ b/precli/rules/python/stdlib/poplib/pop_cleartext.py
@@ -59,7 +59,7 @@ Alternatively, the ``stls`` function can be used to enter a secure session.
 
 .. seealso::
 
- - `Cleartext Transmission of Sensitive Information in the Poplib Module <https://docs.securesauce.dev/rules/PRE0013>`_
+ - `Cleartext Transmission of Sensitive Information in the Poplib Module <https://docs.securesauce.dev/rules/PY013>`_
  - `poplib — POP3 protocol client <https://docs.python.org/3/library/poplib.html>`_
  - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
 

--- a/precli/rules/python/stdlib/shelve/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve/shelve_open.py
@@ -37,7 +37,7 @@ any potential malicious code.
 
 .. seealso::
 
- - `Deserialization of Untrusted Data in the Shelve Module <https://docs.securesauce.dev/rules/PRE0014>`_
+ - `Deserialization of Untrusted Data in the Shelve Module <https://docs.securesauce.dev/rules/PY014>`_
  - `shelve — Python object persistence <https://docs.python.org/3/library/shelve.html>`_
  - `CWE-502: Deserialization of Untrusted Data <https://cwe.mitre.org/data/definitions/502.html>`_
 

--- a/precli/rules/python/stdlib/smtplib/smtp_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib/smtp_cleartext.py
@@ -92,7 +92,7 @@ Alternatively, the ``starttls`` function can be used to enter a secure session.
 
 .. seealso::
 
- - `Cleartext Transmission of Sensitive Information in the Smtplib Module <https://docs.securesauce.dev/rules/PRE0015>`_
+ - `Cleartext Transmission of Sensitive Information in the Smtplib Module <https://docs.securesauce.dev/rules/PY015>`_
  - `smtplib — SMTP protocol client <https://docs.python.org/3/library/smtplib.html>`_
  - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
 

--- a/precli/rules/python/stdlib/ssl/create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl/create_unverified_context.py
@@ -49,7 +49,7 @@ these security risks.
 
 .. seealso::
 
- - `Improper Certificate Validation Using ssl._create_unverified_context <https://docs.securesauce.dev/rules/PRE0016>`_
+ - `Improper Certificate Validation Using ssl._create_unverified_context <https://docs.securesauce.dev/rules/PY016>`_
  - `ssl — TLS/SSL wrapper for socket objects <https://docs.python.org/3/library/ssl.html>`_
  - `CWE-295: Improper Certificate Validation <https://cwe.mitre.org/data/definitions/295.html>`_
 

--- a/precli/rules/python/stdlib/ssl/insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl/insecure_tls_version.py
@@ -66,7 +66,7 @@ protect your application from these security risks.
 
 .. seealso::
 
- - `Inadequate Encryption Strength Using Weak SSL Protocols <https://docs.securesauce.dev/rules/PRE0017>`_
+ - `Inadequate Encryption Strength Using Weak SSL Protocols <https://docs.securesauce.dev/rules/PY017>`_
  - `ssl — TLS/SSL wrapper for socket objects <https://docs.python.org/3/library/ssl.html>`_
  - `CWE-326: Inadequate Encryption Strength <https://cwe.mitre.org/data/definitions/326.html>`_
 

--- a/precli/rules/python/stdlib/telnetlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib/telnetlib_cleartext.py
@@ -101,7 +101,7 @@ These alternatives include:
 
 .. seealso::
 
- - `Cleartext Transmission of Sensitive Information in the Telnetlib Module <https://docs.securesauce.dev/rules/PRE0018>`_
+ - `Cleartext Transmission of Sensitive Information in the Telnetlib Module <https://docs.securesauce.dev/rules/PY018>`_
  - `telnetlib — Telnet client <https://docs.python.org/3/library/telnetlib.html>`_
  - `CWE-319: Cleartext Transmission of Sensitive Information <https://cwe.mitre.org/data/definitions/319.html>`_
  - https://www.paramiko.org/

--- a/precli/rules/python/stdlib/tempfile/mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile/mktemp_race_condition.py
@@ -47,7 +47,7 @@ and cleanup when the file is no longer needed.
 
 .. seealso::
 
- - `Insecure Temporary File in the Tempfile Module <https://docs.securesauce.dev/rules/PRE0019>`_
+ - `Insecure Temporary File in the Tempfile Module <https://docs.securesauce.dev/rules/PY019>`_
  - `tempfile — Generate temporary files and directories <https://docs.python.org/3/library/tempfile.html#tempfile.mktemp>`_
  - `CWE-377: Insecure Temporary File <https://cwe.mitre.org/data/definitions/377.html>`_
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,131 +34,131 @@ precli.parsers =
 
 precli.rules.go =
     # precli/rules/go/golang_org_x_crypto_ssh/ssh_insecure_ignore_hostkey.py
-    PRE1501 = precli.rules.go.golang_org_x_crypto_ssh.ssh_insecure_ignore_hostkey:SshInsecureIgnoreHostKey
+    GO501 = precli.rules.go.golang_org_x_crypto_ssh.ssh_insecure_ignore_hostkey:SshInsecureIgnoreHostKey
 
 precli.rules.python =
     # precli/rules/python/stdlib/assert/assert.py
-    PRE0001 = precli.rules.python.stdlib.assert.assert:Assert
+    PY001 = precli.rules.python.stdlib.assert.assert:Assert
 
     # precli/rules/python/stdlib/crypt/crypt_weak_hash.py
-    PRE0002 = precli.rules.python.stdlib.crypt.crypt_weak_hash:CryptWeakHash
+    PY002 = precli.rules.python.stdlib.crypt.crypt_weak_hash:CryptWeakHash
 
     # precli/rules/python/stdlib/ftplib/ftp_cleartext.py
-    PRE0003 = precli.rules.python.stdlib.ftplib.ftp_cleartext:FtpCleartext
+    PY003 = precli.rules.python.stdlib.ftplib.ftp_cleartext:FtpCleartext
 
     # precli/rules/python/stdlib/hashlib/hashlib_weak_hash.py
-    PRE0004 = precli.rules.python.stdlib.hashlib.hashlib_weak_hash:HashlibWeakHash
+    PY004 = precli.rules.python.stdlib.hashlib.hashlib_weak_hash:HashlibWeakHash
 
     # precli/rules/python/stdlib/hmac/hmac_timing_attack.py
-    PRE0005 = precli.rules.python.stdlib.hmac.hmac_timing_attack:HmacTimingAttack
+    PY005 = precli.rules.python.stdlib.hmac.hmac_timing_attack:HmacTimingAttack
 
     # precli/rules/python/stdlib/hmac/hmac_weak_hash.py
-    PRE0006 = precli.rules.python.stdlib.hmac.hmac_weak_hash:HmacWeakHash
+    PY006 = precli.rules.python.stdlib.hmac.hmac_weak_hash:HmacWeakHash
 
     # precli/rules/python/stdlib/imaplib/imap_cleartext.py
-    PRE0007 = precli.rules.python.stdlib.imaplib.imap_cleartext:ImapCleartext
+    PY007 = precli.rules.python.stdlib.imaplib.imap_cleartext:ImapCleartext
 
     # precli/rules/python/stdlib/json/json_load.py
-    PRE0008 = precli.rules.python.stdlib.json.json_load:JsonLoad
+    PY008 = precli.rules.python.stdlib.json.json_load:JsonLoad
 
     # precli/rules/python/stdlib/logging/insecure_listen_config.py
-    PRE0009 = precli.rules.python.stdlib.logging.insecure_listen_config:InsecureListenConfig
+    PY009 = precli.rules.python.stdlib.logging.insecure_listen_config:InsecureListenConfig
 
     # precli/rules/python/stdlib/marshal/marshal_load.py
-    PRE0010 = precli.rules.python.stdlib.marshal.marshal_load:MarshalLoad
+    PY010 = precli.rules.python.stdlib.marshal.marshal_load:MarshalLoad
 
     # precli/rules/python/stdlib/nntplib/nntp_cleartext.py
-    PRE0011 = precli.rules.python.stdlib.nntplib.nntp_cleartext:NntpCleartext
+    PY011 = precli.rules.python.stdlib.nntplib.nntp_cleartext:NntpCleartext
 
     # precli/rules/python/stdlib/pickle/pickle_load.py
-    PRE0012 = precli.rules.python.stdlib.pickle.pickle_load:PickleLoad
+    PY012 = precli.rules.python.stdlib.pickle.pickle_load:PickleLoad
 
     # precli/rules/python/stdlib/poplib/pop_cleartext.py
-    PRE0013 = precli.rules.python.stdlib.poplib.pop_cleartext:PopCleartext
+    PY013 = precli.rules.python.stdlib.poplib.pop_cleartext:PopCleartext
 
     # precli/rules/python/stdlib/shelve/shelve_open.py
-    PRE0014 = precli.rules.python.stdlib.shelve.shelve_open:ShelveOpen
+    PY014 = precli.rules.python.stdlib.shelve.shelve_open:ShelveOpen
 
     # precli/rules/python/stdlib/smtplib/smtp_cleartext.py
-    PRE0015 = precli.rules.python.stdlib.smtplib.smtp_cleartext:SmtpCleartext
+    PY015 = precli.rules.python.stdlib.smtplib.smtp_cleartext:SmtpCleartext
 
     # precli/rules/python/stdlib/ssl/create_unverified_context.py
-    PRE0016 = precli.rules.python.stdlib.ssl.create_unverified_context:CreateUnverifiedContext
+    PY016 = precli.rules.python.stdlib.ssl.create_unverified_context:CreateUnverifiedContext
 
     # precli/rules/python/stdlib/ssl/insecure_tls_version.py
-    PRE0017 = precli.rules.python.stdlib.ssl.insecure_tls_version:InsecureTlsVersion
+    PY017 = precli.rules.python.stdlib.ssl.insecure_tls_version:InsecureTlsVersion
 
     # precli/rules/python/stdlib/telnetlib/telnetlib_cleartext.py
-    PRE0018 = precli.rules.python.stdlib.telnetlib.telnetlib_cleartext:TelnetlibCleartext
+    PY018 = precli.rules.python.stdlib.telnetlib.telnetlib_cleartext:TelnetlibCleartext
 
     # precli/rules/python/stdlib/tempfile/mktemp_race_condition.py
-    PRE0019 = precli.rules.python.stdlib.tempfile.mktemp_race_condition:MktempRaceCondition
+    PY019 = precli.rules.python.stdlib.tempfile.mktemp_race_condition:MktempRaceCondition
 
     # precli/rules/python/aiohttp/no_certificate_verify.py
-    PRE0501 = precli.rules.python.aiohttp.no_certificate_verify:NoCertificateVerify
+    PY501 = precli.rules.python.aiohttp.no_certificate_verify:NoCertificateVerify
 
     # precli/rules/python/cryptography/cryptography_weak_cipher.py
-    PRE0502 = precli.rules.python.cryptography.cryptography_weak_cipher:CryptographyWeakCipher
+    PY502 = precli.rules.python.cryptography.cryptography_weak_cipher:CryptographyWeakCipher
 
     # precli/rules/python/cryptography/cryptography_weak_cipher_mode.py
-    PRE0503 = precli.rules.python.cryptography.cryptography_weak_cipher_mode:CryptographyWeakCipherMode
+    PY503 = precli.rules.python.cryptography.cryptography_weak_cipher_mode:CryptographyWeakCipherMode
 
     # precli/rules/python/cryptography/cryptography_weak_hash.py
-    PRE0504 = precli.rules.python.cryptography.cryptography_weak_hash:CryptographyWeakHash
+    PY504 = precli.rules.python.cryptography.cryptography_weak_hash:CryptographyWeakHash
 
     # precli/rules/python/cryptography/cryptography_weak_key.py
-    PRE0505 = precli.rules.python.cryptography.cryptography_weak_key:CryptographyWeakKey
+    PY505 = precli.rules.python.cryptography.cryptography_weak_key:CryptographyWeakKey
 
     # precli/rules/python/dill/dill_load.py
-    PRE0506 = precli.rules.python.dill.dill_load:DillLoad
+    PY506 = precli.rules.python.dill.dill_load:DillLoad
 
     # precli/rules/python/httpx/no_certificate_verify.py
-    PRE0507 = precli.rules.python.httpx.no_certificate_verify:NoCertificateVerify
+    PY507 = precli.rules.python.httpx.no_certificate_verify:NoCertificateVerify
 
     # precli/rules/python/jsonpickle/jsonpickle_decode.py
-    PRE0508 = precli.rules.python.jsonpickle.jsonpickle_decode:JsonpickleDecode
+    PY508 = precli.rules.python.jsonpickle.jsonpickle_decode:JsonpickleDecode
 
     # precli/rules/python/M2Crypto/m2crypto_weak_key.py
-    PRE0509 = precli.rules.python.M2Crypto.m2crypto_weak_key:M2CryptoWeakKey
+    PY509 = precli.rules.python.M2Crypto.m2crypto_weak_key:M2CryptoWeakKey
 
     # precli/rules/python/pandas/pandas_read_pickle.py
-    PRE0510 = precli.rules.python.pandas.pandas_read_pickle:PandasReadPickle
+    PY510 = precli.rules.python.pandas.pandas_read_pickle:PandasReadPickle
 
     # precli/rules/python/paramiko/paramiko_no_host_key_verify.py
-    PRE0511 = precli.rules.python.paramiko.paramiko_no_host_key_verify:ParamikoNoHostKeyVerify
+    PY511 = precli.rules.python.paramiko.paramiko_no_host_key_verify:ParamikoNoHostKeyVerify
 
     # precli/rules/python/pycrypto/pycrypto_weak_cipher.py
-    PRE0512 = precli.rules.python.pycrypto.pycrypto_weak_cipher:PycryptoWeakCipher
+    PY512 = precli.rules.python.pycrypto.pycrypto_weak_cipher:PycryptoWeakCipher
 
     # precli/rules/python/pycrypto/pycrypto_weak_hash.py
-    PRE0513 = precli.rules.python.pycrypto.pycrypto_weak_hash:PycryptoWeakHash
+    PY513 = precli.rules.python.pycrypto.pycrypto_weak_hash:PycryptoWeakHash
 
     # precli/rules/python/pycrypto/pycrypto_weak_key.py
-    PRE0514 = precli.rules.python.pycrypto.pycrypto_weak_key:PycryptoWeakKey
+    PY514 = precli.rules.python.pycrypto.pycrypto_weak_key:PycryptoWeakKey
 
     # precli/rules/python/pycryptodomex/pycryptodomex_weak_cipher.py
-    PRE0515 = precli.rules.python.pycryptodomex.pycryptodomex_weak_cipher:PycryptodomexWeakCipher
+    PY515 = precli.rules.python.pycryptodomex.pycryptodomex_weak_cipher:PycryptodomexWeakCipher
 
     # precli/rules/python/pycryptodomex/pycryptodomex_weak_hash.py
-    PRE0516 = precli.rules.python.pycryptodomex.pycryptodomex_weak_hash:PycryptodomexWeakHash
+    PY516 = precli.rules.python.pycryptodomex.pycryptodomex_weak_hash:PycryptodomexWeakHash
 
     # precli/rules/python/pycryptodomex/pycryptodomex_weak_key.py
-    PRE0517 = precli.rules.python.pycryptodomex.pycryptodomex_weak_key:PycryptodomexWeakKey
+    PY517 = precli.rules.python.pycryptodomex.pycryptodomex_weak_key:PycryptodomexWeakKey
 
     # precli/rules/python/pyghmi/pyghmi_cleartext.py
-    PRE0518 = precli.rules.python.pyghmi.pyghmi_cleartext:PyghmiCleartext
+    PY518 = precli.rules.python.pyghmi.pyghmi_cleartext:PyghmiCleartext
 
     # precli/rules/python/pyopenssl/insecure_tls_method.py
-    PRE0519 = precli.rules.python.pyopenssl.insecure_tls_method:InsecureTlsMethod
+    PY519 = precli.rules.python.pyopenssl.insecure_tls_method:InsecureTlsMethod
 
     # precli/rules/python/pyopenssl/pyopenssl_weak_key.py
-    PRE0520 = precli.rules.python.pyopenssl.pyopenssl_weak_key:PyopensslWeakKey
+    PY520 = precli.rules.python.pyopenssl.pyopenssl_weak_key:PyopensslWeakKey
 
     # precli/rules/python/PyYAML/yaml_load.py
-    PRE0521 = precli.rules.python.PyYAML.yaml_load:YamlLoad
+    PY521 = precli.rules.python.PyYAML.yaml_load:YamlLoad
 
     # precli/rules/python/requests/no_certificate_verify.py
-    PRE0522 = precli.rules.python.requests.no_certificate_verify:NoCertificateVerify
+    PY522 = precli.rules.python.requests.no_certificate_verify:NoCertificateVerify
 
 [build_sphinx]
 all_files = 1

--- a/tests/unit/parsers/examples/suppress.py
+++ b/tests/unit/parsers/examples/suppress.py
@@ -1,4 +1,4 @@
 import hashlib
 
 
-hashlib.md5()  # suppress: PRE0004
+hashlib.md5()  # suppress: PY004

--- a/tests/unit/parsers/examples/suppress_lowercase_rule.py
+++ b/tests/unit/parsers/examples/suppress_lowercase_rule.py
@@ -1,4 +1,4 @@
 import hashlib
 
 
-hashlib.md5()  # suppress: pre0004
+hashlib.md5()  # suppress: py004

--- a/tests/unit/parsers/examples/suppress_multiline.py
+++ b/tests/unit/parsers/examples/suppress_multiline.py
@@ -1,4 +1,4 @@
 import hashlib
 
 
-hashlib.md5()  # suppress: PRE0004
+hashlib.md5()  # suppress: PY004

--- a/tests/unit/parsers/examples/suppress_multiple_comments.py
+++ b/tests/unit/parsers/examples/suppress_multiple_comments.py
@@ -1,4 +1,4 @@
 import hashlib
 
 
-hashlib.md5()  # type: ... # suppress: PRE0004 # noqa: E501 ; pylint: disable=line-too-long
+hashlib.md5()  # type: ... # suppress: PY004 # noqa: E501 ; pylint: disable=line-too-long

--- a/tests/unit/parsers/examples/suppress_multiple_rules.py
+++ b/tests/unit/parsers/examples/suppress_multiple_rules.py
@@ -1,4 +1,4 @@
 import hashlib
 
 
-hashlib.md5()  # suppress: PRE0001, PRE0002, PRE0003, PRE0004, PRE0005
+hashlib.md5()  # suppress: PY001, PY002, PY003, PY004, PY005

--- a/tests/unit/parsers/examples/suppress_preceding.py
+++ b/tests/unit/parsers/examples/suppress_preceding.py
@@ -1,5 +1,5 @@
 import hashlib
 
 
-# suppress: PRE0004
+# suppress: PY004
 hashlib.md5()

--- a/tests/unit/parsers/examples/suppress_spaced_rules.py
+++ b/tests/unit/parsers/examples/suppress_spaced_rules.py
@@ -1,4 +1,4 @@
 import hashlib
 
 
-hashlib.md5()  # suppress: PRE0003 PRE0004
+hashlib.md5()  # suppress: PY003 PY004

--- a/tests/unit/parsers/examples/suppress_wrong_rule.py
+++ b/tests/unit/parsers/examples/suppress_wrong_rule.py
@@ -1,4 +1,4 @@
 import hashlib
 
 
-hashlib.md5()  # suppress: PRE0005
+hashlib.md5()  # suppress: PY005

--- a/tests/unit/parsers/test_python.py
+++ b/tests/unit/parsers/test_python.py
@@ -24,7 +24,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -38,7 +38,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -52,7 +52,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -66,7 +66,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -80,7 +80,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -94,7 +94,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(5, result.location.start_line)
         self.assertEqual(5, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -108,7 +108,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)
@@ -122,7 +122,7 @@ class TestCase(testtools.TestCase):
         )
         self.assertEqual(1, len(results))
         result = results[0]
-        self.assertEqual("PRE0004", result.rule_id)
+        self.assertEqual("PY004", result.rule_id)
         self.assertEqual(4, result.location.start_line)
         self.assertEqual(4, result.location.end_line)
         self.assertEqual(0, result.location.start_column)

--- a/tests/unit/rules/python/M2Crypto/test_m2crypto_weak_key.py
+++ b/tests/unit/rules/python/M2Crypto/test_m2crypto_weak_key.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class M2cryptoWeakKeyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0509"
+        self.rule_id = "PY509"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/PyYAML/test_yaml_load.py
+++ b/tests/unit/rules/python/PyYAML/test_yaml_load.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class YamlLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0521"
+        self.rule_id = "PY521"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/aiohttp/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/aiohttp/test_no_certificate_verify.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class NoCertificateVerifyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0501"
+        self.rule_id = "PY501"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/cryptography/test_cryptography_weak_cipher.py
+++ b/tests/unit/rules/python/cryptography/test_cryptography_weak_cipher.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class CryptographyWeakCipherTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0502"
+        self.rule_id = "PY502"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/cryptography/test_cryptography_weak_cipher_mode.py
+++ b/tests/unit/rules/python/cryptography/test_cryptography_weak_cipher_mode.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class CryptographyWeakCipherModeTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0503"
+        self.rule_id = "PY503"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/cryptography/test_cryptography_weak_hash.py
+++ b/tests/unit/rules/python/cryptography/test_cryptography_weak_hash.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class CryptographyWeakHashTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0504"
+        self.rule_id = "PY504"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/cryptography/test_cryptography_weak_key.py
+++ b/tests/unit/rules/python/cryptography/test_cryptography_weak_key.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class CryptographyWeakKeyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0505"
+        self.rule_id = "PY505"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/dill/test_dill_load.py
+++ b/tests/unit/rules/python/dill/test_dill_load.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class DillLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0506"
+        self.rule_id = "PY506"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/httpx/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/httpx/test_no_certificate_verify.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class NoCertificateVerifyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0507"
+        self.rule_id = "PY507"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/jsonpickle/test_jsonpickle_decode.py
+++ b/tests/unit/rules/python/jsonpickle/test_jsonpickle_decode.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class JsonPickleDecodeTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0508"
+        self.rule_id = "PY508"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pandas/test_pandas_read_pickle.py
+++ b/tests/unit/rules/python/pandas/test_pandas_read_pickle.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PandasReadPickleTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0510"
+        self.rule_id = "PY510"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/paramiko/test_host_key_policy.py
+++ b/tests/unit/rules/python/paramiko/test_host_key_policy.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class HostKeyPolicyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0511"
+        self.rule_id = "PY511"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pycrypto/test_pycrypto_weak_cipher.py
+++ b/tests/unit/rules/python/pycrypto/test_pycrypto_weak_cipher.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PycryptoWeakCipherTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0512"
+        self.rule_id = "PY512"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pycrypto/test_pycrypto_weak_hash.py
+++ b/tests/unit/rules/python/pycrypto/test_pycrypto_weak_hash.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PycryptoWeakCipherTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0513"
+        self.rule_id = "PY513"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pycrypto/test_pycrypto_weak_key.py
+++ b/tests/unit/rules/python/pycrypto/test_pycrypto_weak_key.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PycryptoWeakKeyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0514"
+        self.rule_id = "PY514"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pycryptodomex/test_pycryptodomex_weak_cipher.py
+++ b/tests/unit/rules/python/pycryptodomex/test_pycryptodomex_weak_cipher.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PycryptodomexWeakCipherTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0515"
+        self.rule_id = "PY515"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pycryptodomex/test_pycryptodomex_weak_hash.py
+++ b/tests/unit/rules/python/pycryptodomex/test_pycryptodomex_weak_hash.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PycryptodomexWeakCipherTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0516"
+        self.rule_id = "PY516"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pycryptodomex/test_pycryptodomex_weak_key.py
+++ b/tests/unit/rules/python/pycryptodomex/test_pycryptodomex_weak_key.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PycryptodomexWeakKeyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0517"
+        self.rule_id = "PY517"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pyghmi/test_pyghmi_cleartext.py
+++ b/tests/unit/rules/python/pyghmi/test_pyghmi_cleartext.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PyghmiCleartextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0518"
+        self.rule_id = "PY518"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pyopenssl/test_pyopenssl_weak_key.py
+++ b/tests/unit/rules/python/pyopenssl/test_pyopenssl_weak_key.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class PyopensslWeakKeyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0520"
+        self.rule_id = "PY520"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/pyopenssl/test_ssl_context.py
+++ b/tests/unit/rules/python/pyopenssl/test_ssl_context.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class SslContextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0519"
+        self.rule_id = "PY519"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/requests/test_no_certificate_verify.py
+++ b/tests/unit/rules/python/requests/test_no_certificate_verify.py
@@ -12,7 +12,7 @@ from tests.unit.rules.python import test_case
 class NoCertificateVerifyTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0522"
+        self.rule_id = "PY522"
         self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",

--- a/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class CryptWeakHashTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0002"
+        self.rule_id = "PY002"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftp_cleartext.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftp_cleartext.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class FtpCleartextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0003"
+        self.rule_id = "PY003"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class HashlibWeakHashTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0004"
+        self.rule_id = "PY004"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class HmacTimingAttackTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0005"
+        self.rule_id = "PY005"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class HmacWeakHashTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0006"
+        self.rule_id = "PY006"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/imaplib/test_imap_cleartext.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imap_cleartext.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class ImapCleartextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0007"
+        self.rule_id = "PY007"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/json/test_json_load.py
+++ b/tests/unit/rules/python/stdlib/json/test_json_load.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class JsonLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0008"
+        self.rule_id = "PY008"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/logging/test_insecure_listen_config.py
+++ b/tests/unit/rules/python/stdlib/logging/test_insecure_listen_config.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class InsecureListenConfigTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0009"
+        self.rule_id = "PY009"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
+++ b/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class MarshalLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0010"
+        self.rule_id = "PY010"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntp_cleartext.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntp_cleartext.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class NntpCleartextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0011"
+        self.rule_id = "PY011"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
+++ b/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class PickleLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0012"
+        self.rule_id = "PY012"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/poplib/test_pop_cleartext.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_pop_cleartext.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class PopCleartextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0013"
+        self.rule_id = "PY013"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
+++ b/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class ShelveOpenTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0014"
+        self.rule_id = "PY014"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtp_cleartext.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtp_cleartext.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class SmtpCleartextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0015"
+        self.rule_id = "PY015"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_get_server_certificate.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_get_server_certificate.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class GetServerCertificateTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0017"
+        self.rule_id = "PY017"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class SslSocketTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0017"
+        self.rule_id = "PY017"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class SslCreateContextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0016"
+        self.rule_id = "PY016"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_wrap_socket.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_wrap_socket.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class WrapSocketTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0017"
+        self.rule_id = "PY017"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class TelnetlibCleartextTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0018"
+        self.rule_id = "PY018"
         self.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/tempfile/test_mktemp_race_condition.py
+++ b/tests/unit/rules/python/stdlib/tempfile/test_mktemp_race_condition.py
@@ -11,7 +11,7 @@ from tests.unit.rules.python import test_case
 class MktempRaceConditionTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
-        self.rule_id = "PRE0019"
+        self.rule_id = "PY019"
         self.base_path = os.path.join(
             "tests",
             "unit",


### PR DESCRIPTION
Switch to language specific IDs where the prefix identifies the language followed by a three digit number.

For example:

PY503 = Python rule 503
GO103 = Go rule 103