### PR TITLE
Fix traceback on unsupported files

### DIFF
--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -118,10 +118,10 @@ class Run:
                     ),
                     None,
                 )
-                artifact.language = parser.lexer
 
             if parser is not None:
                 LOG.debug("Working on file: %s", artifact.file_name)
+                artifact.language = parser.lexer
                 return parser.parse(artifact)
         except KeyboardInterrupt:
             sys.exit(2)


### PR DESCRIPTION
Only set the artifact language if the parser is not None. In other words, only set the value if a parser is found for a supported file extension (just *.py and *.go right now).

Fixes #298