### PR TITLE
Fix traceback on syntax errors

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -77,7 +77,7 @@ class Parser(ABC):
         :rtype: list
         """
         self.results = []
-        self.context = {}
+        self.context = {"artifact": artifact}
         if artifact.contents is None:
             with open(artifact.file_name, "rb") as fdata:
                 artifact.contents = fdata.read()


### PR DESCRIPTION
Recent change to remove the artifact from the context causes a traceback when visiting an ERROR node which needs the file name.

Fixes: #272