### PR TITLE
Add rule on argparse to check for an argument of password

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -38,3 +38,4 @@
 | PY024 | [nntplib — unverified context](rules/python/stdlib/nntplib_unverified_context.md) | Improper Certificate Validation Using `nntplib` |
 | PY025 | [poplib — unverified context](rules/python/stdlib/poplib_unverified_context.md) | Improper Certificate Validation Using `poplib` |
 | PY026 | [smtplib — unverified context](rules/python/stdlib/smtplib_unverified_context.md) | Improper Certificate Validation Using `smtplib` |
+| PY027 | [argparse — sensitive info](rules/python/stdlib/argparse_sensitive_info.md) | Invocation of Process Using Visible Sensitive Information in `argparse` |

--- a/docs/rules/python/stdlib/argparse_sensitive_info.md
+++ b/docs/rules/python/stdlib/argparse_sensitive_info.md
@@ -1,0 +1,3 @@
+# argparse — sensitive info
+
+::: precli.rules.python.stdlib.argparse_sensitive_info

--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -1,0 +1,107 @@
+# Copyright 2024 Secure Saurce LLC
+r"""
+# Invocation of Process Using Visible Sensitive Information in `argparse`
+
+Do not read secrets directly from command line arguments. When a command
+accepts a secret like via a --password argument, the argument value will
+leak the secret into ps output and shell history. This also encourages the
+use of insecure environment variables for secrets.
+
+## Example
+
+```python
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog='ProgramName',
+    description='What the program does',
+)
+parser.add_argument(
+    "-p",
+    "--password",
+    dest="password",
+    action="store",
+    help="password for the database",
+)
+```
+
+## Remediation
+
+Consider accepting sensitive data only from an interactive hidden prompt or
+via files. A --password-file argument allows a secret to be passed in
+discreetly, in a wide variety of contexts.
+
+```python
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog='ProgramName',
+    description='What the program does',
+)
+parser.add_argument(
+    "-p",
+    "--password",
+    dest="password",
+    action="store_true",
+    help="password for the database",
+)
+```
+
+## See also
+
+- [argparse — Parser for command-line options, arguments and sub-commands](https://docs.python.org/3/library/argparse.html)
+- [CWE-214: Invocation of Process Using Visible Sensitive Information](https://cwe.mitre.org/data/definitions/214.html)
+
+_New in version 0.3.14_
+
+"""  # noqa: E501
+from precli.core.config import Config
+from precli.core.level import Level
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class ArgparseSensitiveInfo(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="visible_sensitive_information",
+            description=__doc__,
+            cwe_id=214,
+            message="{0} in CLI arguments are leaked to command history, "
+            "logs, ps output, etc.",
+            targets=("call"),
+            wildcards={
+                "argparse.*": [
+                    "ArgumentParser",
+                ]
+            },
+            config=Config(level=Level.ERROR),
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+        if call.name_qualified not in [
+            "argparse.ArgumentParser.add_argument",
+        ]:
+            return
+
+        # add_argument(*args, **kwargs)
+        # add_argument(dest, ..., name=value, ...)
+        # add_argument(option_string, option_string, ..., name=value, ...)
+        arg0 = call.get_argument(position=0)
+        arg1 = call.get_argument(position=1)
+        action = call.get_argument(name="action")
+
+        if (
+            "--password" in [arg0.value, arg1.value]
+            and action.value == "store"
+        ):
+            return Result(
+                rule_id=self.id,
+                location=Location(node=call.node),
+                message=self.message.format("Passwords"),
+            )

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -70,7 +70,7 @@ class HttpUrlSecret(Rule):
             message="Secrets in URLs are vulnerable to unauthorized access.",
             targets=("call"),
             wildcards={
-                "http.client": [
+                "http.client.*": [
                     "HTTPConnection",
                     "HTTPSConnection",
                 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,6 +125,9 @@ precli.rules.python =
     # precli/rules/python/stdlib/smtplib_unverified_context.py
     PY026 = precli.rules.python.stdlib.smtplib_unverified_context:SmtplibUnverifiedContext
 
+    # precli/rules/python/stdlib/argparse_sensitive_info.py
+    PY027 = precli.rules.python.stdlib.argparse_sensitive_info:ArgparseSensitiveInfo
+
 [build_sphinx]
 all_files = 1
 build-dir = docs/build

--- a/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_password.py
+++ b/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_password.py
@@ -1,0 +1,26 @@
+# level: ERROR
+# start_line: 20
+# end_line: 26
+# start_column: 0
+# end_column: 1
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog="ProgramName",
+    description="What the program does",
+)
+parser.add_argument(
+    "-u",
+    "--user",
+    dest="user",
+    action="store",
+    help="user for the database",
+)
+parser.add_argument(
+    "-p",
+    "--password",
+    dest="password",
+    action="store",
+    help="password for the database",
+)

--- a/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_password_file.py
+++ b/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_password_file.py
@@ -1,0 +1,21 @@
+# level: NONE
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog="ProgramName",
+    description="What the program does",
+)
+parser.add_argument(
+    "--user",
+    dest="user",
+    action="store",
+    help="user for the database",
+)
+parser.add_argument(
+    "--password-file",
+    dest="password_file",
+    action="store",
+    type=argparse.FileType("w", encoding="utf-8"),
+    help="password file to load",
+)

--- a/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_password_store_true.py
+++ b/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_password_store_true.py
@@ -1,0 +1,22 @@
+# level: NONE
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog="ProgramName",
+    description="What the program does",
+)
+parser.add_argument(
+    "-u",
+    "--user",
+    dest="user",
+    action="store",
+    help="user for the database",
+)
+parser.add_argument(
+    "-p",
+    "--password",
+    dest="password",
+    action="store_true",
+    help="password for the database",
+)

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Secure Saurce LLC
+import os
+
+from parameterized import parameterized
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class ArgparseSensitiveInfoTests(test_case.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule_id = "PY027"
+        self.parser = python.Python()
+        self.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "argparse",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        self.assertEqual(self.rule_id, rule.id)
+        self.assertEqual("visible_sensitive_information", rule.name)
+        self.assertEqual(
+            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        )
+        self.assertEqual(True, rule.default_config.enabled)
+        self.assertEqual(Level.ERROR, rule.default_config.level)
+        self.assertEqual(-1.0, rule.default_config.rank)
+        self.assertEqual("214", rule.cwe.cwe_id)
+
+    @parameterized.expand(
+        [
+            "argparse_add_argument_password.py",
+            "argparse_add_argument_password_file.py",
+            "argparse_add_argument_password_store_true.py",
+        ]
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
Sensitive data like a password should not be arguments of a CLI. They would end up appearing in the CLI history, ps output, logs, etc.

Closes: #339