### PR TITLE
Use rich console capture of printed text

### DIFF
--- a/precli/renderers/detailed.py
+++ b/precli/renderers/detailed.py
@@ -20,156 +20,158 @@ class Detailed(Renderer):
             self.console = console.Console(highlight=False)
 
     def render(self, run: Run):
-        for result in run.results:
-            match result.level:
-                case Level.ERROR:
-                    emoji = ":no_entry-emoji:"
-                    style = "red"
+        with self.console.capture() as capture:
+            for result in run.results:
+                match result.level:
+                    case Level.ERROR:
+                        emoji = ":no_entry-emoji:"
+                        style = "red"
 
-                case Level.WARNING:
-                    emoji = ":warning-emoji: "
-                    style = "yellow"
+                    case Level.WARNING:
+                        emoji = ":warning-emoji: "
+                        style = "yellow"
 
-                case Level.NOTE:
-                    emoji = ":information-emoji: "
-                    style = "blue"
+                    case Level.NOTE:
+                        emoji = ":information-emoji: "
+                        style = "blue"
 
-            if result.artifact.uri is not None:
-                if result.location.start_line != result.location.end_line:
-                    lines = (
-                        f"L{result.location.start_line}-"
-                        f"L{result.location.end_line}"
-                    )
+                if result.artifact.uri is not None:
+                    if result.location.start_line != result.location.end_line:
+                        lines = (
+                            f"L{result.location.start_line}-"
+                            f"L{result.location.end_line}"
+                        )
+                    else:
+                        lines = f"L{result.location.start_line}"
+                    file_name = f"{result.artifact.uri}#{lines}"
                 else:
-                    lines = f"L{result.location.start_line}"
-                file_name = f"{result.artifact.uri}#{lines}"
-            else:
-                file_name = result.artifact.file_name
+                    file_name = result.artifact.file_name
 
-            self.console.print(
-                f"{emoji} {result.level.name.title()} on line "
-                f"{result.location.start_line} in {file_name}",
-                style=style,
-                markup=False,
-            )
-            rule = Rule.get_by_id(result.rule_id)
-            self.console.print(
-                f"{rule.id}: {rule.cwe.name}",
-                style=style,
-            )
-            self.console.print(
-                f"{result.message}",
-                style=style,
-            )
-
-            line_offset = result.location.start_line - 2
-            code = syntax.Syntax(
-                result.snippet,
-                result.artifact.language,
-                line_numbers=True,
-                start_line=line_offset + 1,
-                line_range=(
-                    result.location.start_line - line_offset - 1,
-                    result.location.end_line - line_offset + 1,
-                ),
-                highlight_lines=(
-                    result.location.start_line,
-                    result.location.end_line,
-                ),
-            )
-            self.console.print(code)
-
-            if result.fixes:
                 self.console.print(
-                    f"Suggested fix: {result.fixes[0].description}",
+                    f"{emoji} {result.level.name.title()} on line "
+                    f"{result.location.start_line} in {file_name}",
+                    style=style,
+                    markup=False,
+                )
+                rule = Rule.get_by_id(result.rule_id)
+                self.console.print(
+                    f"{rule.id}: {rule.cwe.name}",
+                    style=style,
+                )
+                self.console.print(
+                    f"{result.message}",
                     style=style,
                 )
 
-            highlight_lines = set()
-            for fix in result.fixes:
-                highlight_lines.add(fix.deleted_location.start_line)
-                highlight_lines.add(fix.deleted_location.end_line)
-
-            for fix in result.fixes:
-                start_line = fix.deleted_location.start_line
-                end_line = fix.deleted_location.end_line
-                start_column = fix.deleted_location.start_column
-                end_column = fix.deleted_location.end_column
-
-                linecache = LineCache(
-                    result.artifact.file_name,
-                    result.artifact.contents.decode(),
-                )
-
-                if (start_line - 1) in highlight_lines:
-                    line_before = ""
-                    before = 0
-                else:
-                    line_before = linecache.getline(lineno=start_line - 1)
-                    before = 1
-
-                code = linecache.getline(lineno=start_line)
-
-                if (start_line + 1) in highlight_lines:
-                    line_after = ""
-                    after = 0
-                else:
-                    line_after = linecache.getline(lineno=start_line + 1)
-                    after = 1
-
-                code = (
-                    code[:start_column]
-                    + fix.inserted_content
-                    + code[end_column:]
-                )
-                code = line_before + code + line_after
-                for _ in range(start_line - 1 - before):
-                    code = "\n" + code
-
+                line_offset = result.location.start_line - 2
                 code = syntax.Syntax(
-                    code,
+                    result.snippet,
                     result.artifact.language,
                     line_numbers=True,
-                    line_range=(start_line - before, end_line + after),
-                    highlight_lines=highlight_lines,
+                    start_line=line_offset + 1,
+                    line_range=(
+                        result.location.start_line - line_offset - 1,
+                        result.location.end_line - line_offset + 1,
+                    ),
+                    highlight_lines=(
+                        result.location.start_line,
+                        result.location.end_line,
+                    ),
                 )
                 self.console.print(code)
