### PR TITLE
Add more testing of HttpUrlSecret rule

### DIFF
--- a/tests/unit/rules/python/stdlib/examples/http_url_secret_apikey_in_header.py
+++ b/tests/unit/rules/python/stdlib/examples/http_url_secret_apikey_in_header.py
@@ -1,0 +1,9 @@
+# level: NONE
+import http.client
+
+
+host = "example.com"
+headers = {"X-FullContact-APIKey": "value"}
+conn = http.client.HTTPSConnection(host)
+conn.request("GET", "/path?otherParam=123", headers=headers)
+response = conn.getresponse()

--- a/tests/unit/rules/python/stdlib/examples/http_url_secret_password.py
+++ b/tests/unit/rules/python/stdlib/examples/http_url_secret_password.py
@@ -1,0 +1,14 @@
+# level: ERROR
+# start_line: 12
+# end_line: 12
+# start_column: 11
+# end_column: 49
+import http.client
+
+
+host = "example.com"
+conn = http.client.HTTPSConnection(host)
+conn.request(
+    "GET", "/path?password=abc123&otherParam=123", headers={"Host": host}
+)
+response = conn.getresponse()

--- a/tests/unit/rules/python/stdlib/examples/http_url_secret_username.py
+++ b/tests/unit/rules/python/stdlib/examples/http_url_secret_username.py
@@ -1,0 +1,14 @@
+# level: ERROR
+# start_line: 12
+# end_line: 12
+# start_column: 11
+# end_column: 46
+import http.client
+
+
+host = "example.com"
+conn = http.client.HTTPSConnection(host)
+conn.request(
+    "GET", "/path?username=bob&otherParam=123", headers={"Host": host}
+)
+response = conn.getresponse()

--- a/tests/unit/rules/python/stdlib/test_http_url_secret.py
+++ b/tests/unit/rules/python/stdlib/test_http_url_secret.py
@@ -38,6 +38,9 @@ class HttpUrlSecretTests(test_case.TestCase):
     @parameterized.expand(
         [
             "http_url_secret_apikey.py",
+            "http_url_secret_apikey_in_header.py",
+            "http_url_secret_password.py",
+            "http_url_secret_username.py",
         ]
     )
     def test(self, filename):


### PR DESCRIPTION
Add tests of apikey, password, and username in the URL. Also add a compliant case where the apikey is in the header.