### PR TITLE
Only trigger unit tests on pull requests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   format:


### PR DESCRIPTION
Only run unit tests on the creation of a pull requests and not also a push event.