### PR TITLE
Better handling of SyntaxErrors

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -218,7 +218,11 @@ def parse_file(
     except KeyboardInterrupt:
         sys.exit(2)
     except SyntaxError as e:
-        print(e)
+        print(
+            f"Syntax error while parsing file. ({e.filename}, "
+            f"line {e.lineno})",
+            file=sys.stderr,
+        )
         files_skipped.append((fname, e))
         new_file_list.remove(fname)
     except Exception as e:

--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -144,15 +144,19 @@ class Parser(ABC):
         # TODO: add the justification to the suppression
 
     def visit_ERROR(self, nodes: list[Node]):
+        err_node = self.first_match(self.context["node"], "ERROR")
+        if err_node is None:
+            err_node = self.context["node"]
+
         raise SyntaxError(
             "Syntax error while parsing file.",
             (
                 self.context["file_name"],
-                self.context["node"].start_point[0] + 1,
-                self.context["node"].start_point[1] + 1,
-                self.context["node"].text.decode(),
-                self.context["node"].end_point[0] + 1,
-                self.context["node"].end_point[1] + 1,
+                err_node.start_point[0] + 1,
+                err_node.start_point[1] + 1,
+                err_node.text.decode(errors="ignore"),
+                err_node.end_point[0] + 1,
+                err_node.end_point[1] + 1,
             ),
         )
 


### PR DESCRIPTION
Sometimes need to find the ERROR node to properly print the line number.

Also adjusted the printing of the error to go to stderr with full file name.