### PR TITLE
Clean up the description text for rules

### DIFF
--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Saurce LLC
+# Copyright 2024 Secure Saurce LLC
 from abc import ABC
 from abc import abstractmethod
 from typing import Self
@@ -19,7 +19,7 @@ class Rule(ABC):
         self,
         id: str,
         name: str,
-        full_descr: str,
+        description: str,
         cwe_id: int,
         message: str,
         targets: set[str],
@@ -29,7 +29,20 @@ class Rule(ABC):
     ):
         self._id = id
         self._name = name
-        self._full_descr = full_descr
+        try:
+            start = description.index("\n# ") + 3
+        except ValueError:
+            start = 0
+        try:
+            end = description.index("\n\n")
+        except ValueError:
+            end = len(description)
+        self._short_descr = description[start:end].replace("`", "")
+        try:
+            start = description.index("\n\n") + 2
+        except ValueError:
+            start = 0
+        self._full_descr = description[start:]
         self._cwe = Rule._cwedb.get(cwe_id)
         self._message = message
         self._targets = targets
@@ -83,20 +96,12 @@ class Rule(ABC):
         :return: rule short description
         :rtype: str
         """
-        try:
-            start = self._full_descr.index("\n# ") + 3
-        except ValueError:
-            start = 0
-        try:
-            end = self._full_descr.index("\n\n")
-        except ValueError:
-            end = len(self._full_descr)
-        return self._full_descr[start:end]
+        return self._short_descr
 
     @property
     def full_description(self) -> str:
         """
-        Full description of the rule.
+        Full description of the rule in markdown format.
 
         :return: rule full description
         :rtype: str

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -124,7 +124,7 @@ class WeakCipher(Rule):
         super().__init__(
             id=id,
             name="use_of_a_broken_or_risky_cryptographic_algorithm",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=327,
             message="Weak ciphers like '{0}' should be avoided due to their "
             "known vulnerabilities and weaknesses.",

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -75,7 +75,7 @@ class WeakHash(Rule):
         super().__init__(
             id=id,
             name="reversible_one_way_hash",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -90,7 +90,7 @@ class WeakKey(Rule):
         super().__init__(
             id=id,
             name="inadequate_encryption_strength",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=326,
             message="Using '{0}' key sizes less than '{1}' bits is considered "
             "vulnerable to attacks.",

--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -61,7 +61,7 @@ class Assert(Rule):
         super().__init__(
             id=id,
             name="improper_check",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=703,
             message="Assert statements are disabled when optimizations are "
             "enabled.",

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -96,7 +96,7 @@ class CryptWeakHash(Rule):
         super().__init__(
             id=id,
             name="reversible_one_way_hash",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -82,7 +82,7 @@ class FtpCleartext(Rule):
         super().__init__(
             id=id,
             name="cleartext_transmission",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=319,
             message="The FTP protocol can transmit data in cleartext without "
             "encryption.",

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -86,7 +86,7 @@ class HashlibWeakHash(Rule):
         super().__init__(
             id=id,
             name="reversible_one_way_hash",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -89,7 +89,7 @@ class HmacTimingAttack(Rule):
         super().__init__(
             id=id,
             name="observable_timing_discrepancy",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=208,
             message="Comparing digests with the '{0}' operator is vulnerable "
             "to timing attacks.",

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -86,7 +86,7 @@ class HmacWeakHash(Rule):
         super().__init__(
             id=id,
             name="reversible_one_way_hash",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -65,7 +65,7 @@ class HttpUrlSecret(Rule):
         super().__init__(
             id=id,
             name="sensitive_query_strings",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=598,
             message="Secrets in URLs are vulnerable to unauthorized access.",
             targets=("call"),

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -71,7 +71,7 @@ class ImapCleartext(Rule):
         super().__init__(
             id=id,
             name="cleartext_transmission",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=319,
             message="The IMAP protocol can transmit data in cleartext without "
             "encryption.",

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -42,7 +42,7 @@ class JsonLoad(Rule):
         super().__init__(
             id=id,
             name="deserialization_of_untrusted_data",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -53,7 +53,7 @@ class InsecureListenConfig(Rule):
         super().__init__(
             id=id,
             name="code_injection",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=94,
             message="Using '{0}' with unset 'verify' vulnerable to code "
             "injection.",

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -46,7 +46,7 @@ class MarshalLoad(Rule):
         super().__init__(
             id=id,
             name="deserialization_of_untrusted_data",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -55,7 +55,7 @@ class NntpCleartext(Rule):
         super().__init__(
             id=id,
             name="cleartext_transmission",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=319,
             message="The NNTP protocol can transmit data in cleartext without "
             "encryption.",

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -58,7 +58,7 @@ class PickleLoad(Rule):
         super().__init__(
             id=id,
             name="deserialization_of_untrusted_data",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -67,7 +67,7 @@ class PopCleartext(Rule):
         super().__init__(
             id=id,
             name="cleartext_transmission",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -45,7 +45,7 @@ class ShelveOpen(Rule):
         super().__init__(
             id=id,
             name="deserialization_of_untrusted_data",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -100,7 +100,7 @@ class SmtpCleartext(Rule):
         super().__init__(
             id=id,
             name="cleartext_transmission",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -62,7 +62,7 @@ class SslContextWeakKey(Rule):
         super().__init__(
             id=id,
             name="inadequate_encryption_strength",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=326,
             message="Using '{0}' key sizes less than '{1}' bits is considered "
             "vulnerable to attacks.",

--- a/precli/rules/python/stdlib/ssl_create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl_create_unverified_context.py
@@ -55,7 +55,7 @@ class CreateUnverifiedContext(Rule):
         super().__init__(
             id=id,
             name="improper_certificate_validation",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates.",

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -83,7 +83,7 @@ class InsecureTlsVersion(Rule):
         super().__init__(
             id=id,
             name="inadequate_encryption_strength",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=326,
             message="The '{0}' protocol has insufficient encryption strength.",
             targets=("call"),

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -109,7 +109,7 @@ class TelnetlibCleartext(Rule):
         super().__init__(
             id=id,
             name="cleartext_transmission",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=319,
             message="The '{0}' module transmits data in cleartext without "
             "encryption.",

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -54,7 +54,7 @@ class MktempRaceCondition(Rule):
         super().__init__(
             id=id,
             name="insecure_temporary_file",
-            full_descr=__doc__,
+            description=__doc__,
             cwe_id=377,
             message="The function '{0}' can allow insecure ways of creating "
             "temporary files and directories that can lead to race "


### PR DESCRIPTION
* The short description should not contain markdown
* The long description should begin after the title or what is used for the short description.