### PR TITLE
Add varibles of function parameters to symtab

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -50,7 +50,37 @@ class Python(Parser):
     def visit_function_definition(self, nodes: list[Node]):
         func_id = self.first_match(self.context["node"], "identifier")
         func = func_id.text.decode()
+
         self.current_symtab = SymbolTable(func, parent=self.current_symtab)
+
+        func_parameters = self.first_match(self.context["node"], "parameters")
+        func_args = func_parameters.named_children
+
+        for func_arg in func_args:
+            # typed_parameter or identifier
+            if func_arg.type == "typed_parameter":
+                param_id = self.first_match(func_arg, "identifier")
+                param_type = self.first_match(func_arg, "type")
+
+                if param_type.named_children[0].type in (
+                    "attribute",
+                    "identifier",
+                    "string",
+                    "integer",
+                    "float",
+                    "true",
+                    "false",
+                    "none",
+                ):
+                    param_name = param_id.text.decode()
+                    param_type = self.literal_value(
+                        param_type.named_children[0],
+                        default=param_type.named_children[0],
+                    )
+                    self.current_symtab.put(
+                        param_name, "identifier", param_type
+                    )
+
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 


### PR DESCRIPTION
If the code being parsed is using type hinting, we can identify the type of a function parameter. As such, we can add that identifier and type to our symbol table to help in detecting issues.