### PR TITLE
Add an output to a file CLI argument

### DIFF
--- a/docs/source/man/precli.rst
+++ b/docs/source/man/precli.rst
@@ -6,7 +6,7 @@ SYNOPSIS
 ========
 
 precli [-h] [-d] [-r] [--enable ENABLE] [--disable DISABLE] [--json] [--plain]
-       [--markdown] [--no-color] [--version]
+       [--markdown] [-o OUTPUT] [--no-color] [--version]
        [targets ...]
 
 
@@ -29,6 +29,8 @@ OPTIONS
   --json             display output as formatted JSON
   --plain            display output in plain, tabular text
   --markdown         display output in markdown format
+  -o OUTPUT, --output OUTPUT
+                     output results to a file
   --no-color         do not display color in output
   --version          show program's version number and exit
 

--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -84,6 +84,15 @@ def setup_arg_parser():
         help="display output in markdown format",
     )
     parser.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        action="store",
+        type=argparse.FileType("w", encoding="utf-8"),
+        default=sys.stdout,
+        help="output results to a file",
+    )
+    parser.add_argument(
         "--no-color",
         dest="no_color",
         action="store_true",
@@ -234,18 +243,26 @@ def main():
     # Invoke the run
     run.invoke()
 
+    no_color = True if args.output.name != sys.stdout.name else args.no_color
+
     if args.json is True:
-        json = Json(args.no_color)
-        json.render(run)
+        json = Json(no_color)
+        capture = json.render(run)
     elif args.plain is True:
-        plain = Plain(args.no_color)
-        plain.render(run)
+        plain = Plain(no_color)
+        capture = plain.render(run)
     elif args.markdown is True:
-        markdown = Markdown(args.no_color)
-        markdown.render(run)
+        markdown = Markdown(no_color)
+        capture = markdown.render(run)
     else:
-        detailed = Detailed(args.no_color)
-        detailed.render(run)
+        detailed = Detailed(no_color)
+        capture = detailed.render(run)
+
+    with args.output:
+        args.output.write(capture)
+
+    if args.output.name != sys.stdout.name:
+        print(f"Output written to file: {args.output.name}")
 
 
 if __name__ == "__main__":

--- a/precli/renderers/__init__.py
+++ b/precli/renderers/__init__.py
@@ -2,13 +2,19 @@
 from abc import ABC
 from abc import abstractmethod
 
+from rich import console
+
 from precli.core.run import Run
 
 
 class Renderer(ABC):
     def __init__(self, no_color: bool = False):
         self._no_color = no_color
+        if no_color is True:
+            self.console = console.Console(color_system=None, highlight=False)
+        else:
+            self.console = console.Console(highlight=False)
 
     @abstractmethod
-    def render(self, run: Run):
+    def render(self, run: Run) -> str:
         pass

--- a/precli/renderers/detailed.py
+++ b/precli/renderers/detailed.py
@@ -1,6 +1,5 @@
 # Copyright 2024 Secure Saurce LLC
 from rich import box
-from rich import console
 from rich import syntax
 from rich.table import Table
 
@@ -14,12 +13,8 @@ from precli.rules import Rule
 class Detailed(Renderer):
     def __init__(self, no_color: bool = False):
         super().__init__(no_color=no_color)
-        if no_color is True:
-            self.console = console.Console(color_system=None, highlight=False)
-        else:
-            self.console = console.Console(highlight=False)
 
-    def render(self, run: Run):
+    def render(self, run: Run) -> str:
         with self.console.capture() as capture:
             for result in run.results:
                 match result.level:
@@ -174,4 +169,4 @@ class Detailed(Renderer):
                 style="blue" if run.metrics.notes else "",
             )
             self.console.print(table)
-        print(capture.get())
+        return capture.get()

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 import sarif_om
 from jschema_to_python.to_json import to_json
-from rich import console
 
 from precli.core.fix import Fix
 from precli.core.run import Run
@@ -21,7 +20,6 @@ TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 class Json(Renderer):
     def __init__(self, no_color: bool = False):
         super().__init__(no_color=no_color)
-        self.console = console.Console(highlight=False)
 
     def to_uri(self, file):
         path = pathlib.PurePath(file)
@@ -52,7 +50,7 @@ class Json(Renderer):
             description=fix.description,
         )
 
-    def render(self, run: Run):
+    def render(self, run: Run) -> str:
         log = sarif_om.SarifLog(
             schema_uri=SCHEMA_URI,
             version="2.1.0",
@@ -120,4 +118,4 @@ class Json(Renderer):
 
         with self.console.capture() as capture:
             self.console.print_json(to_json(log))
-        print(capture.get())
+        return capture.get()

--- a/precli/renderers/markdown.py
+++ b/precli/renderers/markdown.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Secure Saurce LLC
 import logging
 
-from rich import console
 from rich import markdown
 
 from precli.core.level import Level
@@ -17,9 +16,8 @@ logging.getLogger("markdown_it").setLevel(logging.INFO)
 class Markdown(Renderer):
     def __init__(self, no_color: bool = False):
         super().__init__(no_color=no_color)
-        self.console = console.Console(highlight=False)
 
-    def render(self, run: Run):
+    def render(self, run: Run) -> str:
         with self.console.capture() as capture:
             for result in run.results:
                 rule = Rule.get_by_id(result.rule_id)
@@ -105,4 +103,4 @@ class Markdown(Renderer):
 
             md = markdown.Markdown(table)
             self.console.print(md)
-        print(capture.get())
+        return capture.get()

--- a/precli/renderers/plain.py
+++ b/precli/renderers/plain.py
@@ -1,5 +1,4 @@
 # Copyright 2024 Secure Saurce LLC
-from rich import console
 from rich.padding import Padding
 
 from precli.core.level import Level
@@ -11,9 +10,8 @@ from precli.rules import Rule
 class Plain(Renderer):
     def __init__(self, no_color: bool = False):
         super().__init__(no_color=no_color)
-        self.console = console.Console(highlight=False)
 
-    def render(self, run: Run):
+    def render(self, run: Run) -> str:
         with self.console.capture() as capture:
             for result in run.results:
                 rule = Rule.get_by_id(result.rule_id)
@@ -73,4 +71,4 @@ class Plain(Renderer):
                 f"{run.metrics.files} files and {run.metrics.lines} lines of "
                 f"code."
             )
-        print(capture.get())
+        return capture.get()


### PR DESCRIPTION
Give the user a option to output to a file instead of just stdout. This also disables the color option to the rich console when sent to a file.

Closes #293