### PR TITLE
Correct invalid examples for hmac timing attack

### DIFF
--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -36,7 +36,7 @@ key = b"my-secret-key"
 password = b"pass"
 digest = hmac.digest(key, password, digest="sha224")
 
-return digest == received_digest
+print(digest == received_digest)
 ```
 
 ## Remediation
@@ -57,7 +57,7 @@ key = b"my-secret-key"
 password = b"pass"
 digest = hmac.digest(key, password, digest="sha224")
 
-return hmac.compare_digest(digest, received_digest)
+print(hmac.compare_digest(digest, received_digest))
 ```
 
 ## See also

--- a/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack.py
+++ b/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack.py
@@ -1,8 +1,8 @@
 # level: ERROR
 # start_line: 18
 # end_line: 18
-# start_column: 14
-# end_column: 16
+# start_column: 13
+# end_column: 15
 import hmac
 
 
@@ -15,4 +15,4 @@ key = b"my-super-duper-secret-key-string"
 password = b"pass"
 digest = hmac.digest(key, password, digest="sha224")
 
-return digest == received_digest
+print(digest == received_digest)

--- a/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack_class.py
+++ b/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack_class.py
@@ -1,8 +1,8 @@
 # level: ERROR
 # start_line: 19
 # end_line: 19
-# start_column: 14
-# end_column: 16
+# start_column: 13
+# end_column: 15
 import hmac
 
 
@@ -16,4 +16,4 @@ password = b"pass"
 h = hmac.HMAC(key, msg=password, digestmod="sha224")
 digest = h.digest()
 
-return digest == received_digest
+print(digest == received_digest)

--- a/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack_class_hexdigest.py
+++ b/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack_class_hexdigest.py
@@ -1,8 +1,8 @@
 # level: ERROR
 # start_line: 16
 # end_line: 16
-# start_column: 14
-# end_column: 16
+# start_column: 13
+# end_column: 15
 import hmac
 
 
@@ -13,4 +13,4 @@ password = b"pass"
 h = hmac.HMAC(key, msg=password, digestmod="sha224")
 digest = h.hexdigest()
 
-return digest == received_digest
+print(digest == received_digest)

--- a/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack_compare_digest.py
+++ b/tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack_compare_digest.py
@@ -11,4 +11,4 @@ key = b"my-super-duper-secret-key-string"
 password = b"pass"
 digest = hmac.digest(key, password, digest="sha224")
 
-return hmac.compare_digest(digest, received_digest)
+print(hmac.compare_digest(digest, received_digest))


### PR DESCRIPTION
The examples for the hmac timing attack code uses a return, but not inside a function. This would be a syntax error if the code was attempted to run.