### PR TITLE
Fix a couple errors found scanning thousands of files

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -225,13 +225,12 @@ def parse_file(
         files_skipped.append((fname, e))
         new_file_list.remove(fname)
     except Exception as e:
-        print(traceback.format_exc())
         LOG.error(
             f"Exception occurred when executing rules against "
             f'{fname}. Run "precli --debug {fname}" to see the full '
             f"traceback."
         )
-        # self.skipped.append((fname, "exception while scanning file"))
+        files_skipped.append((fname, "Exception while parsing file"))
         new_file_list.remove(fname)
         LOG.debug(f"  Exception string: {e}")
         LOG.debug(f"  Exception traceback: {traceback.format_exc()}")

--- a/precli/rules/python/stdlib/tempfile/mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile/mktemp_race_condition.py
@@ -88,7 +88,8 @@ class MktempRaceCondition(Rule):
             file_arg = call.get_argument(position=0, name="file")
 
             if (
-                file_arg.node.type == "identifier"
+                file_arg.node is not None
+                and file_arg.node.type == "identifier"
                 and file_arg.value == "tempfile.mktemp"
             ):
                 """


### PR DESCRIPTION
* The mktemp_race_condition rule needs to carefully check whether arguments are None or not.
* Some files can trigger a recursion max depth being reached. If found, it should discontinue parsing of that file, mark as skipped, and properly log.