### PR TITLE
Better languages detection

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Secure Saurce LLC
 from abc import ABC
+from abc import abstractmethod
 from importlib.metadata import entry_points
 
 import tree_sitter_languages
@@ -66,6 +67,14 @@ class Parser(ABC):
         :rtype: str
         """
         return self._lexer
+
+    @abstractmethod
+    def file_extensions(self) -> list[str]:
+        """
+        File extension of files this parser can handle.
+        :return: file extensions such as ".py"
+        :rtype: list
+        """
 
     def parse(self, artifact: Artifact) -> list[Result]:
         """

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -18,6 +18,9 @@ class Go(Parser):
         )
         self.SUPPRESSED_RULES = re.compile(r"(?:(GO\d\d\d|[a-z_]+),?)+")
 
+    def file_extensions(self) -> list[str]:
+        return [".go"]
+
     def visit_source_file(self, nodes: list[Node]):
         self.suppressions = {}
         self.current_symtab = SymbolTable("<source_file>")

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -5,3 +5,6 @@ from precli.parsers import Parser
 class Java(Parser):
     def __init__(self, enabled: list = None, disabled: list = None):
         super().__init__("java", enabled, disabled)
+
+    def file_extensions(self) -> list[str]:
+        return [".java"]

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -21,6 +21,9 @@ class Python(Parser):
         self.SUPPRESS_COMMENT = re.compile(r"# suppress:? (?P<rules>[^#]+)?#?")
         self.SUPPRESSED_RULES = re.compile(r"(?:(PY\d\d\d|[a-z_]+),?)+")
 
+    def file_extensions(self) -> list[str]:
+        return [".py", ".pyw"]
+
     def visit_module(self, nodes: list[Node]):
         self.suppressions = {}
         self.current_symtab = SymbolTable("<module>")


### PR DESCRIPTION
Relying on rich Syntax to guess the lexer in all cases is problemmatic. It would actually hang on some files.

Therefore, reverting to using file extensions to identify the lexer type as the primary method. Only use pygments guess_lexer when the file is standard input.