### PR TITLE
New rule for socket based unrestricted bind

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -40,3 +40,4 @@
 | PY026 | [smtplib — unverified context](rules/python/stdlib/smtplib-unverified-context.md) | Improper Certificate Validation Using `smtplib` |
 | PY027 | [argparse — sensitive info](rules/python/stdlib/argparse-sensitive-info.md) | Invocation of Process Using Visible Sensitive Information in `argparse` |
 | PY028 | [secrets — weak token](rules/python/stdlib/secrets-weak-token.md) | Insufficient Token Length |
+| PY029 | [secrets — weak token](rules/python/stdlib/socket-unrestricted-bind.md) | Binding to an Unrestricted IP Address in `socket` Module |

--- a/docs/rules/python/stdlib/socket-unrestricted-bind.md
+++ b/docs/rules/python/stdlib/socket-unrestricted-bind.md
@@ -1,0 +1,10 @@
+---
+id: PY029
+title: socket — unrestricted bind
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/PY029
+---
+
+::: precli.rules.python.stdlib.socket_unrestricted_bind

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -91,6 +91,7 @@ class Python(Parser):
             "call",
             "attribute",
             "identifier",
+            "tuple",
             "string",
             "integer",
             "float",
@@ -381,9 +382,9 @@ class Python(Parser):
                     # value = ast.literal_eval(nodetext)
                     pass
                 case "tuple":
-                    # TODO: don't use ast.literal_eval
-                    # value = ast.literal_eval(nodetext)
-                    pass
+                    value = ()
+                    for child in node.named_children:
+                        value += (self.literal_value(child),)
                 case "string":
                     # TODO: handle byte strings (b"abc")
                     # TODO: handle f-strings? (f"{a}")

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -3,8 +3,8 @@ from abc import ABC
 from abc import abstractmethod
 from typing import Self
 
-from cwe import Database
-from cwe import Weakness
+from cwe2.database import Database
+from cwe2.weakness import Weakness
 
 from precli.core.config import Config
 from precli.core.fix import Fix

--- a/precli/rules/python/stdlib/socket_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socket_unrestricted_bind.py
@@ -1,0 +1,105 @@
+# Copyright 2024 Secure Saurce LLC
+r"""
+# Binding to an Unrestricted IP Address in `socket` Module
+
+Sockets can be bound to the IPv4 address `0.0.0.0` or IPv6 equivalent of
+`::`, which configures the socket to listen for incoming connections on all
+network interfaces. While this can be intended in environments where
+services are meant to be publicly accessible, it can also introduce significant
+security risks if the service is not intended for public or wide network
+access.
+
+Binding a socket to `0.0.0.0` or `::` can unintentionally expose the
+application to the wider network or the internet, making it accessible from
+any interface. This exposure can lead to unauthorized access, data breaches,
+or exploitation of vulnerabilities within the application if the service is
+not adequately secured or if the binding is unintended. Restricting the socket
+to listen on specific interfaces limits the exposure and reduces the attack
+surface.
+
+## Example
+
+```python
+import socket
+
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("0.0.0.0", 8080))
+s.listen()
+```
+
+## Remediation
+
+All socket bindings MUST specify a specific network interface or localhost
+(127.0.0.1/localhost for IPv4, ::1 for IPv6) unless the application is
+explicitly designed to be accessible from any network interface. This
+practice ensures that services are not exposed more broadly than intended.
+
+```python
+import socket
+
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 8080))
+s.listen()
+```
+
+## See also
+
+- [socket.create_server — Low-level networking interface](https://docs.python.org/3/library/socket.html#socket.create_server)
+- [socket.socket.bind — Low-level networking interface](https://docs.python.org/3/library/socket.html#socket.socket.bind)
+- [CWE-1327: Binding to an Unrestricted IP Address](https://cwe.mitre.org/data/definitions/1327.html)
+
+_New in version 0.3.14_
+
+"""  # noqa: E501
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+INADDR_ANY = "0.0.0.0"
+IN6ADDR_ANY = "::"
+
+
+class SocketUnrestrictedBind(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="unrestricted_bind",
+            description=__doc__,
+            cwe_id=1327,
+            message="Binding to '{0}' exposes the application on all network "
+            "interfaces, increasing the risk of unauthorized access.",
+            targets=("call"),
+            wildcards={
+                "socket.*": [
+                    "create_server",
+                    "socket",
+                ]
+            },
+        )
+
+    def analyze(self, context: dict, **kwargs: dict) -> Result:
+        call = kwargs.get("call")
+        if call.name_qualified not in [
+            "socket.create_server",
+            "socket.socket.bind",
+        ]:
+            return
+
+        arg = call.get_argument(position=0, name="address")
+        address = arg.value
+
+        if isinstance(address, tuple) and address[0] in (
+            "",
+            INADDR_ANY,
+            IN6ADDR_ANY,
+        ):
+            return Result(
+                rule_id=self.id,
+                location=Location(node=arg.node),
+                message=self.message.format(
+                    "INADDR_ANY (0.0.0.0) or IN6ADDR_ANY (::)"
+                ),
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cwe
+cwe2
 Pygments
 rich # MIT
 tree_sitter>=0.20.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -131,5 +131,8 @@ precli.rules.python =
     # precli/rules/python/stdlib/secrets_weak_token.py
     PY028 = precli.rules.python.stdlib.secrets_weak_token:SecretsWeakToken
 
+    # precli/rules/python/stdlib/socket_unrestricted_bind.py
+    PY029 = precli.rules.python.stdlib.socket_unrestricted_bind:SocketUnrestrictedBind
+
 [build_sphinx]
 all_files = 1

--- a/tests/unit/rules/python/stdlib/socket/examples/socket_create_server.py
+++ b/tests/unit/rules/python/stdlib/socket/examples/socket_create_server.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 4
+# end_column: 16
+import socket
+
+
+s = socket.create_server(
+    ("::", 8080), family=socket.AF_INET6, dualstack_ipv6=True
+)

--- a/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind.py
+++ b/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 7
+# end_column: 15
+import socket
+
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("", 80))

--- a/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind_as_var.py
+++ b/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind_as_var.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 7
+# end_column: 11
+import socket
+
+
+addr = ("0.0.0.0", 80)
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(addr)

--- a/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind_as_vars.py
+++ b/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind_as_vars.py
@@ -1,0 +1,13 @@
+# level: WARNING
+# start_line: 13
+# end_line: 13
+# start_column: 7
+# end_column: 11
+import socket
+
+
+address = "0.0.0.0"
+port = 80
+addr = (address, port)
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(addr)

--- a/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Secure Saurce LLC
+import os
+
+from parameterized import parameterized
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class SocketUnrestrictedBindTests(test_case.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule_id = "PY029"
+        self.parser = python.Python()
+        self.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "socket",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        self.assertEqual(self.rule_id, rule.id)
+        self.assertEqual("unrestricted_bind", rule.name)
+        self.assertEqual(
+            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        )
+        self.assertEqual(True, rule.default_config.enabled)
+        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(-1.0, rule.default_config.rank)
+        self.assertEqual("1327", rule.cwe.cwe_id)
+
+    @parameterized.expand(
+        [
+            "socket_create_server.py",
+            "socket_socket_bind.py",
+            "socket_socket_bind_as_var.py",
+            "socket_socket_bind_as_vars.py",
+        ]
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
Checks for use of "", "0.0.0.0", or "::" usage when binding sockets.

Partially-fixes: #225