### PR TITLE
Change json_load rule to be default of disabled

### DIFF
--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -39,6 +39,7 @@ should first sanitize the data to remove any potential malicious code.
 .. versionadded:: 0.1.0
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -60,6 +61,7 @@ class JsonLoad(Rule):
                     "loads",
                 ]
             },
+            config=Config(enabled=False),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:

--- a/tests/unit/rules/python/stdlib/test_json_load.py
+++ b/tests/unit/rules/python/stdlib/test_json_load.py
@@ -13,7 +13,7 @@ class JsonLoadTests(test_case.TestCase):
     def setUp(self):
         super().setUp()
         self.rule_id = "PY009"
-        self.parser = python.Python()
+        self.parser = python.Python(enabled=[self.rule_id])
         self.base_path = os.path.join(
             "tests",
             "unit",


### PR DESCRIPTION
The json_load rule is far too noisy. As a result,
this change will disable it by default so there isn't a flurry of false positives by default.

It really needs taint analysis instead of the current rule logic.