### PR TITLE
Fix traceback from usage of importlib.import_module

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -158,10 +158,11 @@ class Python(Parser):
             and self.context["node"].parent.type == tokens.ASSIGNMENT
         ):
             module = self.importlib_import_module(call)
-            left_hand = self.context["node"].parent.children[0]
-            identifier = left_hand.text.decode()
-            self.current_symtab.remove(identifier)
-            self.current_symtab.put(identifier, tokens.IMPORT, module)
+            if module:
+                left_hand = self.context["node"].parent.children[0]
+                identifier = left_hand.text.decode()
+                self.current_symtab.remove(identifier)
+                self.current_symtab.put(identifier, tokens.IMPORT, module)
 
         self.analyze_node(self.context["node"].type, call=call)
 
@@ -314,8 +315,10 @@ class Python(Parser):
                 modules.append(imp.module)
         return f"from {package} import {', '.join(modules)}"
 
-    def importlib_import_module(self, call: Call) -> dict:
+    def importlib_import_module(self, call: Call) -> str:
         name = call.get_argument(position=0, name="name").value_str
+        if name is None:
+            return None
         package = call.get_argument(position=1, name="package").value_str
         if package is None:
             return name

--- a/tests/unit/parsers/examples/importlib_import_module.py
+++ b/tests/unit/parsers/examples/importlib_import_module.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+query = "worker:run"
+module_name, _, func_name = query.partition(":")
+module = importlib.import_module(module_name, package="base_package")

--- a/tests/unit/parsers/test_python.py
+++ b/tests/unit/parsers/test_python.py
@@ -19,6 +19,13 @@ class PythonTestCase(testtools.TestCase):
             "examples",
         )
 
+    def test_importlib_import_module(self):
+        artifact = Artifact(
+            os.path.join(self.base_path, "importlib_import_module.py")
+        )
+        results = self.parser.parse(artifact)
+        self.assertEqual(0, len(results))
+
     def test_suppress(self):
         artifact = Artifact(os.path.join(self.base_path, "suppress.py"))
         results = self.parser.parse(artifact)


### PR DESCRIPTION
If the name part of the parameter to import_module cannot be determined (in this case it was None), the code should not attempt to continue or put in symbol table.

Fixes #405