### PR TITLE
Add security-severity property to sarif rules

### DIFF
--- a/precli/core/level.py
+++ b/precli/core/level.py
@@ -23,3 +23,23 @@ class Level(str, enum.Enum):
     WARNING = "warning"
     NOTE = "note"
     NONE = "none"
+
+    def to_severity(self) -> float:
+        """
+        Returns a security severity value.
+
+        Code scanning translates numerical scores as follows:
+        over 9.0 is critical, 7.0 to 8.9 is high, 4.0 to 6.9 is medium and
+        3.9 or less is low.
+
+        :return: severity as float
+        :rtype: float
+        """
+        if self.value == self.ERROR:
+            return 8.0
+        elif self.value == self.WARNING:
+            return 5.0
+        elif self.value == self.NOTE:
+            return 3.0
+        else:
+            return 0.0

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -13,6 +13,7 @@ from precli.renderers import Renderer
 
 
 SCHEMA_URI = "https://json.schemastore.org/sarif-2.1.0.json"
+SCHEMA_VER = "2.1.0"
 TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
@@ -72,6 +73,9 @@ class Json(Renderer):
                         "security",
                         f"external/cwe/cwe-{rule.cwe.cwe_id}",
                     ],
+                    "security-severity": (
+                        rule.default_config.level.to_severity()
+                    ),
                 },
             )
             rules.append(reporting_descriptor)
@@ -91,14 +95,13 @@ class Json(Renderer):
             short_description=sarif_om.MultiformatMessageString(
                 text=run.tool.short_description
             ),
