### PR TITLE
Add rule descriptions to SARIF output

### DIFF
--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -63,6 +63,12 @@ class Json(Renderer):
                 id=rule.id,
                 name=rule.__class__.__name__,
                 help_uri=rule.help_url,
+                short_description=sarif_om.MultiformatMessageString(
+                    text=rule.short_description
+                ),
+                full_description=sarif_om.MultiformatMessageString(
+                    text=rule.full_description
+                ),
                 message_strings={
                     "default": sarif_om.MultiformatMessageString(
                         text=rule.message

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -76,7 +76,7 @@ class Rule(ABC):
         return self._name
 
     @property
-    def short_descr(self) -> str:
+    def short_description(self) -> str:
         """
         Short description of the rule.
 
@@ -84,17 +84,17 @@ class Rule(ABC):
         :rtype: str
         """
         try:
-            start = self._full_descr.rindex("===\n") + 4
+            start = self._full_descr.index("\n\n") + 2
         except ValueError:
             start = 0
         try:
-            end = self._full_descr.index("\n---")
+            end = self._full_descr.index("\n##")
         except ValueError:
             end = len(self._full_descr)
         return self._full_descr[start:end]
 
     @property
-    def full_descr(self) -> str:
+    def full_description(self) -> str:
         """
         Full description of the rule.
 


### PR DESCRIPTION
Now that the docstrings are in markdown format, we can safely add them as rule descriptions to the SARIF output so we get better contextual information on a result.