### PR TITLE
Fix for IndexError in an expression list assignment

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -92,6 +92,7 @@ class Python(Parser):
         if (
             nodes[0].type == tokens.PATTERN_LIST
             and nodes[2].type == tokens.EXPRESSION_LIST
+            and len(nodes[0].named_children) == len(nodes[2].named_children)
         ):
             for i in range(len(nodes[0].named_children)):
                 self.visit_assignment(

--- a/tests/unit/parsers/examples/expression_list_assignment.py
+++ b/tests/unit/parsers/examples/expression_list_assignment.py
@@ -1,0 +1,6 @@
+import torch
+
+
+torch.tensor([[0.1, 1.2], [2.2, 3.1], [4.9, 5.2]])
+x = torch.tensor([[0.1, 1.2], [2.2, 3.1], [4.9, 5.2]])
+b, *_, device = *x.shape, x.device

--- a/tests/unit/parsers/test_python.py
+++ b/tests/unit/parsers/test_python.py
@@ -19,6 +19,13 @@ class PythonTestCase(testtools.TestCase):
             "examples",
         )
 
+    def test_expression_list_assignment(self):
+        artifact = Artifact(
+            os.path.join(self.base_path, "expression_list_assignment.py")
+        )
+        results = self.parser.parse(artifact)
+        self.assertEqual(0, len(results))
+
     def test_importlib_import_module(self):
         artifact = Artifact(
             os.path.join(self.base_path, "importlib_import_module.py")


### PR DESCRIPTION
There are some cases where the left and right hand sides of the assignment don't have equal number of arguments. This change ensures the node children have identical sizes to avoid this condition.

A longer term solution might be to handle star arguments.

Fixes #407