### PR TITLE
Refactor how rules are called to analyze

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -177,22 +177,26 @@ class Parser(ABC):
         child = list(filter(lambda x: x.type == type, node.named_children))
         return child[0] if child else None
 
-    def process_rules(self, target: str, **kwargs: dict) -> list[Result]:
+    def analyze_node(self, node_type: str, **kwargs: dict) -> list[Result]:
         """
-        Process the rules based on target.
+        Process the rules based on node_type.
 
         This function will iterate through all rules that are designed to
-        handle the given node type (target).
+        handle the given node type (node_type).
 
-        :param str target: process nodes of this node type
+        :param str node_type: process nodes of this node type
 
         :return: list of results
         :rtype: list
         """
+        fn = f"analyze_{node_type}"
         for rule in self.rules.values():
-            if rule.default_config.enabled and target in rule.targets:
+            if hasattr(rule, fn) and rule.default_config.enabled:
                 context = self.context
                 context["symtab"] = self.current_symtab
-                result = rule.analyze(self.context, **kwargs)
+
+                analyze_fn = getattr(rule, fn)
+                result = analyze_fn(self.context, **kwargs)
+
                 if result is not None:
                     self.results.append(result)

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -92,7 +92,7 @@ class Go(Parser):
             args=func_call_args,
         )
 
-        self.process_rules("call", call=call)
+        self.analyze_node(self.context["node"].type, call=call)
 
         if call.var_node is not None:
             symbol = self.current_symtab.get(call.var_node.text.decode())

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -153,7 +153,7 @@ class Python(Parser):
             self.current_symtab.remove(identifier)
             self.current_symtab.put(identifier, "import", module)
 
-        self.process_rules("call", call=call)
+        self.analyze_node(self.context["node"].type, call=call)
 
         if call.var_node is not None:
             symbol = self.current_symtab.get(call.var_node.text.decode())
@@ -166,7 +166,7 @@ class Python(Parser):
         self.visit(nodes)
 
     def visit_assert(self, nodes: list[Node]):
-        self.process_rules("assert")
+        self.analyze_node(self.context["node"].type)
         self.visit(nodes)
 
     def visit_with_item(self, nodes: list[Node]):
@@ -209,7 +209,7 @@ class Python(Parser):
                 operator=operator,
                 right_hand=right_hand,
             )
-            self.process_rules("comparison_operator", comparison=comparison)
+            self.analyze_node("comparison_operator", comparison=comparison)
         self.visit(nodes)
 
     def import_statement(self, nodes: list[Node]) -> dict:

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2024 Secure Saurce LLC
 from abc import ABC
-from abc import abstractmethod
 from typing import Self
 
 from cwe2.database import Database
@@ -22,7 +21,6 @@ class Rule(ABC):
         description: str,
         cwe_id: int,
         message: str,
-        targets: set[str],
         wildcards: dict[str, list[str]] = None,
         config: Config = None,
         help_url: str = None,
@@ -45,7 +43,6 @@ class Rule(ABC):
         self._full_descr = description[start:]
         self._cwe = Rule._cwedb.get(cwe_id)
         self._message = message
-        self._targets = targets
         self._wildcards = wildcards
         self._config = Config() if not config else config
         self._help_url = f"https://docs.securesauce.dev/rules/{id}"
@@ -149,20 +146,6 @@ class Rule(ABC):
         return self._message
 
     @property
