### PR TITLE
Go and Java docs should have similar headers as Python

### DIFF
--- a/docs/rules/go/stdlib/crypto-weak-cipher.md
+++ b/docs/rules/go/stdlib/crypto-weak-cipher.md
@@ -1,3 +1,10 @@
-# crypto — weak cipher
+---
+id: GO001
+title: crypto — weak cipher
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/GO001
+---
 
 ::: precli.rules.go.stdlib.crypto_weak_cipher

--- a/docs/rules/go/stdlib/crypto-weak-hash.md
+++ b/docs/rules/go/stdlib/crypto-weak-hash.md
@@ -1,3 +1,10 @@
-# crypto — weak hash
+---
+id: GO002
+title: crypto — weak hash
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/GO002
+---
 
 ::: precli.rules.go.stdlib.crypto_weak_hash

--- a/docs/rules/go/stdlib/crypto-weak-key.md
+++ b/docs/rules/go/stdlib/crypto-weak-key.md
@@ -1,3 +1,10 @@
-# crypto — weak key
+---
+id: GO003
+title: crypto — weak key
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/GO003
+---
 
 ::: precli.rules.go.stdlib.crypto_weak_key

--- a/docs/rules/java/stdlib/java-security-weak-hash.md
+++ b/docs/rules/java/stdlib/java-security-weak-hash.md
@@ -1,3 +1,10 @@
-# java.security — weak hash
+---
+id: JAV002
+title: java.security — weak hash
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/JAV002
+---
 
 ::: precli.rules.java.stdlib.java_security_weak_hash

--- a/docs/rules/java/stdlib/java-security-weak-key.md
+++ b/docs/rules/java/stdlib/java-security-weak-key.md
@@ -1,3 +1,10 @@
-# java.security — weak key
+---
+id: JAV003
+title: java.security — weak key
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/JAV003
+---
 
 ::: precli.rules.java.stdlib.java_security_weak_key

--- a/docs/rules/java/stdlib/javax-crypto-weak-cipher.md
+++ b/docs/rules/java/stdlib/javax-crypto-weak-cipher.md
@@ -1,3 +1,10 @@
-# javax.crypto — weak cipher
+---
+id: JAV001
+title: javax.crypto — weak cipher
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/JAV001
+---
 
 ::: precli.rules.java.stdlib.javax_crypto_weak_cipher


### PR DESCRIPTION
The Python docs have headers with slug, title, etc. So should the Go and Java docs