### PR TITLE
Fix collison in rule wildcards

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -57,7 +57,11 @@ class Parser(ABC):
                 self.rules[rule.name].default_config.enabled = False
 
             if self.rules[rule.name].wildcards:
-                self.wildcards |= self.rules[rule.name].wildcards
+                for k, v in self.rules[rule.name].wildcards.items():
+                    if k in self.wildcards:
+                        self.wildcards[k] += v
+                    else:
+                        self.wildcards[k] = v
 
     @property
     def lexer(self) -> str:

--- a/tests/unit/rules/java/stdlib/java_security/examples/MessageDigestMD5.java
+++ b/tests/unit/rules/java/stdlib/java_security/examples/MessageDigestMD5.java
@@ -1,10 +1,9 @@
 // level: ERROR
-// start_line: 13
-// end_line: 13
+// start_line: 12
+// end_line: 12
 // start_column: 57
 // end_column: 62
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.security.*;
 
 
 public class MessageDigestMD5 {


### PR DESCRIPTION
It's possible for different rules define a wildcard that has the same key. As a result, this collison would overwrite the other.

This change fixes the collison by appending the wildcard value to the other.