### PR TITLE
Check for no action passed in argparse rule

### DIFF
--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -100,7 +100,7 @@ class ArgparseSensitiveInfo(Rule):
         if (
             "--password" in [arg0.value_str, arg1.value_str]
             or "--api-key" in [arg0.value_str, arg1.value_str]
-        ) and action.value_str == "store":
+        ) and (action.value is None or action.value_str == "store"):
             return Result(
                 rule_id=self.id,
                 location=Location(node=call.node),

--- a/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_default_action.py
+++ b/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_default_action.py
@@ -1,0 +1,17 @@
+# level: ERROR
+# start_line: 13
+# end_line: 17
+# start_column: 0
+# end_column: 1
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog="ProgramName",
+    description="What the program does",
+)
+parser.add_argument(
+    "--api-key",
+    dest="api_key",
+    help="API key to connect to the server",
+)

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -39,6 +39,7 @@ class ArgparseSensitiveInfoTests(test_case.TestCase):
     @parameterized.expand(
         [
             "argparse_add_argument_api_key.py",
+            "argparse_add_argument_default_action.py",
             "argparse_add_argument_password.py",
             "argparse_add_argument_password_file.py",
             "argparse_add_argument_password_store_true.py",


### PR DESCRIPTION
The default value for action when no value is passed is "store" which is the exact value we are trying to detect for issues. So if a program creates CLI arguments via add_argument with api-key or password arg and unset action, it needs to surface this as an issue.