-    def targets(self) -> set[str]:
-        """
-        Target node types this rule operates on.
-
-        This property defines what node types the rule can process. For
-        example, if the rule is designed to find suspicous calls, the rule
-        can define target set of ("call").
-
-        :return: set of target node types
-        :rtype: set
-        """
-        return self._targets
-
-    @property
     def wildcards(self) -> dict[str, list[str]]:
         """
         Mapping of wildcard imports to concrete modules.
@@ -194,15 +177,3 @@ class Rule(ABC):
         ]
         # TODO(ericwb): verify the new content will fully resolve, otherwise
         # only make suggested fix as part of the description.
-
-    @abstractmethod
-    def analyze(self, context: dict, **kwargs: dict):
-        """Analyze the code and return a result.
-
-        :param dict context: current context of the parse
-        :param list args: arguments
-        :param dict kwargs: keyword arguments
-
-        :return: an issue as a Result object or None
-        :rtype: Result
-        """

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -112,6 +112,7 @@ func main() {
 _New in version 0.2.1_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -128,14 +129,11 @@ class WeakCipher(Rule):
             cwe_id=327,
             message="Weak ciphers like '{0}' should be avoided due to their "
             "known vulnerabilities and weaknesses.",
-            targets=("call"),
             wildcards={},
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call_expression(self, context: dict, call: Call) -> Result:
         if call.name_qualified in [
             "crypto/des.NewCipher",
             "crypto/des.NewTripleDESCipher",

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -63,6 +63,7 @@ func main() {
 _New in version 0.2.1_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -79,14 +80,11 @@ class WeakHash(Rule):
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",
-            targets=("call"),
             wildcards={},
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call_expression(self, context: dict, call: Call) -> Result:
         if call.name_qualified in [
             "crypto/md5.New",
             "crypto/sha1.New",

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -79,6 +79,7 @@ func main() {
 _New in version 0.2.1_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -94,13 +95,10 @@ class WeakKey(Rule):
             cwe_id=326,
             message="Using '{0}' key sizes less than '{1}' bits is considered "
             "vulnerable to attacks.",
-            targets=("call"),
             wildcards={},
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call_expression(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["crypto/dsa.GenerateParameters"]:
             argument = call.get_argument(position=2)
             sizes = argument.value

--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -57,6 +57,7 @@ parser.add_argument(
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -73,7 +74,6 @@ class ArgparseSensitiveInfo(Rule):
             cwe_id=214,
             message="{0} in CLI arguments are leaked to command history, "
             "logs, ps output, etc.",
-            targets=("call"),
             wildcards={
                 "argparse.*": [
                     "ArgumentParser",
@@ -82,8 +82,7 @@ class ArgparseSensitiveInfo(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "argparse.ArgumentParser.add_argument",
         ]:

--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -65,10 +65,9 @@ class Assert(Rule):
             cwe_id=703,
             message="Assert statements are disabled when optimizations are "
             "enabled.",
-            targets=("assert"),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
+    def analyze_assert(self, context: dict) -> Result:
         return Result(
             rule_id=self.id,
             artifact=context["artifact"],

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -80,6 +80,7 @@ alternatives include `bcrypt`, `pbkdf2`, and `scrypt`.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -100,7 +101,6 @@ class CryptWeakHash(Rule):
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",
-            targets=("call"),
             wildcards={
                 "crypt.*": [
                     "crypt",
@@ -109,9 +109,7 @@ class CryptWeakHash(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["crypt.crypt"]:
             name = call.get_argument(position=1, name="salt").value
 

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -71,6 +71,7 @@ These alternatives include:
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -86,7 +87,6 @@ class FtpCleartext(Rule):
             cwe_id=319,
             message="The FTP protocol can transmit data in cleartext without "
             "encryption.",
-            targets=("call"),
             wildcards={
                 "ftplib.*": [
                     "FTP",
@@ -94,9 +94,7 @@ class FtpCleartext(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["ftplib.FTP"]:
             """
             FTP(

--- a/precli/rules/python/stdlib/ftplib_unverified_context.py
+++ b/precli/rules/python/stdlib/ftplib_unverified_context.py
@@ -52,6 +52,7 @@ with ftplib.FTP_TLS(
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -69,7 +70,6 @@ class FtplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            targets=("call"),
             wildcards={
                 "ftplib.*": [
                     "FTP_TLS",
@@ -77,8 +77,7 @@ class FtplibUnverifiedContext(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in ["ftplib.FTP_TLS"]:
             return
 

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -71,6 +71,7 @@ _New in version 0.1.0_
 
 """  # noqa: E501
 from precli.core.argument import Argument
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -90,7 +91,6 @@ class HashlibWeakHash(Rule):
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",
-            targets=("call"),
             wildcards={
                 "hashlib.*": [
                     "md4",
@@ -103,9 +103,7 @@ class HashlibWeakHash(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in [
             "hashlib.md4",
             "hashlib.md5",

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -68,6 +68,7 @@ return hmac.compare_digest(digest, received_digest)
 _New in version 0.1.4_
 
 """  # noqa: E501
+from precli.core.comparison import Comparison
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -93,7 +94,6 @@ class HmacTimingAttack(Rule):
             cwe_id=208,
             message="Comparing digests with the '{0}' operator is vulnerable "
             "to timing attacks.",
-            targets=("comparison_operator"),
             wildcards={
                 "hmac.*": [
                     "new",
@@ -106,9 +106,9 @@ class HmacTimingAttack(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        comparison = kwargs.get("comparison")
-
+    def analyze_comparison_operator(
+        self, context: dict, comparison: Comparison
+    ) -> Result:
         if comparison.operator == "==" and (
             comparison.left_hand in TIMING_VULNERABLE
             or comparison.right_hand in TIMING_VULNERABLE

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -64,6 +64,7 @@ mac = hmac_obj.digest()
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -90,7 +91,6 @@ class HmacWeakHash(Rule):
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",
-            targets=("call"),
             wildcards={
                 "hmac.*": [
                     "new",
@@ -100,9 +100,7 @@ class HmacWeakHash(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["hmac.new"]:
             """
             hmac.new(key, msg=None, digestmod='')

--- a/precli/rules/python/stdlib/http_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/http_server_unrestricted_bind.py
@@ -57,6 +57,7 @@ def run(server_class: HTTPServer, handler_class: BaseHTTPRequestHandler):
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -75,7 +76,6 @@ class HttpServerUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            targets=("call"),
             wildcards={
                 "http.server.*": [
                     "HTTPServer",
@@ -84,8 +84,7 @@ class HttpServerUnrestrictedBind(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "http.server.HTTPServer",
             "http.server.ThreadingHTTPServer",

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -50,6 +50,7 @@ _New in version 0.3.4_
 from urllib.parse import parse_qs
 from urllib.parse import urlsplit
 
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -68,7 +69,6 @@ class HttpUrlSecret(Rule):
             description=__doc__,
             cwe_id=598,
             message="Secrets in URLs are vulnerable to unauthorized access.",
-            targets=("call"),
             wildcards={
                 "http.client.*": [
                     "HTTPConnection",
@@ -78,8 +78,7 @@ class HttpUrlSecret(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "http.client.HTTPConnection.request",
             "http.client.HTTPSConnection.request",

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -59,6 +59,7 @@ M.logout()
 _New in version 0.1.9_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -75,7 +76,6 @@ class ImapCleartext(Rule):
             cwe_id=319,
             message="The IMAP protocol can transmit data in cleartext without "
             "encryption.",
-            targets=("call"),
             wildcards={
                 "imaplib.*": [
                     "IMAP4",
@@ -84,9 +84,7 @@ class ImapCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "imaplib.IMAP4.authenticate",
             "imaplib.IMAP4.login",

--- a/precli/rules/python/stdlib/imaplib_unverified_context.py
+++ b/precli/rules/python/stdlib/imaplib_unverified_context.py
@@ -53,6 +53,7 @@ with imaplib.IMAP4_SSL(
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -70,7 +71,6 @@ class ImaplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            targets=("call"),
             wildcards={
                 "imaplib.*": [
                     "IMAP4",
@@ -79,8 +79,7 @@ class ImaplibUnverifiedContext(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "imaplib.IMAP4_SSL",
             "imaplib.IMAP4.starttls",

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -31,6 +31,7 @@ should first sanitize the data to remove any potential malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
@@ -46,7 +47,6 @@ class JsonLoad(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            targets=("call"),
             wildcards={
                 "json.*": [
                     "load",
@@ -56,9 +56,7 @@ class JsonLoad(Rule):
             config=Config(enabled=False),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in [
             "json.load",
             "json.loads",

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -43,6 +43,7 @@ thread = logging.config.listen(verify=validate)
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -57,7 +58,6 @@ class InsecureListenConfig(Rule):
             cwe_id=94,
             message="Using '{0}' with unset 'verify' vulnerable to code "
             "injection.",
-            targets=("call"),
             wildcards={
                 "logging.config.*": [
                     "listen",
@@ -65,8 +65,7 @@ class InsecureListenConfig(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in ["logging.config.listen"]:
             return
 

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -36,6 +36,7 @@ you should first sanitize the data to remove any potential malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -50,7 +51,6 @@ class MarshalLoad(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            targets=("call"),
             wildcards={
                 "marshal.*": [
                     "load",
@@ -59,9 +59,7 @@ class MarshalLoad(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["marshal.load", "marshal.loads"]:
             """
             marshal.load(file, /)

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -43,6 +43,7 @@ with NNTP_SSL('news.gmane.io') as n:
 _New in version 0.1.9_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -59,7 +60,6 @@ class NntpCleartext(Rule):
             cwe_id=319,
             message="The NNTP protocol can transmit data in cleartext without "
             "encryption.",
-            targets=("call"),
             wildcards={
                 "nntplib.*": [
                     "NNTP",
@@ -68,8 +68,7 @@ class NntpCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in ["nntplib.NNTP.login"]:
             return
 

--- a/precli/rules/python/stdlib/nntplib_unverified_context.py
+++ b/precli/rules/python/stdlib/nntplib_unverified_context.py
@@ -53,6 +53,7 @@ with nntplib.NNTP_SSL(
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -70,7 +71,6 @@ class NntplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            targets=("call"),
             wildcards={
                 "nntplib.*": [
                     "NNTP",
@@ -79,8 +79,7 @@ class NntplibUnverifiedContext(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "nntplib.NNTP_SSL",
             "nntplib.NNTP.starttls",

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -48,6 +48,7 @@ to be secure and cannot be used to execute malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -62,7 +63,6 @@ class PickleLoad(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            targets=("call"),
             wildcards={
                 "pickle.*": [
                     "load",
@@ -72,9 +72,7 @@ class PickleLoad(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in [
             "pickle.load",
             "pickle.loads",

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -55,6 +55,7 @@ for i in range(numMessages):
 _New in version 0.1.9_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -71,7 +72,6 @@ class PopCleartext(Rule):
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",
-            targets=("call"),
             wildcards={
                 "poplib.*": [
                     "POP3",
@@ -80,8 +80,7 @@ class PopCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "poplib.POP3.user",
             "poplib.POP3.pass_",

--- a/precli/rules/python/stdlib/poplib_unverified_context.py
+++ b/precli/rules/python/stdlib/poplib_unverified_context.py
@@ -51,6 +51,7 @@ with poplib.POP3_SSL(
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -68,7 +69,6 @@ class PoplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            targets=("call"),
             wildcards={
                 "poplib.*": [
                     "POP3",
@@ -77,8 +77,7 @@ class PoplibUnverifiedContext(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "poplib.POP3_SSL",
             "poplib.POP3.stls",

--- a/precli/rules/python/stdlib/re_denial_of_service.py
+++ b/precli/rules/python/stdlib/re_denial_of_service.py
@@ -49,6 +49,7 @@ _New in version 0.3.14_
 
 """  # noqa: E501
 from precli.core import redos
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -66,14 +67,11 @@ class ReDenialOfService(Rule):
             message="The call to '{0}'' with regex pattern '{1}'' is "
             "susceptible to catastrophic backtracking and may cause "
             "performance degradation.",
-            targets=("call"),
             wildcards={},
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "re.compile",
             "re.search",

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -44,6 +44,7 @@ token = secrets.token_bytes()
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -59,13 +60,10 @@ class SecretsWeakToken(Rule):
             cwe_id=326,
             message="Using token lengths less than '{0}' bytes is considered "
             "vulnerable to brute-force attacks.",
-            targets=("call"),
             wildcards={},
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "secrets.token_bytes",
             "secrets.token_hex",

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -35,6 +35,7 @@ any potential malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -49,7 +50,6 @@ class ShelveOpen(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            targets=("call"),
             wildcards={
                 "shelve.*": [
                     "open",
@@ -58,9 +58,7 @@ class ShelveOpen(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["shelve.open", "shelve.DbfilenameShelf"]:
             return Result(
                 rule_id=self.id,

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -88,6 +88,7 @@ server.quit()
 _New in version 0.1.9_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -104,7 +105,6 @@ class SmtpCleartext(Rule):
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",
-            targets=("call"),
             wildcards={
                 "smtplib.*": [
                     "SMTP",
@@ -113,8 +113,7 @@ class SmtpCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "smtplib.SMTP.login",
             "smtplib.SMTP.auth",

--- a/precli/rules/python/stdlib/smtplib_unverified_context.py
+++ b/precli/rules/python/stdlib/smtplib_unverified_context.py
@@ -53,6 +53,7 @@ with smtplib.SMTP_SSL(
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -70,7 +71,6 @@ class SmtplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            targets=("call"),
             wildcards={
                 "smtplib.*": [
                     "SMTP",
@@ -79,8 +79,7 @@ class SmtplibUnverifiedContext(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "smtplib.SMTP_SSL",
             "smtplib.SMTP.starttls",

--- a/precli/rules/python/stdlib/socket_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socket_unrestricted_bind.py
@@ -53,6 +53,7 @@ s.listen()
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -71,7 +72,6 @@ class SocketUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            targets=("call"),
             wildcards={
                 "socket.*": [
                     "create_server",
@@ -80,8 +80,7 @@ class SocketUnrestrictedBind(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "socket.create_server",
             "socket.socket.bind",

--- a/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
@@ -71,6 +71,7 @@ with socketserver.UDPServer((HOST, PORT), MyUDPHandler) as server:
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -89,7 +90,6 @@ class SocketserverUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            targets=("call"),
             wildcards={
                 "socketserver.*": [
                     "TCPServer",
@@ -102,8 +102,7 @@ class SocketserverUnrestrictedBind(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "socketserver.TCPServer",
             "socketserver.UDPServer",

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -51,6 +51,7 @@ _New in version 0.2.3_
 """  # noqa: E501
 import re
 
+from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
@@ -66,13 +67,10 @@ class SslContextWeakKey(Rule):
             cwe_id=326,
             message="Using '{0}' key sizes less than '{1}' bits is considered "
             "vulnerable to attacks.",
-            targets=("call"),
             wildcards={},
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "ssl.SSLContext.set_ecdh_curve",
             "ssl.create_default_context.set_ecdh_curve",

--- a/precli/rules/python/stdlib/ssl_create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl_create_unverified_context.py
@@ -45,6 +45,7 @@ context = ssl.create_default_context()
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -59,10 +60,9 @@ class CreateUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates.",
-            targets=("call"),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
+    def analyze_call(self, context: dict, call: Call) -> Result:
         """
         _create_unverified_context(
             protocol=None,
@@ -94,8 +94,6 @@ class CreateUnverifiedContext(Rule):
             cadata=None
         )
         """
-        call = kwargs.get("call")
-
         if call.name_qualified in ["ssl._create_unverified_context"]:
             fixes = Rule.get_fixes(
                 context=context,

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -63,6 +63,7 @@ _New in version 0.1.0_
 
 """  # noqa: E501
 from precli.core.argument import Argument
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -86,13 +87,10 @@ class InsecureTlsVersion(Rule):
             description=__doc__,
             cwe_id=326,
             message="The '{0}' protocol has insufficient encryption strength.",
-            targets=("call"),
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["ssl.get_server_certificate"]:
             """
             get_server_certificate(

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -97,6 +97,7 @@ These alternatives include:
 _New in version 0.1.0_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
 from precli.core.location import Location
@@ -113,7 +114,6 @@ class TelnetlibCleartext(Rule):
             cwe_id=319,
             message="The '{0}' module transmits data in cleartext without "
             "encryption.",
-            targets=("call"),
             wildcards={
                 "telnetlib.*": [
                     "Telnet",
@@ -122,9 +122,7 @@ class TelnetlibCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["telnetlib.Telnet"]:
             return Result(
                 rule_id=self.id,

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -43,6 +43,7 @@ with tempfile.NamedTemporaryFile(delete=False) as f:
 _New in version 0.1.9_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.fix import Fix
 from precli.core.location import Location
 from precli.core.result import Result
@@ -59,7 +60,6 @@ class MktempRaceCondition(Rule):
             message="The function '{0}' can allow insecure ways of creating "
             "temporary files and directories that can lead to race "
             "conditions.",
-            targets=("call"),
             wildcards={
                 "os.*": [
                     "open",
@@ -70,9 +70,7 @@ class MktempRaceCondition(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
-
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified in ["open"]:
             file_arg = call.get_argument(position=0, name="file")
 

--- a/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
@@ -57,6 +57,7 @@ def run(server_class: DocXMLRPCServer, handler_class: DocXMLRPCRequestHandler):
 _New in version 0.3.14_
 
 """  # noqa: E501
+from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -75,7 +76,6 @@ class XmlrpcServerUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            targets=("call"),
             wildcards={
                 "xmlrpc.server.*": [
                     "DocXMLRPCServer",
@@ -84,8 +84,7 @@ class XmlrpcServerUnrestrictedBind(Rule):
             },
         )
 
-    def analyze(self, context: dict, **kwargs: dict) -> Result:
-        call = kwargs.get("call")
+    def analyze_call(self, context: dict, call: Call) -> Result:
         if call.name_qualified not in [
             "xmlrpc.server.DocXMLRPCServer",
             "xmlrpc.server.SimpleXMLRPCServer",


### PR DESCRIPTION
* Remove the targets property of a rule
* Each rule crafts a function that defines the type of node it wishes to analyze. For example, analyze_call()

Note: this is a breaking change for the rules