### PR TITLE
Resolve a call argument that is a call to its identifier

### DIFF
--- a/precli/core/argument.py
+++ b/precli/core/argument.py
@@ -26,6 +26,8 @@ class Argument:
         if node is None:
             return None
         # TODO(ericwb): does this function fail with nested calls?
+        if node.type == tokens.CALL:
+            return Argument._get_func_ident(node.named_children[0])
         if node.type in [tokens.ATTRIBUTE, tokens.SELECTOR_EXPRESSION]:
             return Argument._get_func_ident(node.named_children[1])
         if node.type in [tokens.IDENTIFIER, tokens.FIELD_IDENTIFIER]:


### PR DESCRIPTION
This fixes the case when a call is analyzed that has a call as one of its arguments.

foobar("foo", bar())

Now the call in the argument list will resolve to an identifier node.