### PR TITLE
Remove reference to direct dependencies

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Publish distribution to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,10 +18,6 @@ classifier =
 project_urls =
     Release notes = https://github.com/securesauce/precli/releases
 
-[options.extras_require]
-thirdparty =
-    precli-thirdparty @ git+https://github.com/securesauce/precli-thirdparty@main
-
 [entry_points]
 console_scripts =
     precli = precli.cli.main:main


### PR DESCRIPTION
PyPI doesn't support direct dependencies so we can't use it as an extra.