### PR TITLE
Add --api_key checked in the CLI args

### DIFF
--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -3,9 +3,9 @@ r"""
 # Invocation of Process Using Visible Sensitive Information in `argparse`
 
 Do not read secrets directly from command line arguments. When a command
-accepts a secret like via a --password argument, the argument value will
-leak the secret into ps output and shell history. This also encourages the
-use of insecure environment variables for secrets.
+accepts a secret like via a `--password` argument or `--api_key`, the argument
+value will leak the secret into ps output and shell history. This also
+encourages the use of insecure environment variables for secrets.
 
 ## Example
 
@@ -56,6 +56,8 @@ parser.add_argument(
 
 _New in version 0.3.14_
 
+_Changed in version 0.4.1: --api_key also checked_
+
 """  # noqa: E501
 from precli.core.call import Call
 from precli.core.config import Config
@@ -97,10 +99,10 @@ class ArgparseSensitiveInfo(Rule):
 
         if (
             "--password" in [arg0.value, arg1.value]
-            and action.value == "store"
-        ):
+            or "--api_key" in [arg0.value, arg1.value]
+        ) and action.value == "store":
             return Result(
                 rule_id=self.id,
                 location=Location(node=call.node),
-                message=self.message.format("Passwords"),
+                message=self.message.format("Secrets"),
             )

--- a/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_api_key.py
+++ b/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_api_key.py
@@ -1,0 +1,18 @@
+# level: ERROR
+# start_line: 13
+# end_line: 18
+# start_column: 0
+# end_column: 1
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog="ProgramName",
+    description="What the program does",
+)
+parser.add_argument(
+    "--api_key",
+    dest="api_key",
+    action="store",
+    help="API key to connect to the server",
+)

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -38,6 +38,7 @@ class ArgparseSensitiveInfoTests(test_case.TestCase):
 
     @parameterized.expand(
         [
+            "argparse_add_argument_api_key.py",
             "argparse_add_argument_password.py",
             "argparse_add_argument_password_file.py",
             "argparse_add_argument_password_store_true.py",


### PR DESCRIPTION
An api_key is equally as bad as a password argument to a CLI.