### PR TITLE
Support passing a file via standard input

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -3,7 +3,6 @@ import argparse
 import io
 import logging
 import os
-import pathlib
 import sys
 import tempfile
 import traceback
@@ -13,7 +12,9 @@ from urllib.parse import urlparse
 
 import requests
 from ignorelib import IgnoreFilterManager
+from pygments import lexers
 from rich import progress
+from rich import syntax
 
 import precli
 from precli.core import loader
@@ -283,10 +284,15 @@ def parse_file(
 ) -> list[Result]:
     try:
         data = fdata.read()
-        file_extension = pathlib.Path(fname).suffix
-        if file_extension in parsers.keys():
+
+        lexer_name = syntax.Syntax.guess_lexer(fname, data)
+        if lexer_name == "default":
+            lexer = lexers.guess_lexer(data)
+            lexer_name = lexer.aliases[0] if lexer.aliases else lexer.name
+
+        if lexer_name in parsers.keys():
             LOG.debug("working on file : %s", fname)
-            parser = parsers[file_extension]
+            parser = parsers[lexer_name]
             return parser.parse(fname, data)
     except KeyboardInterrupt:
         sys.exit(2)

--- a/precli/core/linecache.py
+++ b/precli/core/linecache.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Secure Saurce LLC
+import linecache
+
+
+class LineCache:
+    def __init__(self, file_name: str, file_contents: str):
+        """
+        Initialize the cache with the given file contents.
+
+        :param file_name: Name of the file (can be <stdin>.
+        :param file_contents: A string containing the entire file data.
+        """
+        self._file_name = file_name
+        if self._file_name == "<stdin>":
+            self._lines = file_contents.splitlines(keepends=True)
+
+    def getline(self, lineno: int) -> str:
+        """
+        Return the line from the file contents at the given line number.
+
+        :param lineno: The line number to fetch, 1-based.
+        :return: The line at the specified line number, or an empty string if
+                 the line does not exist.
+        """
+        if self._file_name != "<stdin>":
+            return linecache.getline(self._file_name, lineno)
+        else:
+            if 0 < lineno <= len(self._lines):
+                return self._lines[lineno - 1]
+            return ""

--- a/precli/core/loader.py
+++ b/precli/core/loader.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 from importlib.metadata import entry_points
 
 
@@ -8,6 +8,6 @@ def load_parsers(enabled: list[str], disabled: list[str]) -> dict:
     discovered_plugins = entry_points(group="precli.parsers")
     for plugin in discovered_plugins:
         parser = plugin.load()(enabled, disabled)
-        parsers[parser.file_extension()] = parser
+        parsers[parser.lexer] = parser
 
     return parsers

--- a/precli/core/location.py
+++ b/precli/core/location.py
@@ -12,6 +12,7 @@ class Location:
         end_line: int = -1,
         start_column: int = 1,
         end_column: int = -1,
+        snippet: str = None,
     ):
         self._file_name = file_name
         self._url = url
@@ -26,6 +27,7 @@ class Location:
             self._start_column = start_column
             # TODO: default to end of line
             self._end_column = end_column
+        self._snippet = snippet
 
     @property
     def file_name(self) -> str:
@@ -96,3 +98,22 @@ class Location:
         :rtype: int
         """
         return self._end_column
+
+    @property
+    def snippet(self) -> str:
+        """
+        Snippet of context of the code.
+
+        :return: snippet of context
+        :rtype: str
+        """
+        return self._snippet
+
+    @snippet.setter
+    def snippet(self, snippet):
+        """
+        Set the code context snippet.
+
+        :param str snippet: context snippet
+        """
+        self._snippet = snippet

--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -48,6 +48,26 @@ class Result:
         return self._rule_id
 
     @property
+    def source_language(self) -> str:
+        """
+        The source language.
+
+        :return: language of the source code
+        :rtype: str
+        """
+        match (self._rule_id[:2]):
+            case "GO":
+                return "go"
+            case "JV":
+                return "java"
+            case "PY":
+                return "python"
+            case "RB":
+                return "ruby"
+            case "RS":
+                return "rust"
+
+    @property
     def location(self) -> Location:
         """
         The location of the issue.

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 import ast
 import re
 
