### PR TITLE
Make the artifact argument of a Result to be lazy set

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -77,7 +77,7 @@ class Parser(ABC):
         :rtype: list
         """
         self.results = []
-        self.context = {"artifact": artifact}
+        self.context = {}
         if artifact.contents is None:
             with open(artifact.file_name, "rb") as fdata:
                 artifact.contents = fdata.read()
@@ -85,6 +85,8 @@ class Parser(ABC):
         self.visit([tree.root_node])
 
         for result in self.results:
+            result.artifact = artifact
+
             suppression = self.suppressions.get(result.location.start_line)
             if suppression and result.rule_id in suppression.rules:
                 result.suppression = suppression

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -158,7 +158,6 @@ class WeakCipher(Rule):
             )
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 level=Level.ERROR,
                 message=self.message.format(call.name),

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -106,7 +106,6 @@ class WeakHash(Rule):
             )
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 level=Level.ERROR,
                 message=self.message.format(call.name_qualified),
@@ -124,7 +123,6 @@ class WeakHash(Rule):
             )
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 level=Level.ERROR,
                 message=self.message.format(call.name_qualified),

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -125,7 +125,6 @@ class WeakKey(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=argument.identifier_node),
                     level=Level.ERROR,
                     message=self.message.format("DSA", 2048),
@@ -145,7 +144,6 @@ class WeakKey(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=argument.node),
                     level=Level.ERROR if bits <= 1024 else Level.WARNING,
                     message=self.message.format("RSA", 2048),

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 r"""
 =======================================
 Reversible One Way Hash in Crypt Module
@@ -134,7 +134,6 @@ class CryptWeakHash(Rule):
             if isinstance(name, str) and name in WEAK_CRYPT_HASHES:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     message=self.message.format(name),
                 )
@@ -144,7 +143,6 @@ class CryptWeakHash(Rule):
             if isinstance(name, str) and name in WEAK_CRYPT_HASHES:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     message=self.message.format(name),
                 )

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -154,7 +154,6 @@ class FtpCleartext(Rule):
             if call.get_argument(position=2, name="passwd").value is not None:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     level=Level.ERROR,
                     message=f"The '{call.name_qualified}' module will "
@@ -164,7 +163,6 @@ class FtpCleartext(Rule):
             else:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     message=self.message.format(call.name_qualified),
                     fixes=fixes,
@@ -176,7 +174,6 @@ class FtpCleartext(Rule):
             if call.get_argument(position=1, name="passwd").value is not None:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.identifier_node),
                     level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -137,7 +137,6 @@ class HashlibWeakHash(Rule):
             if used_for_security is True:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     level=Level.ERROR,
                     message=self.message.format(call.name_qualified),
@@ -157,7 +156,6 @@ class HashlibWeakHash(Rule):
             if isinstance(hash_name, str) and hash_name.lower() in WEAK_HASHES:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     level=Level.ERROR,
                     message=self.message.format(hash_name),
@@ -176,7 +174,6 @@ class HashlibWeakHash(Rule):
                 if used_for_security is True:
                     return Result(
                         rule_id=self.id,
-                        artifact=context["artifact"],
                         location=Location(node=call.function_node),
                         level=Level.ERROR,
                         message=self.message.format(name),

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -134,7 +134,6 @@ class HmacTimingAttack(Rule):
 
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=comparison.operator_node),
                 level=Level.ERROR,
                 fixes=fixes,

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -123,7 +123,6 @@ class HmacWeakHash(Rule):
             ) or digestmod in HASHLIB_WEAK_HASHES:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=argument.node),
                     level=Level.ERROR,
                     message=self.message.format(digestmod),
@@ -140,7 +139,6 @@ class HmacWeakHash(Rule):
             ) or digest in HASHLIB_WEAK_HASHES:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=argument.node),
                     level=Level.ERROR,
                     message=self.message.format(digest),

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 r"""
 =====================================================================
 Cleartext Transmission of Sensitive Information in the Imaplib Module
@@ -116,7 +116,6 @@ class ImapCleartext(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.identifier_node),
                     level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -109,7 +109,6 @@ class JsonLoad(Rule):
             """
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 message=self.message.format(call.name_qualified),
             )

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -83,7 +83,6 @@ class InsecureListenConfig(Rule):
             if call.get_argument(position=1, name="verify").value is None:
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     message=self.message.format(call.name_qualified),
                 )

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -78,7 +78,6 @@ class MarshalLoad(Rule):
             """
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 message=self.message.format(call.name_qualified),
             )

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -97,7 +97,6 @@ class NntpCleartext(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.identifier_node),
                     level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -90,7 +90,6 @@ class PickleLoad(Rule):
         ]:
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 message=self.message.format(call.name_qualified),
             )

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -113,7 +113,6 @@ class PopCleartext(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.identifier_node),
                     level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -72,7 +72,6 @@ class ShelveOpen(Rule):
         if call.name_qualified in ["shelve.open", "shelve.DbfilenameShelf"]:
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 message=self.message.format(call.name_qualified),
             )

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -144,7 +144,6 @@ class SmtpCleartext(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.identifier_node),
                     level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -110,7 +110,6 @@ class SslContextWeakKey(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=arg.node),
                     level=Level.ERROR if key_size < 160 else Level.WARNING,
                     message=self.message.format("EC", 224),

--- a/precli/rules/python/stdlib/ssl_create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl_create_unverified_context.py
@@ -116,7 +116,6 @@ class CreateUnverifiedContext(Rule):
             )
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 message=self.message.format(call.name_qualified),
                 fixes=fixes,

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 r"""
 =======================================================
 Inadequate Encryption Strength Using Weak SSL Protocols
@@ -124,7 +124,6 @@ class InsecureTlsVersion(Rule):
                 )
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=argument.identifier_node),
                     level=Level.ERROR,
                     message=self.message.format(version),
@@ -165,7 +164,6 @@ class InsecureTlsVersion(Rule):
                 )
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=argument.identifier_node),
                     level=Level.ERROR,
                     message=self.message.format(version),
@@ -193,7 +191,6 @@ class InsecureTlsVersion(Rule):
                 )
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=argument.identifier_node),
                     level=Level.ERROR,
                     message=self.message.format(protocol),

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -138,7 +138,6 @@ class TelnetlibCleartext(Rule):
         if call.name_qualified in ["telnetlib.Telnet"]:
             return Result(
                 rule_id=self.id,
-                artifact=context["artifact"],
                 location=Location(node=call.function_node),
                 level=Level.ERROR,
                 message=self.message.format(call.name_qualified),

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 r"""
 ==============================================
 Insecure Temporary File in the Tempfile Module
@@ -178,7 +178,6 @@ class MktempRaceCondition(Rule):
 
                 return Result(
                     rule_id=self.id,
-                    artifact=context["artifact"],
                     location=Location(node=call.function_node),
                     message=self.message.format(file_arg.value),
                     fixes=fixes,


### PR DESCRIPTION
In order to simplify the rules, this change reduces the need to pass the file artifact when initializing the Result. This amounts to less code in each Rule. The artifact still gets set, but later in the parser. As a result, the snippet and artifact URI are also set later.