### PR TITLE
Handle SyntaxWarnings appearing in output

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -167,8 +167,6 @@ def run_checks(parsers: dict, file_list: list[str]) -> list[Result]:
     results = []
     lines = 0
     for fname in files:
-        LOG.debug("working on file : %s", fname)
-
         try:
             if fname == "-":
                 open_fd = os.fdopen(sys.stdin.fileno(), "rb", 0)
@@ -213,6 +211,7 @@ def parse_file(
         data = fdata.read()
         file_extension = pathlib.Path(fname).suffix
         if file_extension in parsers.keys():
+            LOG.debug("working on file : %s", fname)
             parser = parsers[file_extension]
             return parser.parse(fname, data)
     except KeyboardInterrupt:

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -1,5 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
-import ast
+# Copyright 2024 Secure Saurce LLC
 import builtins
 import re
 from collections import namedtuple
@@ -341,19 +340,37 @@ class Python(Parser):
                         keyword: self.literal_value(kwvalue, default=kwvalue)
                     }
                 case "dictionary":
-                    value = ast.literal_eval(nodetext)
+                    # TODO: don't use ast.literal_eval
+                    # value = ast.literal_eval(nodetext)
+                    pass
                 case "list":
-                    value = ast.literal_eval(nodetext)
+                    # TODO: don't use ast.literal_eval
+                    # value = ast.literal_eval(nodetext)
+                    pass
                 case "tuple":
-                    value = ast.literal_eval(nodetext)
+                    # TODO: don't use ast.literal_eval
+                    # value = ast.literal_eval(nodetext)
+                    pass
                 case "string":
-                    # TODO: bytes and f-type strings are messed up
-                    value = ast.literal_eval(nodetext)
+                    # TODO: handle byte strings (b"abc")
+                    # TODO: handle f-strings? (f"{a}")
+                    if nodetext.startswith('"""') or nodetext.startswith(
+                        "'''"
+                    ):
+                        value = nodetext[3:-3]
+                    elif nodetext.startswith('"') or nodetext.startswith("'"):
+                        value = nodetext[1:-1]
                 case "integer":
                     # TODO: hex, octal, binary
-                    value = ast.literal_eval(nodetext)
+                    try:
+                        value = int(nodetext)
+                    except ValueError:
+                        value = nodetext
                 case "float":
-                    value = float(nodetext)
+                    try:
+                        value = float(nodetext)
+                    except ValueError:
+                        value = nodetext
                 case "true":
                     value = True
                 case "false":


### PR DESCRIPTION
Because some of the code is using ast.literal_eval(), strings and other types are casuing SyntaxWarnings being emitted by the ast module.

Ideally ast.literal_eval() shouldn't be used at all and that's what this change is doing.