-            version=run.tool.version,
             rules=self.create_rule_array(run),
         )
 
     def render(self, run: Run):
         log = sarif_om.SarifLog(
             schema_uri=SCHEMA_URI,
-            version="2.1.0",
+            version=SCHEMA_URI,
             runs=[
                 sarif_om.Run(
                     tool=sarif_om.Tool(driver=self.create_tool_component(run)),

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -126,6 +126,7 @@ Remediation
 .. versionadded:: 0.2.1
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -143,6 +144,7 @@ class WeakCipher(Rule):
             "known vulnerabilities and weaknesses.",
             targets=("call"),
             wildcards={},
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -163,7 +165,6 @@ class WeakCipher(Rule):
             return Result(
                 rule_id=self.id,
                 location=Location(node=call.function_node),
-                level=Level.ERROR,
                 message=self.message.format(call.name),
                 fixes=fixes,
             )

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -76,6 +76,7 @@ Remediation
 .. versionadded:: 0.2.1
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -93,6 +94,7 @@ class WeakHash(Rule):
             "expectations.",
             targets=("call"),
             wildcards={},
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -111,7 +113,6 @@ class WeakHash(Rule):
             return Result(
                 rule_id=self.id,
                 location=Location(node=call.function_node),
-                level=Level.ERROR,
                 message=self.message.format(call.name_qualified),
                 fixes=fixes,
             )
@@ -128,7 +129,6 @@ class WeakHash(Rule):
             return Result(
                 rule_id=self.id,
                 location=Location(node=call.function_node),
-                level=Level.ERROR,
                 message=self.message.format(call.name_qualified),
                 fixes=fixes,
             )

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -89,6 +89,7 @@ Remediation
 
 """  # noqa: E501
 from precli.core.argument import Argument
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -117,6 +118,7 @@ class HashlibWeakHash(Rule):
                     "sha1",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -144,7 +146,6 @@ class HashlibWeakHash(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=call.function_node),
-                    level=Level.ERROR,
                     message=self.message.format(call.name_qualified),
                 )
         elif call.name_qualified in ["hashlib.pbkdf2_hmac"]:
@@ -163,7 +164,6 @@ class HashlibWeakHash(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=call.function_node),
-                    level=Level.ERROR,
                     message=self.message.format(hash_name),
                 )
         elif call.name_qualified in ["hashlib.new"]:
@@ -181,6 +181,5 @@ class HashlibWeakHash(Rule):
                     return Result(
                         rule_id=self.id,
                         location=Location(node=call.function_node),
-                        level=Level.ERROR,
                         message=self.message.format(name),
                     )

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -82,6 +82,7 @@ Remediation
 .. versionadded:: 0.1.4
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -116,6 +117,7 @@ class HmacTimingAttack(Rule):
                     "HMAC.hexdigest",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -139,7 +141,6 @@ class HmacTimingAttack(Rule):
             return Result(
                 rule_id=self.id,
                 location=Location(node=comparison.operator_node),
-                level=Level.ERROR,
                 message=self.message.format(comparison.operator),
                 fixes=fixes,
             )

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -78,6 +78,7 @@ Remediation
 .. versionadded:: 0.1.0
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -110,6 +111,7 @@ class HmacWeakHash(Rule):
                     "digest",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -128,7 +130,6 @@ class HmacWeakHash(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=argument.node),
-                    level=Level.ERROR,
                     message=self.message.format(digestmod),
                 )
         elif call.name_qualified in ["hmac.digest"]:
@@ -144,6 +145,5 @@ class HmacWeakHash(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=argument.node),
-                    level=Level.ERROR,
                     message=self.message.format(digest),
                 )

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -64,6 +64,7 @@ Remediation
 from urllib.parse import parse_qs
 from urllib.parse import urlsplit
 
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -88,6 +89,7 @@ class HttpUrlSecret(Rule):
                     "HTTPSConnection",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -109,5 +111,4 @@ class HttpUrlSecret(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=argument.node),
-                    level=Level.ERROR,
                 )

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -73,6 +73,7 @@ Remediation
 .. versionadded:: 0.1.9
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -94,6 +95,7 @@ class ImapCleartext(Rule):
                     "IMAP4",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -121,7 +123,6 @@ class ImapCleartext(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=call.identifier_node),
-                    level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "
                     f"transmit authentication information such as a user, "
                     "password in cleartext.",

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -57,6 +57,7 @@ Remediation
 .. versionadded:: 0.1.9
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -78,6 +79,7 @@ class NntpCleartext(Rule):
                     "NNTP",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -101,7 +103,6 @@ class NntpCleartext(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=call.identifier_node),
-                    level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "
                     f"transmit authentication information such as a user, "
                     "password in cleartext.",

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -69,6 +69,7 @@ Remediation
 .. versionadded:: 0.1.9
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -90,6 +91,7 @@ class PopCleartext(Rule):
                     "POP3",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -118,7 +120,6 @@ class PopCleartext(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=call.identifier_node),
-                    level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "
                     f"transmit authentication information such as a user, "
                     "password in cleartext.",

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -102,6 +102,7 @@ Remediation
 .. versionadded:: 0.1.9
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -123,6 +124,7 @@ class SmtpCleartext(Rule):
                     "SMTP",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -149,7 +151,6 @@ class SmtpCleartext(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=call.identifier_node),
-                    level=Level.ERROR,
                     message=f"The '{call.name_qualified}' function will "
                     f"transmit authentication information such as a user, "
                     "password in cleartext.",

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -77,6 +77,7 @@ Remediation
 
 """  # noqa: E501
 from precli.core.argument import Argument
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -100,6 +101,7 @@ class InsecureTlsVersion(Rule):
             cwe_id=326,
             message="The '{0}' protocol has insufficient encryption strength.",
             targets=("call"),
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -129,7 +131,6 @@ class InsecureTlsVersion(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=argument.identifier_node),
-                    level=Level.ERROR,
                     message=self.message.format(version),
                     fixes=fixes,
                 )
@@ -169,7 +170,6 @@ class InsecureTlsVersion(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=argument.identifier_node),
-                    level=Level.ERROR,
                     message=self.message.format(version),
                     fixes=fixes,
                 )
@@ -196,7 +196,6 @@ class InsecureTlsVersion(Rule):
                 return Result(
                     rule_id=self.id,
                     location=Location(node=argument.identifier_node),
-                    level=Level.ERROR,
                     message=self.message.format(protocol),
                     fixes=fixes,
                 )

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -113,6 +113,7 @@ These alternatives include:
 .. versionadded:: 0.1.0
 
 """  # noqa: E501
+from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -134,6 +135,7 @@ class TelnetlibCleartext(Rule):
                     "Telnet",
                 ]
             },
+            config=Config(level=Level.ERROR),
         )
 
     def analyze(self, context: dict, **kwargs: dict) -> Result:
@@ -143,6 +145,5 @@ class TelnetlibCleartext(Rule):
             return Result(
                 rule_id=self.id,
                 location=Location(node=call.function_node),
-                level=Level.ERROR,
                 message=self.message.format(call.name_qualified),
             )

--- a/tests/unit/rules/go/stdlib/test_crypto_weak_cipher.py
+++ b/tests/unit/rules/go/stdlib/test_crypto_weak_cipher.py
@@ -33,7 +33,7 @@ class CryptoWeakCipherTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("327", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/go/stdlib/test_crypto_weak_hash.py
+++ b/tests/unit/rules/go/stdlib/test_crypto_weak_hash.py
@@ -31,7 +31,7 @@ class CryptoWeakHashTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("328", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_hashlib_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/test_hashlib_weak_hash.py
@@ -31,7 +31,7 @@ class HashlibWeakHashTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("328", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_hmac_timing_attack.py
+++ b/tests/unit/rules/python/stdlib/test_hmac_timing_attack.py
@@ -31,7 +31,7 @@ class HmacTimingAttackTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("208", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_hmac_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/test_hmac_weak_hash.py
@@ -31,7 +31,7 @@ class HmacWeakHashTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("328", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_http_url_secret.py
+++ b/tests/unit/rules/python/stdlib/test_http_url_secret.py
@@ -31,7 +31,7 @@ class HttpUrlSecretTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("598", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_imaplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/test_imaplib_cleartext.py
@@ -31,7 +31,7 @@ class ImapCleartextTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("319", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_nntplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/test_nntplib_cleartext.py
@@ -31,7 +31,7 @@ class NntpCleartextTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("319", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_poplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/test_poplib_cleartext.py
@@ -31,7 +31,7 @@ class PopCleartextTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("319", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_smtplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/test_smtplib_cleartext.py
@@ -31,7 +31,7 @@ class SmtpCleartextTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("319", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_ssl_context_tls_version.py
+++ b/tests/unit/rules/python/stdlib/test_ssl_context_tls_version.py
@@ -31,7 +31,7 @@ class SslSocketTlsVersionTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("326", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_ssl_get_server_certificate_tls_version.py
+++ b/tests/unit/rules/python/stdlib/test_ssl_get_server_certificate_tls_version.py
@@ -31,7 +31,7 @@ class GetServerCertificateTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("326", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_ssl_wrap_socket_tls_version.py
+++ b/tests/unit/rules/python/stdlib/test_ssl_wrap_socket_tls_version.py
@@ -31,7 +31,7 @@ class WrapSocketTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("326", rule.cwe.cwe_id)
 

--- a/tests/unit/rules/python/stdlib/test_telnetlib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/test_telnetlib_cleartext.py
@@ -31,7 +31,7 @@ class TelnetlibCleartextTests(test_case.TestCase):
             f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
         )
         self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
         self.assertEqual(-1.0, rule.default_config.rank)
         self.assertEqual("319", rule.cwe.cwe_id)
 


### PR DESCRIPTION
In order for GitHub to render a High, Medium, Low for results it requires the security-severity to be set.

This also means each rule needs a default level specific to it to be set. Before it was defaulting to warning, but now will default to the minimum possible value of level in results.