### PR TITLE
Allow install of thirdparty rules via an extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,10 @@ classifier =
 project_urls =
     Release notes = https://github.com/securesauce/precli/releases
 
+[options.extras_require]
+thirdparty =
+    precli-thirdparty @ git+https://github.com/securesauce/precli-thirdparty@main
+
 [entry_points]
 console_scripts =
     precli = precli.cli.main:main


### PR DESCRIPTION
A new extra permits installation of the third-party rules via the private GitHub repo.

To install:
pip install precli[thirdparty]

Note: the thirdparty rules are not public and are maintained privately.