### PR TITLE
Automatically ignore files matching .gitignore patterns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cwe
 rich # MIT
 tree_sitter>=0.20.4
 tree-sitter-languages>=1.9.1
+ignorelib


### PR DESCRIPTION
This change will honor the config set by .gitignore if analyzing a Git project or any global ignore settings set by the user.

This speeds up the scanning by skipping many files that are possibly included as a result of a build, tox, etc.