### PR TITLE
Drop support of Windows

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -73,7 +73,7 @@ jobs:
         python-version: [
           ["3.12", "312"]
         ]
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (${{ matrix.python-version[0] }})
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifier =
     Intended Audience :: System Administrators
     Intended Audience :: Developers
     Operating System :: MacOS
-    Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3


### PR DESCRIPTION
There is a need to switch from the Python package cwe to cwe2 since cwe2 is more current and maintain better.

However, cwe2 raises an encoding traceback when looking up a CWE in its database.