### PR TITLE
Rework how a typed parameter is handled

### DIFF
--- a/tests/unit/rules/python/stdlib/examples/ssl_context_set_ecdh_curve_typed_default_param.py
+++ b/tests/unit/rules/python/stdlib/examples/ssl_context_set_ecdh_curve_typed_default_param.py
@@ -1,0 +1,14 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 27
+# end_column: 39
+import ssl
+
+
+def set_curve(context: ssl.SSLContext = None) -> None:
+    context.set_ecdh_curve("prime192v1")
+
+
+context = ssl.SSLContext()
+set_curve(context)

--- a/tests/unit/rules/python/stdlib/examples/ssl_context_set_ecdh_curve_typed_param.py
+++ b/tests/unit/rules/python/stdlib/examples/ssl_context_set_ecdh_curve_typed_param.py
@@ -1,0 +1,14 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 27
+# end_column: 39
+import ssl
+
+
+def set_curve(context: ssl.SSLContext) -> None:
+    context.set_ecdh_curve("prime192v1")
+
+
+context = ssl.SSLContext()
+set_curve(context)

--- a/tests/unit/rules/python/stdlib/test_ssl_context_weak_key.py
+++ b/tests/unit/rules/python/stdlib/test_ssl_context_weak_key.py
@@ -49,6 +49,8 @@ class SslSocketWeakKeyTests(test_case.TestCase):
             "ssl_context_set_ecdh_curve_secp256r1.py",
             "ssl_context_set_ecdh_curve_sect163k1.py",
             "ssl_context_set_ecdh_curve_sect571k1.py",
+            "ssl_context_set_ecdh_curve_typed_default_param.py",
+            "ssl_context_set_ecdh_curve_typed_param.py",
             "ssl_context_set_ecdh_curve_unverified_context.py",
         ]
     )


### PR DESCRIPTION
This change utilizes the visitor pattern to process nodes of type typed_parameter and typed_default_parameter instead of manually checking children of the function def. This works because typed parameters are only within function defs.

This commit also adds test cases to ensure this is working.

This change also protects against the traceback found when encountering an unexpected *arg as a function parameter.

Fixes #310