### PR TITLE
Properly check key size or bits type as int

### DIFF
--- a/precli/rules/go/stdlib/crypto/weak_key.py
+++ b/precli/rules/go/stdlib/crypto/weak_key.py
@@ -138,7 +138,7 @@ class WeakKey(Rule):
             argument = call.get_argument(position=1)
             bits = argument.value
 
-            if bits < 2048:
+            if isinstance(bits, int) and bits < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=argument.node),

--- a/precli/rules/python/M2Crypto/m2crypto_weak_key.py
+++ b/precli/rules/python/M2Crypto/m2crypto_weak_key.py
@@ -122,7 +122,7 @@ class M2CryptoWeakKey(Rule):
             arg0 = call.get_argument(position=0, name="bits")
             bits = arg0.value
 
-            if bits < 2048:
+            if isinstance(bits, int) and bits < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=arg0.node),
@@ -144,7 +144,7 @@ class M2CryptoWeakKey(Rule):
             arg0 = call.get_argument(position=0, name="bits")
             bits = arg0.value
 
-            if bits < 2048:
+            if isinstance(bits, int) and bits < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=arg0.node),

--- a/precli/rules/python/cryptography/cryptography_weak_key.py
+++ b/precli/rules/python/cryptography/cryptography_weak_key.py
@@ -148,7 +148,7 @@ class CryptographyWeakKey(Rule):
             argument = call.get_argument(position=0, name="key_size")
             key_size = argument.value
 
-            if key_size < 2048:
+            if isinstance(key_size, int) and key_size < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=argument.node),
@@ -173,7 +173,7 @@ class CryptographyWeakKey(Rule):
             argument = call.get_argument(position=1, name="key_size")
             key_size = argument.value
 
-            if key_size < 2048:
+            if isinstance(key_size, int) and key_size < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=argument.node),

--- a/precli/rules/python/pycrypto/pycrypto_weak_key.py
+++ b/precli/rules/python/pycrypto/pycrypto_weak_key.py
@@ -106,7 +106,7 @@ class PycryptoWeakKey(Rule):
             argument = call.get_argument(position=0, name="bits")
             bits = argument.value
 
-            if bits < 2048:
+            if isinstance(bits, int) and bits < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=argument.node),
@@ -128,7 +128,7 @@ class PycryptoWeakKey(Rule):
             argument = call.get_argument(position=0, name="bits")
             bits = argument.value
 
-            if bits < 2048:
+            if isinstance(bits, int) and bits < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=argument.node),

--- a/precli/rules/python/pycryptodomex/pycryptodomex_weak_key.py
+++ b/precli/rules/python/pycryptodomex/pycryptodomex_weak_key.py
@@ -106,7 +106,7 @@ class PycryptodomexWeakKey(Rule):
             argument = call.get_argument(position=0, name="bits")
             bits = argument.value
 
-            if bits < 2048:
+            if isinstance(bits, int) and bits < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=argument.node),
@@ -128,7 +128,7 @@ class PycryptodomexWeakKey(Rule):
             argument = call.get_argument(position=0, name="bits")
             bits = argument.value
 
-            if bits < 2048:
+            if isinstance(bits, int) and bits < 2048:
                 fixes = Rule.get_fixes(
                     context=context,
                     deleted_location=Location(node=argument.node),

--- a/tests/unit/rules/go/stdlib/crypto/examples/weak_key_rsa_bits_as_var.go
+++ b/tests/unit/rules/go/stdlib/crypto/examples/weak_key_rsa_bits_as_var.go
@@ -1,0 +1,43 @@
+// level: NONE
+package main
+
+import (
+    "crypto/rand"
+    "crypto/rsa"
+    "crypto/x509"
+    "encoding/pem"
+    "log"
+)
+
+func GeneratePrivateKey(bits int) (*rsa.PrivateKey) {
+    privateKey, err := rsa.GenerateKey(rand.Reader, bits)
+    if err != nil {
+        return nil, nil
+    }
+    return privateKey
+}
+
+func main() {
+    // Generate the RSA key
+    privateKey, err := GeneratePrivateKey(2048)
+    if err != nil {
+        log.Fatalf("Failed to generate key: %v", err)
+    }
+
+    // Extract the public key from the private key
+    publicKey := &privateKey.PublicKey
+
+    // Encode the public key to PEM format
+    publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+    if err != nil {
+        log.Fatalf("Failed to marshal public key: %v", err)
+    }
+
+    publicKeyPEM := pem.EncodeToMemory(&pem.Block{
+        Type:  "RSA PUBLIC KEY",
+        Bytes: publicKeyBytes,
+    })
+
+    // Print the public key
+    log.Println(string(publicKeyPEM))
+}

--- a/tests/unit/rules/go/stdlib/crypto/test_weak_key.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_weak_key.py
@@ -44,6 +44,7 @@ class CryptoWeakKeyTests(test_case.TestCase):
             "weak_key_rsa_1024.go",
             "weak_key_rsa_2048.go",
             "weak_key_rsa_4096.go",
+            "weak_key_rsa_bits_as_var.go",
         ]
     )
     def test(self, filename):


### PR DESCRIPTION
The key_size or bits as passed to key generation functions must of type int.

Previous code was raising an exception when the key size was a string as a result of being a variable of a function argument. Since variable values are not known when passed through functions, it defaulted to a string of the name of the function arg.