### PR TITLE
Add new rule to check for context=None in stls or POP3_SSL

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -36,3 +36,4 @@
 | PY022 | [ftplib — unverified context](rules/python/stdlib/ftplib_unverified_context.md) | Improper Certificate Validation Using `ftplib` |
 | PY023 | [imaplib — unverified context](rules/python/stdlib/imaplib_unverified_context.md) | Improper Certificate Validation Using `imaplib` |
 | PY024 | [nntplib — unverified context](rules/python/stdlib/nntplib_unverified_context.md) | Improper Certificate Validation Using `nntplib` |
+| PY025 | [poplib — unverified context](rules/python/stdlib/poplib_unverified_context.md) | Improper Certificate Validation Using `poplib` |

--- a/docs/rules/python/stdlib/poplib_unverified_context.md
+++ b/docs/rules/python/stdlib/poplib_unverified_context.md
@@ -1,0 +1,3 @@
+# poplib — unverified context
+
+::: precli.rules.python.stdlib.poplib_unverified_context

--- a/precli/rules/python/stdlib/poplib_unverified_context.py
+++ b/precli/rules/python/stdlib/poplib_unverified_context.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Secure Saurce LLC
+r"""
+# Improper Certificate Validation Using `poplib`
+
+The Python class `poplib.POP3_SSL` by default creates an SSL context that
+does not verify the server's certificate if the context parameter is unset or
+has a value of None. This means that an attacker can easily impersonate a
+legitimate server and fool your application into connecting to it.
+
+If you use `poplib.POP3_SSL` or `stls` without a context set, you are
+opening your application up to a number of security risks, including:
+
+- Man-in-the-middle attacks
+- Session hijacking
+- Data theft
+
+## Example
+
+```python
+import poplib
+
+
+with poplib.POP3("domain.org") as pop3:
+    pop3.user("user")
+```
+
+## Remediation
+
+Set the value of the `context` keyword argument to
+`ssl.create_default_context()` to ensure the connection is fully verified.
+
+```python
+import poplib
+import ssl
+
+
+with poplib.POP3(
+    "domain.org",
+    context=ssl.create_default_context(),
+) as pop3:
+    pop3.user("user")
+```
+
+## See also
+
+- [poplib.POP3_SSL — POP3 protocol client](https://docs.python.org/3/library/poplib.html#nntplib.POP3_SSL)
+- [poplib.POP3.stls — POP3 protocol client](https://docs.python.org/3/library/poplib.html#poplib.POP3.stls)
+- [ssl — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/ssl.html#best-defaults)
+- [CWE-295: Improper Certificate Validation](https://cwe.mitre.org/data/definitions/295.html)
+
+_New in version 0.3.14_
+
+"""  # noqa: E501
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+CONTEXT_FIX = "ssl.create_default_context()"
+
+
+class PoplibUnverifiedContext(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="improper_certificate_validation",
+            description=__doc__,
+            cwe_id=295,
+            message="The '{0}' function does not properly validate "
+            "certificates when context is unset or None.",
+            targets=("call"),
+            wildcards={
+                "poplib.*": [
+                    "POP3",
+                ]
+            },
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+        if call.name_qualified not in [
+            "poplib.POP3_SSL",
+            "poplib.POP3.stls",
+        ]:
+            return
+
+        if call.name_qualified == "poplib.POP3_SSL":
+            ssl_context = call.get_argument(name="context")
+        else:
+            ssl_context = call.get_argument(position=0, name="context")
+        if ssl_context.value is not None:
+            return
+
+        if ssl_context.node is not None:
+            result_node = ssl_context.node
+            fix_node = ssl_context.node
+            content = CONTEXT_FIX
+        else:
+            result_node = call.function_node
+            arg_list_node = call.arg_list_node
+            fix_node = arg_list_node
+            args = [
+                child.text.decode() for child in arg_list_node.named_children
+            ]
+            args.append(f"context={CONTEXT_FIX}")
+            content = f"({', '.join(args)})"
+
+        fixes = Rule.get_fixes(
+            context=context,
+            deleted_location=Location(node=fix_node),
+            description=f"Pass {CONTEXT_FIX} to safely validate certificates.",
+            inserted_content=content,
+        )
+        return Result(
+            rule_id=self.id,
+            location=Location(node=result_node),
+            message=self.message.format(call.name_qualified),
+            fixes=fixes,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,6 +119,9 @@ precli.rules.python =
     # precli/rules/python/stdlib/nntplib_unverified_context.py
     PY024 = precli.rules.python.stdlib.nntplib_unverified_context:NntplibUnverifiedContext
 
+    # precli/rules/python/stdlib/poplib_unverified_context.py
+    PY025 = precli.rules.python.stdlib.poplib_unverified_context:PoplibUnverifiedContext
+
 [build_sphinx]
 all_files = 1
 build-dir = docs/build

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl.py
@@ -1,9 +1,10 @@
 # level: NONE
 import getpass
 import poplib
+import ssl
 
 
-M = poplib.POP3_SSL("localhost")
+M = poplib.POP3_SSL("localhost", context=ssl.create_default_context())
 M.user(getpass.getuser())
 M.pass_(getpass.getpass())
 numMessages = len(M.list()[1])

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl_context_as_var.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl_context_as_var.py
@@ -1,11 +1,14 @@
-# level: NONE
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 41
+# end_column: 48
 import getpass
 import poplib
-import ssl
 
 
-M = poplib.POP3("localhost")
-M.stls(context=ssl.create_default_context())
+context = None
+M = poplib.POP3_SSL("localhost", context=context)
 M.user(getpass.getuser())
 M.pass_(getpass.getpass())
 numMessages = len(M.list()[1])

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl_context_none.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl_context_none.py
@@ -1,11 +1,13 @@
-# level: NONE
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 41
+# end_column: 45
 import getpass
 import poplib
-import ssl
 
 
-M = poplib.POP3("localhost")
-M.stls(context=ssl.create_default_context())
+M = poplib.POP3_SSL("localhost", context=None)
 M.user(getpass.getuser())
 M.pass_(getpass.getpass())
 numMessages = len(M.list()[1])

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl_context_unset.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_ssl_context_unset.py
@@ -1,11 +1,13 @@
-# level: NONE
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 4
+# end_column: 19
 import getpass
 import poplib
-import ssl
 
 
-M = poplib.POP3("localhost")
-M.stls(context=ssl.create_default_context())
+M = poplib.POP3_SSL("localhost")
 M.user(getpass.getuser())
 M.pass_(getpass.getpass())
 numMessages = len(M.list()[1])

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_stls_context_as_var.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_stls_context_as_var.py
@@ -1,11 +1,15 @@
-# level: NONE
+# level: WARNING
+# start_line: 12
+# end_line: 12
+# start_column: 15
+# end_column: 22
 import getpass
 import poplib
-import ssl
 
 
+context = None
 M = poplib.POP3("localhost")
-M.stls(context=ssl.create_default_context())
+M.stls(context=context)
 M.user(getpass.getuser())
 M.pass_(getpass.getpass())
 numMessages = len(M.list()[1])

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_stls_context_none.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_stls_context_none.py
@@ -1,11 +1,14 @@
-# level: NONE
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 15
+# end_column: 19
 import getpass
 import poplib
-import ssl
 
 
 M = poplib.POP3("localhost")
-M.stls(context=ssl.create_default_context())
+M.stls(context=None)
 M.user(getpass.getuser())
 M.pass_(getpass.getpass())
 numMessages = len(M.list()[1])

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_stls_context_unset.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_stls_context_unset.py
@@ -1,11 +1,14 @@
-# level: NONE
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 0
+# end_column: 6
 import getpass
 import poplib
-import ssl
 
 
 M = poplib.POP3("localhost")
-M.stls(context=ssl.create_default_context())
+M.stls()
 M.user(getpass.getuser())
 M.pass_(getpass.getpass())
 numMessages = len(M.list()[1])

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Secure Saurce LLC
+import os
+
+from parameterized import parameterized
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class PoplibUnverifiedContextTests(test_case.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule_id = "PY025"
+        self.parser = python.Python()
+        self.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "poplib",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        self.assertEqual(self.rule_id, rule.id)
+        self.assertEqual("improper_certificate_validation", rule.name)
+        self.assertEqual(
+            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        )
+        self.assertEqual(True, rule.default_config.enabled)
+        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(-1.0, rule.default_config.rank)
+        self.assertEqual("295", rule.cwe.cwe_id)
+
+    @parameterized.expand(
+        [
+            "poplib_pop3_ssl_context_as_var.py",
+            "poplib_pop3_ssl_context_none.py",
+            "poplib_pop3_ssl_context_unset.py",
+            "poplib_pop3_stls_context_as_var.py",
+            "poplib_pop3_stls_context_none.py",
+            "poplib_pop3_stls_context_unset.py",
+        ]
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
If a context of unset or None is passed to POP3_SSL, the implementation will default to creating an unverified context. This means the client connection will not properly verify the server its connecting to. The instance method of stls is also vulnerable.

Closes: #344