### PR TITLE
Fix for cases of a reassignment of a variable

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -115,7 +115,16 @@ class Python(Parser):
         ):
             left_hand = self.resolve(nodes[0], default=nodes[0])
             right_hand = self.resolve(nodes[2], default=nodes[2])
+
+            # This is in case a variable is reassigned
+            self.current_symtab.put(
+                nodes[0].text.decode(), tokens.IDENTIFIER, right_hand
+            )
+
+            # This is to help full resolution of an attribute/call.
+            # This results in two entries in the symtab for this assignment.
             self.current_symtab.put(left_hand, tokens.IDENTIFIER, right_hand)
+
             if nodes[2].type == tokens.CALL:
                 (call_args, call_kwargs) = self.get_func_args(
                     nodes[2].children[1]

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -58,8 +58,8 @@ class SecretsWeakToken(Rule):
             name="insufficient_token_length",
             description=__doc__,
             cwe_id=326,
-            message="Using token lengths less than '{0}' bytes is considered "
-            "vulnerable to brute-force attacks.",
+            message="A token size of '{0}' is less than the recommended "
+            "'{1}' bytes, which can be vulnerable to brute-force attacks.",
             wildcards={},
         )
 
@@ -87,6 +87,6 @@ class SecretsWeakToken(Rule):
                 rule_id=self.id,
                 location=Location(node=arg.node),
                 level=Level.ERROR if nbytes < 16 else Level.WARNING,
-                message=self.message.format(32),
+                message=self.message.format(nbytes, 32),
                 fixes=fixes,
             )

--- a/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_bytes_size_var.py
+++ b/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_bytes_size_var.py
@@ -1,0 +1,7 @@
+# level: NONE
+import secrets
+
+
+token_size = 16
+token_size = 32
+secrets.token_bytes(token_size)

--- a/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
+++ b/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
@@ -40,6 +40,7 @@ class SecretsWeakTokenTests(test_case.TestCase):
         [
             "secrets_token_bytes.py",
             "secrets_token_bytes_default.py",
+            "secrets_token_bytes_size_var.py",
             "secrets_token_hex.py",
             "secrets_token_urlsafe.py",
         ]


### PR DESCRIPTION
It is possible for a variable to be used multiple times and even with multiple types prior to its use in the function call. This didn't work because the left hand side of the assignment would be resolved into its complete fully qualified function name.

However, it's also important to keep track of the identifier name in the symbol table in case it is reused. That way the value is properly overwritten.