### PR TITLE
Fix parsing of int values

### DIFF
--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -159,9 +159,15 @@ class Go(Parser):
                     value = ast.literal_eval(nodetext)
                 case "int_literal":
                     # TODO: hex, octal, binary
-                    value = ast.literal_eval(nodetext)
+                    try:
+                        value = int(nodetext)
+                    except ValueError:
+                        value = nodetext
                 case "float_literal":
-                    value = float(nodetext)
+                    try:
+                        value = float(nodetext)
+                    except ValueError:
+                        value = nodetext
                 case "true":
                     value = True
                 case "false":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cwe
 rich # MIT
-tree_sitter
-tree-sitter-languages
+tree_sitter>=0.20.4
+tree-sitter-languages>=1.9.1


### PR DESCRIPTION
Don't use ast.literal_eval for Go code since ast is Python specific.

Also bump the tree-sitter requirements.