### PR TITLE
Skip build for changes to README

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,9 @@
 name: Build and Test
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.rst'
 
 jobs:
   format:


### PR DESCRIPTION
If just the README file was changed, don't re-run all the tests as it won't have any effect on them.