### PR TITLE
importlib.import_module also needs to handle string types

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -306,8 +306,8 @@ class Python(Parser):
         return f"from {package} import {', '.join(modules)}"
 
     def importlib_import_module(self, call: Call) -> dict:
-        name = call.get_argument(position=0, name="name").value
-        package = call.get_argument(position=1, name="package").value
+        name = call.get_argument(position=0, name="name").value_str
+        package = call.get_argument(position=1, name="package").value_str
         if package is None:
             return name
         subpkg = len(name) - len(name.lstrip(".")) - 1

--- a/tests/unit/rules/python/stdlib/hashlib/examples/hashlib_md5_importlib.py
+++ b/tests/unit/rules/python/stdlib/hashlib/examples/hashlib_md5_importlib.py
@@ -1,0 +1,10 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 0
+# end_column: 11
+import importlib
+
+
+hashlib = importlib.import_module("hashlib")
+hashlib.md5()

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
@@ -43,6 +43,7 @@ class HashlibWeakHashTests(test_case.TestCase):
             "hashlib_md4.py",
             "hashlib_md5.py",
             "hashlib_md5_as_identifier.py",
+            "hashlib_md5_importlib.py",
             "hashlib_md5_usedforsecurity_true.py",
             "hashlib_new_blake2b.py",
             "hashlib_new_blake2s.py",


### PR DESCRIPTION
The importlib.import_module module and function also needs to correctly handle the new format for "true" strings in an argument value. It needs to use value_str instead of value.