### PR TITLE
Add new rule for secrets insufficient token length

### DIFF
--- a/docs/rules/python/stdlib/secrets_weak_token.md
+++ b/docs/rules/python/stdlib/secrets_weak_token.md
@@ -1,0 +1,3 @@
+# secrets — weak token
+
+::: precli.rules.python.stdlib.secrets_weak_token

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Secure Saurce LLC
+r"""
+# Insufficient Token Length
+
+Tokens are often used as security-critical elements, such as for
+authentication, session management, or as part of cryptographic operations.
+The strength of a token is significantly influenced by its length and the
+randomness of its generation. Tokens with insufficient byte lengths lack
+the necessary entropy to withstand brute-force attacks, leading to a potential
+compromise of the system's security integrity.
+
+All calls to `secrets.token_bytes()`, `secrets.token_hex()`, and
+`secrets.token_urlsafe()` MUST specify a byte size of at least 32.
+This requirement ensures that the generated tokens have a strong level of
+cryptographic security, reducing the risk of unauthorized access through
+token prediction or brute-force attacks.
+
+## Example
+
+```python
+import secrets
+
+
+token = secrets.token_bytes(16)
+```
+
+## Remediation
+
+Its recommended to increase the token size to at least 32 bytes or leave
+the `nbytes` parameter unset or set to None to use a default entropy.
+
+```python
+import secrets
+
+
+token = secrets.token_bytes()
+```
+
+## See also
+
+- [secrets — Generate secure random numbers for managing secrets](https://docs.python.org/3/library/secrets.html#generating-tokens)
+- [CWE-326: Inadequate Encryption Strength](https://cwe.mitre.org/data/definitions/326.html)
+
+_New in version 0.3.14_
+
+"""  # noqa: E501
+from precli.core.level import Level
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class SecretsWeakToken(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="inadequate_encryption_strength",
+            description=__doc__,
+            cwe_id=326,
+            message="Using token lengths less than '{0}' bytes is considered "
+            "vulnerable to brute-force attacks.",
+            targets=("call"),
+            wildcards={},
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+
+        if call.name_qualified not in [
+            "secrets.token_bytes",
+            "secrets.token_hex",
+            "secrets.token_urlsafe",
+        ]:
+            return
+
+        arg = call.get_argument(position=0, name="nbytes")
+        nbytes = int(arg.value) if arg.node else 32
+
+        if nbytes < 32:
+            fixes = Rule.get_fixes(
+                context=context,
+                deleted_location=Location(node=arg.node),
+                description="Pass None or no parameter to use the default "
+                "entropy.",
+                inserted_content="None",
+            )
+
+            return Result(
+                rule_id=self.id,
+                location=Location(node=arg.node),
+                level=Level.ERROR if nbytes < 16 else Level.WARNING,
+                message=self.message.format(32),
+                fixes=fixes,
+            )

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,6 +128,9 @@ precli.rules.python =
     # precli/rules/python/stdlib/argparse_sensitive_info.py
     PY027 = precli.rules.python.stdlib.argparse_sensitive_info:ArgparseSensitiveInfo
 
+    # precli/rules/python/stdlib/secrets_weak_token.py
+    PY028 = precli.rules.python.stdlib.secrets_weak_token:SecretsWeakToken
+
 [build_sphinx]
 all_files = 1
 build-dir = docs/build

--- a/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_bytes.py
+++ b/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_bytes.py
@@ -1,0 +1,9 @@
+# level: ERROR
+# start_line: 9
+# end_line: 9
+# start_column: 20
+# end_column: 21
+import secrets
+
+
+secrets.token_bytes(4)

--- a/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_bytes_default.py
+++ b/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_bytes_default.py
@@ -1,0 +1,5 @@
+# level: NONE
+import secrets
+
+
+secrets.token_bytes()

--- a/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_hex.py
+++ b/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_hex.py
@@ -1,0 +1,9 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 18
+# end_column: 20
+import secrets
+
+
+secrets.token_hex(16)

--- a/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_urlsafe.py
+++ b/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_urlsafe.py
@@ -1,0 +1,9 @@
+# level: ERROR
+# start_line: 9
+# end_line: 9
+# start_column: 29
+# end_column: 30
+import secrets
+
+
+secrets.token_urlsafe(nbytes=8)

--- a/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
+++ b/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Secure Saurce LLC
+import os
+
+from parameterized import parameterized
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class SecretsWeakTokenTests(test_case.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule_id = "PY028"
+        self.parser = python.Python()
+        self.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "secrets",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        self.assertEqual(self.rule_id, rule.id)
+        self.assertEqual("inadequate_encryption_strength", rule.name)
+        self.assertEqual(
+            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        )
+        self.assertEqual(True, rule.default_config.enabled)
+        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(-1.0, rule.default_config.rank)
+        self.assertEqual("326", rule.cwe.cwe_id)
+
+    @parameterized.expand(
+        [
+            "secrets_token_bytes.py",
+            "secrets_token_bytes_default.py",
+            "secrets_token_hex.py",
+            "secrets_token_urlsafe.py",
+        ]
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
Tokens should be a sufficient length (32 bytes) to avoid vulnerability of brute-force attacks.