-            self.console.print()
 
-        # Print the summary
-        table = Table(
-            box=box.HEAVY,
-            min_width=60,
-            show_header=False,
-        )
-        table.add_column(justify="left")
-        table.add_column(justify="right")
-        table.add_column(justify="left")
-        table.add_column(justify="right")
-        table.add_row(
-            "Files analyzed",
-            f"{run.metrics.files:,}",
-            "Lines analyzed",
-            f"{run.metrics.lines:,}",
-        )
-        table.add_row(
-            "Files skipped",
-            f"{run.metrics.files_skipped:,}",
-            end_section=True,
-        )
-        table.add_row(
-            "Errors",
-            f"{run.metrics.errors:,}",
-            style="red" if run.metrics.errors else "",
-        )
-        table.add_row(
-            "Warnings",
-            f"{run.metrics.warnings:,}",
-            style="yellow" if run.metrics.warnings else "",
-        )
-        table.add_row(
-            "Notes",
-            f"{run.metrics.notes:,}",
-            style="blue" if run.metrics.notes else "",
-        )
-        self.console.print(table)
+                if result.fixes:
+                    self.console.print(
+                        f"Suggested fix: {result.fixes[0].description}",
+                        style=style,
+                    )
+
+                highlight_lines = set()
+                for fix in result.fixes:
+                    highlight_lines.add(fix.deleted_location.start_line)
+                    highlight_lines.add(fix.deleted_location.end_line)
+
+                for fix in result.fixes:
+                    start_line = fix.deleted_location.start_line
+                    end_line = fix.deleted_location.end_line
+                    start_column = fix.deleted_location.start_column
+                    end_column = fix.deleted_location.end_column
+
+                    linecache = LineCache(
+                        result.artifact.file_name,
+                        result.artifact.contents.decode(),
+                    )
+
+                    if (start_line - 1) in highlight_lines:
+                        line_before = ""
+                        before = 0
+                    else:
+                        line_before = linecache.getline(lineno=start_line - 1)
+                        before = 1
+
+                    code = linecache.getline(lineno=start_line)
+
+                    if (start_line + 1) in highlight_lines:
+                        line_after = ""
+                        after = 0
+                    else:
+                        line_after = linecache.getline(lineno=start_line + 1)
+                        after = 1
+
+                    code = (
+                        code[:start_column]
+                        + fix.inserted_content
+                        + code[end_column:]
+                    )
+                    code = line_before + code + line_after
+                    for _ in range(start_line - 1 - before):
+                        code = "\n" + code
+
+                    code = syntax.Syntax(
+                        code,
+                        result.artifact.language,
+                        line_numbers=True,
+                        line_range=(start_line - before, end_line + after),
+                        highlight_lines=highlight_lines,
+                    )
+                    self.console.print(code)
+                self.console.print()
+
+            # Print the summary
+            table = Table(
+                box=box.HEAVY,
+                min_width=60,
+                show_header=False,
+            )
+            table.add_column(justify="left")
+            table.add_column(justify="right")
+            table.add_column(justify="left")
+            table.add_column(justify="right")
+            table.add_row(
+                "Files analyzed",
+                f"{run.metrics.files:,}",
+                "Lines analyzed",
+                f"{run.metrics.lines:,}",
+            )
+            table.add_row(
+                "Files skipped",
+                f"{run.metrics.files_skipped:,}",
+                end_section=True,
+            )
+            table.add_row(
+                "Errors",
+                f"{run.metrics.errors:,}",
+                style="red" if run.metrics.errors else "",
+            )
+            table.add_row(
+                "Warnings",
+                f"{run.metrics.warnings:,}",
+                style="yellow" if run.metrics.warnings else "",
+            )
+            table.add_row(
+                "Notes",
+                f"{run.metrics.notes:,}",
+                style="blue" if run.metrics.notes else "",
+            )
+            self.console.print(table)
+        print(capture.get())

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -118,4 +118,6 @@ class Json(Renderer):
 
             sarif_run.results.append(sarif_result)
 
-        self.console.print_json(to_json(log))
+        with self.console.capture() as capture:
+            self.console.print_json(to_json(log))
+        print(capture.get())

