### PR TITLE
Add new rule to check for no context being passed to FTP_TLS

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -33,3 +33,4 @@
 | PY019 | [ssl — weak key](rules/python/stdlib/ssl_context_weak_key.md) | Inadequate Encryption Strength Using Weak SSL Protocols |
 | PY020 | [telnetlib — cleartext](rules/python/stdlib/telnetlib_cleartext.md) | Cleartext Transmission of Sensitive Information in the `telnetlib` Module |
 | PY021 | [tempfile — mktemp race condition](rules/python/stdlib/tempfile_mktemp_race_condition.md) | Insecure Temporary File in the ``tempfile`` Module |
+| PY022 | [ftplib — unverified context](rules/python/stdlib/ftplib_unverified_context.md) | Improper Certificate Validation Using `ftplib` |

--- a/docs/rules/python/stdlib/ftplib_unverified_context.md
+++ b/docs/rules/python/stdlib/ftplib_unverified_context.md
@@ -1,0 +1,3 @@
+# ftplib — unverified context
+
+::: precli.rules.python.stdlib.ftplib_unverified_context

--- a/precli/core/call.py
+++ b/precli/core/call.py
@@ -118,6 +118,10 @@ class Call:
         """
         return self._name_qual
 
+    @property
+    def arg_list_node(self) -> Node:
+        return self._arg_list_node
+
     def get_argument(
         self, position: int = -1, name: str = None, default: Argument = None
     ) -> Argument:

--- a/precli/rules/python/stdlib/ftplib_unverified_context.py
+++ b/precli/rules/python/stdlib/ftplib_unverified_context.py
@@ -1,0 +1,114 @@
+# Copyright 2024 Secure Saurce LLC
+r"""
+# Improper Certificate Validation Using `ftplib`
+
+The Python class `ftplib.FTP_TLS` by default creates an SSL context that does
+not verify the server's certificate if the context parameter is unset or has
+a value of None. This means that an attacker can easily impersonate a
+legitimate server and fool your application into connecting to it.
+
+If you use `ftplib.FTP_TLS` without a context set, you are opening your
+application up to a number of security risks, including:
+
+- Man-in-the-middle attacks
+- Session hijacking
+- Data theft
+
+## Example
+
+```python
+import ftplib
+
+
+with ftplib.FTP_TLS("ftp.us.debian.org") as ftp:
+    ftp.cwd("debian")
+    ftp.retrlines("LIST")
+```
+
+## Remediation
+
+Set the value of the context keyword argument to `ssl.create_default_context()`
+to ensure the connection is fully verified.
+
+```python
+import ftplib
+import ssl
+
+
+with ftplib.FTP_TLS(
+    "ftp.us.debian.org",
+    context=ssl.create_default_context(),
+) as ftp:
+    ftp.cwd("debian")
+    ftp.retrlines("LIST")
+```
+
+## See also
+
+- [ftplib — FTP protocol client](https://docs.python.org/3/library/ftplib.html#ftplib.FTP_TLS)
+- [ssl — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/ssl.html#best-defaults)
+- [CWE-295: Improper Certificate Validation](https://cwe.mitre.org/data/definitions/295.html)
+
+_New in version 0.3.14_
+
+"""  # noqa: E501
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+CONTEXT_FIX = "ssl.create_default_context()"
+
+
+class FtplibUnverifiedContext(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="improper_certificate_validation",
+            description=__doc__,
+            cwe_id=295,
+            message="The '{0}' function does not properly validate "
+            "certificates when context is unset or None.",
+            targets=("call"),
+            wildcards={
+                "ftplib.*": [
+                    "FTP_TLS",
+                ]
+            },
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+        if call.name_qualified not in ["ftplib.FTP_TLS"]:
+            return
+
+        context_arg = call.get_argument(name="context")
+        if context_arg.value is not None:
+            return
+
+        if context_arg.node is not None:
+            result_node = context_arg.node
+            fix_node = context_arg.node
+            content = CONTEXT_FIX
+        else:
+            result_node = call.function_node
+            arg_list_node = call.arg_list_node
+            fix_node = arg_list_node
+            args = [
+                child.text.decode() for child in arg_list_node.named_children
+            ]
+            args.append(f"context={CONTEXT_FIX}")
+            content = f"({', '.join(args)})"
+
+        fixes = Rule.get_fixes(
+            context=context,
+            deleted_location=Location(node=fix_node),
+            description=f"Pass {CONTEXT_FIX} to safely validate certificates.",
+            inserted_content=content,
+        )
+        return Result(
+            rule_id=self.id,
+            location=Location(node=result_node),
+            message=self.message.format(call.name_qualified),
+            fixes=fixes,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,6 +110,9 @@ precli.rules.python =
     # precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
     PY021 = precli.rules.python.stdlib.tempfile_mktemp_race_condition:MktempRaceCondition
 
+    # precli/rules/python/stdlib/ftplib_unverified_context.py
+    PY022 = precli.rules.python.stdlib.ftplib_unverified_context:FtplibUnverifiedContext
+
 [build_sphinx]
 all_files = 1
 build-dir = docs/build

--- a/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_context_as_var.py
+++ b/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_context_as_var.py
@@ -1,0 +1,20 @@
+# level: WARNING
+# start_line: 12
+# end_line: 12
+# start_column: 12
+# end_column: 19
+import ftplib
+
+
+context = None
+ftp = ftplib.FTP_TLS(
+    "ftp.us.debian.org",
+    context=context,
+    encoding="utf-8",
+)
+ftp.login()
+
+ftp.cwd("debian")
+ftp.retrlines("LIST")
+
+ftp.quit()

--- a/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_context_none.py
+++ b/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_context_none.py
@@ -1,11 +1,15 @@
-# level: NONE
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 12
+# end_column: 16
 import ftplib
-import ssl
 
 
 ftp = ftplib.FTP_TLS(
     "ftp.us.debian.org",
-    context=ssl.create_default_context(),
+    context=None,
+    encoding="utf-8",
 )
 ftp.login()
 

--- a/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_context_unset.py
+++ b/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_context_unset.py
@@ -1,0 +1,15 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 6
+# end_column: 20
+import ftplib
+
+
+ftp = ftplib.FTP_TLS("ftp.us.debian.org")
+ftp.login()
+
+ftp.cwd("debian")
+ftp.retrlines("LIST")
+
+ftp.quit()

--- a/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_user_password.py
+++ b/tests/unit/rules/python/stdlib/examples/ftplib_ftp_tls_user_password.py
@@ -1,8 +1,14 @@
 # level: NONE
 import ftplib
+import ssl
 
 
-ftp = ftplib.FTP_TLS("ftp.us.debian.org", "user", "password")
+ftp = ftplib.FTP_TLS(
+    "ftp.us.debian.org",
+    "user",
+    "password",
+    context=ssl.create_default_context(),
+)
 ftp.login()
 
 ftp.cwd("debian")

--- a/tests/unit/rules/python/stdlib/test_ftplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/test_ftplib_unverified_context.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Secure Saurce LLC
+import os
+
+from parameterized import parameterized
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class FtplibUnverifiedContextTests(test_case.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule_id = "PY022"
+        self.parser = python.Python()
+        self.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        self.assertEqual(self.rule_id, rule.id)
+        self.assertEqual("improper_certificate_validation", rule.name)
+        self.assertEqual(
+            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        )
+        self.assertEqual(True, rule.default_config.enabled)
+        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(-1.0, rule.default_config.rank)
+        self.assertEqual("295", rule.cwe.cwe_id)
+
+    @parameterized.expand(
+        [
+            "ftplib_ftp_tls_context_as_var.py",
+            "ftplib_ftp_tls_context_none.py",
+            "ftplib_ftp_tls_context_unset.py",
+        ]
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
If a context of unset or None is passed to FTP_TLS, the implementation will default to creating an unverified context. This means the client connection will not properly verify the server its connecting to.

Closes: #341