### PR TITLE
Add option to output the results to Gist

### DIFF
--- a/docs/source/man/precli.rst
+++ b/docs/source/man/precli.rst
@@ -6,7 +6,7 @@ SYNOPSIS
 ========
 
 precli [-h] [-d] [-r] [--enable ENABLE] [--disable DISABLE] [--json] [--plain]
-       [--markdown] [-o OUTPUT] [--no-color] [--version]
+       [--markdown] [--gist] [-o OUTPUT] [--no-color] [--version]
        [targets ...]
 
 
@@ -21,18 +21,19 @@ certificate validation, and more.
 OPTIONS
 =======
 
-  -h, --help         show this help message and exit
-  -d, --debug        turn on debug mode
-  -r, --recursive    find and process files in subdirectories
-  --enable ENABLE    comma-separated list of rule IDs or names to enable
-  --disable DISABLE  comma-separated list of rule IDs or names to disable
-  --json             display output as formatted JSON
-  --plain            display output in plain, tabular text
-  --markdown         display output in markdown format
+  -h, --help            show this help message and exit
+  -d, --debug           turn on debug mode
+  -r, --recursive       find and process files in subdirectories
+  --enable ENABLE       comma-separated list of rule IDs or names to enable
+  --disable DISABLE     comma-separated list of rule IDs or names to disable
+  --json                render the output as formatted JSON
+  --plain               render the output in plain, tabular text
+  --markdown            render the output in markdown format
+  --gist                output the results to Gist
   -o OUTPUT, --output OUTPUT
-                     output results to a file
-  --no-color         do not display color in output
-  --version          show program's version number and exit
+                        output the results to a file
+  --no-color            do not display color in output
+  --version             show program's version number and exit
 
 FILES
 =====
@@ -45,6 +46,9 @@ ENVIRONMENT VARIABLES
 
 DEBUG
   Set to any value to enabling debug logging.
+
+GITHUB_TOKEN
+  Set to your GitHub token. This is required to use the ``--gist`` argument.
 
 EXAMPLES
 ========

--- a/precli/renderers/markdown.py
+++ b/precli/renderers/markdown.py
@@ -44,10 +44,7 @@ class Markdown(Renderer):
                     )
                 else:
                     lines = f"L{result.location.start_line}"
-                file_name = (
-                    f"[{result.artifact.uri}#{lines}]"
-                    f"({result.artifact.uri}#{lines})"
-                )
+                file_name = f"{result.artifact.uri}#{lines}"
             else:
                 file_name = result.artifact.file_name
 
@@ -99,7 +96,7 @@ class Markdown(Renderer):
         )
 
         if self._file.name != sys.stdout.name:
-            self.console.print(output)
+            self.console.print(output, soft_wrap=True)
         else:
             md = markdown.Markdown(output)
-            self.console.print(md)
+            self.console.print(md, soft_wrap=True)


### PR DESCRIPTION
* New CLI argument --gist, --output is ignored if using gist
* Create a temporary file to store results of analysis
* After complete, upload results to https://gist.github.com/
* Inform the user of the URL of the Gist created

Note: requires GITHUB_TOKEN environment variable to be set to a valid token of the user in order to upload to Gist.

Closes #296