### PR TITLE
Keep SARIF output as minimal as possible

### DIFF
--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -8,8 +8,10 @@ import sarif_om
 from jschema_to_python.to_json import to_json
 
 from precli.core.fix import Fix
+from precli.core.result import Result
 from precli.core.run import Run
 from precli.renderers import Renderer
+from precli.rules import Rule
 
 
 SCHEMA_URI = "https://json.schemastore.org/sarif-2.1.0.json"
@@ -55,38 +57,40 @@ class Json(Renderer):
             description=sarif_om.Message(text=fix.description),
         )
 
-    def create_rule_array(self, run: Run):
-        rules = []
+    def create_rule_if_not_exists(
+        self, result: Result, rules: dict, rule_indices: dict
+    ):
+        rule = Rule.get_by_id(result.rule_id)
+        if rule.id in rules:
+            return rules[rule.id], rule_indices[rule.id]
 
-        for rule in run.tool.rules:
-            reporting_descriptor = sarif_om.ReportingDescriptor(
-                id=rule.id,
-                name=rule.__class__.__name__,
-                help_uri=rule.help_url,
-                short_description=sarif_om.MultiformatMessageString(
-                    text=rule.short_description
-                ),
-                help=sarif_om.MultiformatMessageString(
-                    text=rule.full_description, markdown=rule.full_description
-                ),
-                message_strings={
-                    "default": sarif_om.MultiformatMessageString(
-                        text=rule.message
-                    )
-                },
-                properties={
-                    "tags": [
-                        "security",
-                        f"external/cwe/cwe-{rule.cwe.cwe_id}",
-                    ],
-                    "security-severity": (
-                        rule.default_config.level.to_severity()
-                    ),
-                },
-            )
-            rules.append(reporting_descriptor)
+        reporting_descriptor = sarif_om.ReportingDescriptor(
+            id=rule.id,
+            name=rule.__class__.__name__,
+            help_uri=rule.help_url,
+            short_description=sarif_om.MultiformatMessageString(
+                text=rule.short_description
+            ),
+            help=sarif_om.MultiformatMessageString(
+                text=rule.full_description, markdown=rule.full_description
+            ),
+            message_strings={
+                "default": sarif_om.MultiformatMessageString(text=rule.message)
+            },
+            properties={
+                "tags": [
+                    "security",
+                    f"external/cwe/cwe-{rule.cwe.cwe_id}",
+                ],
+                "security-severity": (rule.default_config.level.to_severity()),
+            },
+        )
 
-        return rules
+        index = len(rules)
+        rules[rule.id] = reporting_descriptor
+        rule_indices[rule.id] = index
+
+        return reporting_descriptor, index
 
     def create_tool_component(self, run: Run):
         return sarif_om.ToolComponent(
@@ -101,7 +105,6 @@ class Json(Renderer):
             short_description=sarif_om.MultiformatMessageString(
                 text=run.tool.short_description
             ),
-            rules=self.create_rule_array(run),
         )
 
     def render(self, run: Run):
@@ -124,7 +127,14 @@ class Json(Renderer):
         sarif_run = log.runs[0]
         sarif_run.results = []
 
+        rules = {}
+        rule_indices = {}
+
         for result in run.results:
+            rule, rule_index = self.create_rule_if_not_exists(
+                result, rules, rule_indices
+            )
+
             fixes = []
             for fix in result.fixes:
                 fixes.append(self.to_fix(result.artifact.file_name, fix))
@@ -152,14 +162,19 @@ class Json(Renderer):
             )
 
             sarif_result = sarif_om.Result(
+                rule_id=rule.id,
+                rule_index=rule_index,
                 message=sarif_om.Message(text=result.message),
                 fixes=fixes,
                 level=result.level.name.lower(),
                 locations=[
                     sarif_om.Location(physical_location=physical_location),
                 ],
-                rule_id=result.rule_id,
             )
 
             sarif_run.results.append(sarif_result)
+
+        if rules:
+            sarif_run.tool.driver.rules = list(rules.values())
+
         self.console.print_json(to_json(log))


### PR DESCRIPTION
This change will only populate the rules structure of the run.tool for rules of results found in the analysis. It won't colate all the rules possible, in order to keep the SARIF output file as small as possible.