@@ -17,9 +17,6 @@ class Go(Parser):
             r"// suppress:? (?P<rules>[^#]+)?#?"
         )
         self.SUPPRESSED_RULES = re.compile(r"(?:(GO\d\d\d|[a-z_]+),?)+")
-
-    def file_extension(self) -> str:
-        return ".go"
 
     def visit_source_file(self, nodes: list[Node]):
         self.suppressions = {}

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -1,10 +1,7 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 from precli.parsers import Parser
 
 
 class Java(Parser):
     def __init__(self, enabled: list = None, disabled: list = None):
         super().__init__("java", enabled, disabled)
-
-    def file_extension(self) -> str:
-        return ".java"

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -21,9 +21,6 @@ class Python(Parser):
         self.SUPPRESS_COMMENT = re.compile(r"# suppress:? (?P<rules>[^#]+)?#?")
         self.SUPPRESSED_RULES = re.compile(r"(?:(PY\d\d\d|[a-z_]+),?)+")
 
-    def file_extension(self) -> str:
-        return ".py"
-
     def visit_module(self, nodes: list[Node]):
         self.suppressions = {}
         self.current_symtab = SymbolTable("<module>")

--- a/precli/renderers/detailed.py
+++ b/precli/renderers/detailed.py
@@ -39,7 +39,7 @@ class Detailed(Renderer):
             if result.location.url is not None:
                 file_name = result.location.url
             else:
-                result.location.file_name
+                file_name = result.location.file_name
 
             self.console.print(
                 f"{emoji} {result.level.name.title()} on line "
@@ -56,12 +56,16 @@ class Detailed(Renderer):
                 f"{result.message}",
                 style=style,
             )
-            code = syntax.Syntax.from_path(
-                result.location.file_name,
+
+            line_offset = result.location.start_line - 2
+            code = syntax.Syntax(
+                result.location.snippet,
+                result.source_language,
                 line_numbers=True,
+                start_line=line_offset + 1,
                 line_range=(
-                    result.location.start_line - 1,
-                    result.location.end_line + 1,
+                    result.location.start_line - line_offset - 1,
+                    result.location.end_line - line_offset + 1,
                 ),
                 highlight_lines=(
                     result.location.start_line,
@@ -123,7 +127,7 @@ class Detailed(Renderer):
 
                 code = syntax.Syntax(
                     code,
-                    "python",
+                    result.source_language,
                     line_numbers=True,
                     line_range=(start_line - before, end_line + after),
                     highlight_lines=highlight_lines,

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -22,7 +22,7 @@ class Json(Renderer):
             if result.location.url is not None:
                 file_name = result.location.url
             else:
-                result.location.file_name
+                file_name = result.location.file_name
 
             results_json["results"].append(
                 {

--- a/precli/renderers/plain.py
+++ b/precli/renderers/plain.py
@@ -1,6 +1,4 @@
 # Copyright 2024 Secure Saurce LLC
-import linecache
-
 from rich import console
 from rich.padding import Padding
 
@@ -40,17 +38,15 @@ class Plain(Renderer):
             if result.location.url is not None:
                 file_name = result.location.url
             else:
-                result.location.file_name
+                file_name = result.location.file_name
 
             # TODO(ericwb): replace hardcoded <module> with actual scope
             self.console.print(
                 f'  File "{file_name}", line '
                 f"{result.location.start_line}, in <module>",
             )
-            code_line = linecache.getline(
-                filename=result.location.file_name,
-                lineno=result.location.start_line,
-            )
+            code_lines = result.location.snippet.splitlines(keepends=True)
+            code_line = code_lines[1] if len(code_lines) > 1 else code_lines[0]
             underline_width = (
                 result.location.end_column - result.location.start_column
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cwe
+Pygments
 rich # MIT
 tree_sitter>=0.20.4
 tree-sitter-languages>=1.9.1


### PR DESCRIPTION
* If the argument "-" is passed, that tells precli to read the file from stdin.
* Use the existing dependency of rich and Pygments to guess the lexer since there is no file name in this case.
* This change also gets rid of the file extension logic of the parsers and just keeps a lexer name instead.

Closes #214