### PR TITLE
Only use relative paths with function is_ignored()

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -135,18 +135,16 @@ def discover_files(targets: list[str], recursive: bool):
             if recursive is True:
                 for root, _, files in gitignore_mgr.walk():
                     for file in files:
-                        path = os.path.join(root, file)
-                        if not preignore_mgr.is_ignored(path):
-                            file_list.append(path)
+                        if not preignore_mgr.is_ignored(file):
+                            file_list.append(os.path.join(root, file))
             else:
                 files = os.listdir(path=fname)
                 for file in files:
-                    path = os.path.join(fname, file)
                     if not (
-                        gitignore_mgr.is_ignored(path)
-                        or preignore_mgr.is_ignored(path)
+                        gitignore_mgr.is_ignored(file)
+                        or preignore_mgr.is_ignored(file)
                     ):
-                        file_list.append(path)
+                        file_list.append(os.path.join(fname, file))
         else:
             file_list.append(fname)
     return file_list


### PR DESCRIPTION
The is_ignored() function expects paths relative to the starting path given when initializing the class. It raises a traceback if given an absolute path.

```
Traceback (most recent call last):
  File "/Users/ericwb/workspace/precli/.tox/py312/bin/precli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/ericwb/workspace/precli/precli/cli/main.py", line 301, in main
    file_list = discover_files(args.targets, args.recursive)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ericwb/workspace/precli/precli/cli/main.py", line 177, in discover_files
    if not preignore_mgr.is_ignored(path):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ericwb/workspace/precli/.tox/py312/lib/python3.12/site-packages/ignorelib.py", line 401, in is_ignored
    matches = list(self._find_matching(path))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ericwb/workspace/precli/.tox/py312/lib/python3.12/site-packages/ignorelib.py", line 368, in _find_matching
    raise ValueError('%s is an absolute path' % path)
ValueError: /var/folders/m3/_cy_9dfx73107r3w_zhnsd700000gn/T/tmp_100ms8v/securesauce-precli-2ef4388/LICENSE is an absolute path
```
