### PR TITLE
Fix traceback when parsing with without as

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -128,12 +128,14 @@ class Python(Parser):
     def visit_with_item(self, nodes: list[Node]):
         as_pattern = nodes[0] if nodes[0].type == "as_pattern" else None
 
-        if as_pattern is not None:
+        if as_pattern is not None and as_pattern.children:
             statement = as_pattern.children[0]
             as_pattern_target = as_pattern.children[2]
 
-            if as_pattern_target.children[0].type == "identifier" and (
-                statement.type in ("call", "attribute", "identifier")
+            if (
+                as_pattern_target.children
+                and as_pattern_target.children[0].type == "identifier"
+                and statement.type in ("call", "attribute", "identifier")
             ):
                 identifier = as_pattern_target.children[0]
                 identifier = self.literal_value(identifier, default=identifier)

--- a/tests/unit/rules/python/stdlib/examples/ftp_context_mgr.py
+++ b/tests/unit/rules/python/stdlib/examples/ftp_context_mgr.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 5
+# end_column: 8
+from ftplib import FTP
+
+
+with FTP("ftp.us.debian.org"):
+    print("FTP protocol available")

--- a/tests/unit/rules/python/stdlib/test_ftplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/test_ftplib_cleartext.py
@@ -39,6 +39,7 @@ class FtpCleartextTests(test_case.TestCase):
     @parameterized.expand(
         [
             "ftp.py",
+            "ftp_context_mgr.py",
             "ftp_tls.py",
             "ftplib_ftp.py",
             "ftplib_ftp_context_mgr.py",


### PR DESCRIPTION
A with context manager doesn't require an as-statement to assign a variable to the call of the context manager.

Fixes #301