### PR TITLE
Set logging level on urllib

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -208,6 +208,7 @@ def main():
         or os.getenv("DEBUG") is not None
         else logging.INFO
     )
+    logging.getLogger("urllib3").setLevel(debug)
 
     # Setup the command line arguments
     args = setup_arg_parser()

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -38,7 +38,6 @@ class Run:
         LOG.handlers = []
         logging.captureWarnings(True)
         LOG.setLevel(log_level)
-        logging.getLogger("urllib3").setLevel(log_level)
         handler = logging.StreamHandler(sys.stderr)
         LOG.addHandler(handler)
         LOG.debug("logging initialized")


### PR DESCRIPTION
This is to prevent the unintential log messages from urllib3 via requests appearing as stdout.

Fixes: #275