### PR TITLE
Fix missing syntax highlighting on code snippets

### DIFF
--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -118,6 +118,7 @@ class Run:
                     ),
                     None,
                 )
+                artifact.language = parser.lexer
 
             if parser is not None:
                 LOG.debug("Working on file: %s", artifact.file_name)


### PR DESCRIPTION
The artifact.language is unset on standard files that are not stdin. This change properly sets it to the lexer value of the parser.`