### PR TITLE
Add environment variables section to man page

### DIFF
--- a/docs/source/man/precli.rst
+++ b/docs/source/man/precli.rst
@@ -38,6 +38,12 @@ FILES
 .preignore
   file that specifies which files and directories can be ignored
 
+ENVIRONMENT VARIABLES
+=====================
+
+DEBUG
+  Set to any value to enabling debug logging.
+
 EXAMPLES
 ========
 


### PR DESCRIPTION
Further information in the man page about details on any environment variables that precli will read.

Currently the only read variable is DEBUG. When any value is set, it will turn on debug logging.