--- a/precli/renderers/markdown.py
+++ b/precli/renderers/markdown.py
@@ -20,85 +20,89 @@ class Markdown(Renderer):
         self.console = console.Console(highlight=False)
 
     def render(self, run: Run):
-        for result in run.results:
-            rule = Rule.get_by_id(result.rule_id)
+        with self.console.capture() as capture:
+            for result in run.results:
+                rule = Rule.get_by_id(result.rule_id)
 
-            linecache = LineCache(
-                result.artifact.file_name,
-                result.artifact.contents.decode(),
-            )
+                linecache = LineCache(
+                    result.artifact.file_name,
+                    result.artifact.contents.decode(),
+                )
 
-            match result.level:
-                case Level.ERROR:
-                    alert = "CAUTION"
-                case Level.WARNING:
-                    alert = "WARNING"
-                case Level.NOTE:
-                    alert = "NOTE"
+                match result.level:
+                    case Level.ERROR:
+                        alert = "CAUTION"
+                    case Level.WARNING:
+                        alert = "WARNING"
+                    case Level.NOTE:
+                        alert = "NOTE"
 
-            if result.artifact.uri is not None:
-                if result.location.start_line != result.location.end_line:
-                    lines = (
-                        f"L{result.location.start_line}-"
-                        f"L{result.location.end_line}"
+                if result.artifact.uri is not None:
+                    if result.location.start_line != result.location.end_line:
+                        lines = (
+                            f"L{result.location.start_line}-"
+                            f"L{result.location.end_line}"
+                        )
+                    else:
+                        lines = f"L{result.location.start_line}"
+                    file_name = (
+                        f"[{result.artifact.uri}#{lines}]"
+                        f"({result.artifact.uri}#{lines})"
                     )
                 else:
-                    lines = f"L{result.location.start_line}"
-                file_name = (
-                    f"[{result.artifact.uri}#{lines}]"
-                    f"({result.artifact.uri}#{lines})"
+                    file_name = result.artifact.file_name
+
+                output = (
+                    f"> [!{alert}]\n"
+                    f">\n"
+                    f"> [{rule.id}]({rule.help_url}): {rule.cwe.name}\n"
+                    f"on line {result.location.start_line} in {file_name}\n"
+                    f"> \n"
+                    f"> {result.message}\n"
                 )
-            else:
-                file_name = result.artifact.file_name
 
-            output = (
-                f"> [!{alert}]\n"
-                f">\n"
-                f"> [{rule.id}]({rule.help_url}): {rule.cwe.name}\n"
-                f"on line {result.location.start_line} in {file_name}\n"
-                f"> \n"
-                f"> {result.message}\n"
-            )
-
-            output += f"> ```{result.artifact.language}\n"
-            for lineno in range(
-                result.location.start_line, result.location.end_line + 1
-            ):
-                output += f"> {linecache.getline(lineno=lineno)}"
-            output += "> ```\n"
-
-            if result.fixes:
-                output += f"> Suggested fix: {result.fixes[0].description}\n"
-
-            for fix in result.fixes:
-                start_line = fix.deleted_location.start_line
-                start_column = fix.deleted_location.start_column
-                end_column = fix.deleted_location.end_column
-
-                code = linecache.getline(lineno=start_line)
-                code = (
-                    code[:start_column]
-                    + fix.inserted_content
-                    + code[end_column:]
-                )
                 output += f"> ```{result.artifact.language}\n"
-                for line in code.splitlines():
-                    output += f"> {line}\n"
+                for lineno in range(
+                    result.location.start_line, result.location.end_line + 1
+                ):
+                    output += f"> {linecache.getline(lineno=lineno)}"
                 output += "> ```\n"
 
-            md = markdown.Markdown(output)
+                if result.fixes:
+                    output += (
+                        f"> Suggested fix: {result.fixes[0].description}\n"
+                    )
+
+                for fix in result.fixes:
+                    start_line = fix.deleted_location.start_line
+                    start_column = fix.deleted_location.start_column
+                    end_column = fix.deleted_location.end_column
+
+                    code = linecache.getline(lineno=start_line)
+                    code = (
+                        code[:start_column]
+                        + fix.inserted_content
+                        + code[end_column:]
+                    )
+                    output += f"> ```{result.artifact.language}\n"
+                    for line in code.splitlines():
+                        output += f"> {line}\n"
+                    output += "> ```\n"
+
+                md = markdown.Markdown(output)
+                self.console.print(md)
+
+            table = (
+                f"| Metric | Value |\n"
+                f"| --- | --- |\n"
+                f"| Files analyzed | {run.metrics.files:,} |\n"
+                f"| Lines analyzed | {run.metrics.lines:,} |\n"
+                f"| Files skipped | {run.metrics.files_skipped:,} |\n"
+                f"| Errors | {run.metrics.errors:,} |\n"
+                f"| Warnings | {run.metrics.warnings:,} |\n"
+                f"| Notes | {run.metrics.notes:,} |\n"
+            )
+
+            md = markdown.Markdown(table)
             self.console.print(md)
-
-        table = (
-            f"| Metric | Value |\n"
-            f"| --- | --- |\n"
-            f"| Files analyzed | {run.metrics.files:,} |\n"
-            f"| Lines analyzed | {run.metrics.lines:,} |\n"
-            f"| Files skipped | {run.metrics.files_skipped:,} |\n"
-            f"| Errors | {run.metrics.errors:,} |\n"
-            f"| Warnings | {run.metrics.warnings:,} |\n"
-            f"| Notes | {run.metrics.notes:,} |\n"
-        )
-
-        md = markdown.Markdown(table)
-        self.console.print(md)
+        print(capture.get())

--- a/precli/renderers/plain.py
+++ b/precli/renderers/plain.py
@@ -14,58 +14,63 @@ class Plain(Renderer):
         self.console = console.Console(highlight=False)
 
     def render(self, run: Run):
-        for result in run.results:
-            rule = Rule.get_by_id(result.rule_id)
+        with self.console.capture() as capture:
+            for result in run.results:
+                rule = Rule.get_by_id(result.rule_id)
 
-            if self._no_color is True:
-                style = ""
-            else:
-                match result.level:
-                    case Level.ERROR:
-                        style = "red"
+                if self._no_color is True:
+                    style = ""
+                else:
+                    match result.level:
+                        case Level.ERROR:
+                            style = "red"
 
-                    case Level.WARNING:
-                        style = "yellow"
+                        case Level.WARNING:
+                            style = "yellow"
 
-                    case Level.NOTE:
-                        style = "blue"
+                        case Level.NOTE:
+                            style = "blue"
 
+                if result.artifact.uri is not None:
+                    file_name = result.artifact.uri
+                else:
+                    file_name = result.artifact.file_name
+
+                self.console.print(
+                    f"{rule.id}: {rule.cwe.name}",
+                )
+
+                # TODO(ericwb): replace hardcoded <module> with actual scope
+                self.console.print(
+                    f'  File "{file_name}", line '
+                    f"{result.location.start_line}, in <module>",
+                )
+                code_lines = result.snippet.splitlines(keepends=True)
+                code_line = (
+                    code_lines[1] if len(code_lines) > 1 else code_lines[0]
+                )
+                underline_width = (
+                    result.location.end_column - result.location.start_column
+                )
+                underline = (
+                    " " * result.location.start_column + "^" * underline_width
+                )
+                self.console.print(
+                    Padding(code_line + underline, (0, 4)),
+                )
+                self.console.print(
+                    f"{result.level.name.title()}: ",
+                    style=style,
+                    end="",
+                )
+                self.console.print(
+                    f"{result.message}",
+                )
+                self.console.print()
             self.console.print(
-                f"{rule.id}: {rule.cwe.name}",
+                f"Found {run.metrics.errors} errors, {run.metrics.warnings} "
+                f"warnings, and {run.metrics.notes} notes in "
+                f"{run.metrics.files} files and {run.metrics.lines} lines of "
+                f"code."
             )
-
-            if result.artifact.uri is not None:
-                file_name = result.artifact.uri
-            else:
-                file_name = result.artifact.file_name
-
-            # TODO(ericwb): replace hardcoded <module> with actual scope
-            self.console.print(
-                f'  File "{file_name}", line '
-                f"{result.location.start_line}, in <module>",
-            )
-            code_lines = result.snippet.splitlines(keepends=True)
-            code_line = code_lines[1] if len(code_lines) > 1 else code_lines[0]
-            underline_width = (
-                result.location.end_column - result.location.start_column
-            )
-            underline = (
-                " " * result.location.start_column + "^" * underline_width
-            )
-            self.console.print(
-                Padding(code_line + underline, (0, 4)),
-            )
-            self.console.print(
-                f"{result.level.name.title()}: ",
-                style=style,
-                end="",
-            )
-            self.console.print(
-                f"{result.message}",
-            )
-            self.console.print()
-        self.console.print(
-            f"Found {run.metrics.errors} errors, {run.metrics.warnings} "
-            f"warnings, and {run.metrics.notes} notes in {run.metrics.files} "
-            f"files and {run.metrics.lines} lines of code."
-        )
+        print(capture.get())


### PR DESCRIPTION
Printing output to a captured console will help later when there is an option to send the output to a file instead of the console.