### PR TITLE
Add rule for detection of weak random algorithm in SecureRandom

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,6 +15,7 @@
 | JAV001 | [javax.crypto — weak cipher](rules/java/stdlib/javax-crypto-weak-cipher.md) | Use of a Broken or Risky Cryptographic Algorithm in `javax.crypto` Package |
 | JAV002 | [java.security — weak hash](rules/java/stdlib/java-security-weak-hash.md) | Reversible One Way Hash in `java.security` Package |
 | JAV003 | [java.security — weak key](rules/java/stdlib/java-security-weak-key.md) | Inadequate Encryption Strength Using Weak Keys in `java.security` Package |
+| JAV004 | [java.security — weak random](rules/java/stdlib/java-security-weak-random.md) | Use of Cryptographically Weak Pseudo-Random Number Generator `SHA1PRNG` |
 
 ## Python Standard Library
 

--- a/docs/rules/java/stdlib/java-security-weak-random.md
+++ b/docs/rules/java/stdlib/java-security-weak-random.md
@@ -1,0 +1,10 @@
+---
+id: JAV004
+title: java.security — weak random
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/JAV004
+---
+
+::: precli.rules.java.stdlib.java_security_weak_random

--- a/precli/rules/java/stdlib/java_security_weak_random.py
+++ b/precli/rules/java/stdlib/java_security_weak_random.py
@@ -1,0 +1,111 @@
+# Copyright 2024 Secure Saurce LLC
+r"""
+# Use of Cryptographically Weak Pseudo-Random Number Generator `SHA1PRNG`
+
+This rule identifies instances where the Java SecureRandom class is
+instantiated with the SHA1PRNG algorithm. While SHA1PRNG has been widely
+used, it is considered less secure and potentially vulnerable compared to
+newer algorithms available. The use of stronger algorithms is recommended
+to ensure the cryptographic strength of random numbers.
+
+The `SHA1PRNG` algorithm for SecureRandom may not provide a sufficiently strong
+level of randomness for security-sensitive applications. `SHA-1` has been
+found to be weaker against collision attacks, and while `SHA1PRNG` is not
+directly equivalent to `SHA-1`, its association and the lack of transparency
+in its implementation across different Java platforms raise concerns about
+its suitability and security. Modern cryptographic applications require
+stronger guarantees of randomness to prevent attacks.
+
+## Example
+
+```java
+import java.security.*;
+
+public class WeakRNG {
+    public static void main(String[] args) {
+        try {
+            SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
+        } catch (NoSuchAlgorithmException e) {
+            System.err.println("SHA1PRNG random algorithm not available.");
+        }
+    }
+}
+```
+
+## Remediation
+
+It is recommended to use SecureRandom without specifying an algorithm,
+allowing the Java runtime to select the strongest available algorithm, or
+explicitly specify a more secure algorithm like `NativePRNG` or `DRBG` where
+available and appropriate for the application's requirements. This ensures
+the use of secure and up-to-date algorithms for random number generation.
+
+```java
+import java.security.*;
+
+public class StrongRNG {
+    public static void main(String[] args) {
+        SecureRandom sr = new SecureRandom();
+    }
+}
+```
+
+## See also
+
+- [SecureRandom (Java SE & JDK)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/SecureRandom.html#getInstance(java.lang.String))
+- [CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)](https://cwe.mitre.org/data/definitions/338.html)
+- [Recommendations for Random Number Generation Using Deterministic Random Bit Generators (NIST SP 800-90A)](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf)
+- [Weak Random](https://thesecurityvault.com/weak-random/)
+- [Android Developers Blog Security Crypto provider deprecated in Android N](https://android-developers.googleblog.com/2016/06/security-crypto-provider-deprecated-in.html)
+
+_New in version 0.5.0_
+
+"""  # noqa: E501
+from precli.core.call import Call
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class SecureRandomWeakRandom(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="weak_prng",
+            description=__doc__,
+            cwe_id=338,
+            message="The SecureRandom algorithm '{0}' may not provide "
+            "sufficient entropy.",
+            wildcards={
+                "java.security.*": [
+                    "SecureRandom",
+                ],
+            },
+        )
+
+    def analyze_method_invocation(self, context: dict, call: Call) -> Result:
+        if call.name_qualified not in [
+            "java.security.SecureRandom.getInstance",
+        ]:
+            return
+
+        argument = call.get_argument(position=0)
+        algorithm = argument.value_str
+
+        if algorithm.upper() != "SHA1PRNG":
+            return
+
+        fixes = Rule.get_fixes(
+            context=context,
+            deleted_location=Location(node=call.node),
+            description="Use SecureRandom without specifying an algorithm, "
+            "allowing the Java runtime to select the strongest available "
+            "algorithm.",
+            inserted_content="new SecureRandom()",
+        )
+        return Result(
+            rule_id=self.id,
+            location=Location(node=argument.node),
+            message=self.message.format(algorithm),
+            fixes=fixes,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,9 @@ precli.rules.java =
     # precli/rules/java/stdlib/java_security_weak_key.py
     JAV003 = precli.rules.java.stdlib.java_security_weak_key:KeyPairGeneratorWeakKey
 
+    # precli/rules/java/stdlib/java_security_weak_random.py
+    JAV004 = precli.rules.java.stdlib.java_security_weak_random:SecureRandomWeakRandom
+
 precli.rules.python =
     # precli/rules/python/stdlib/assert.py
     PY001 = precli.rules.python.stdlib.assert:Assert

--- a/tests/unit/rules/java/stdlib/java_security/examples/SecureRandomDefault.java
+++ b/tests/unit/rules/java/stdlib/java_security/examples/SecureRandomDefault.java
@@ -1,0 +1,9 @@
+// level: NONE
+import java.security.*;
+
+
+public class SecureRandomDefault {
+    public static void main(String[] args) {
+        SecureRandom sr = new SecureRandom();
+    }
+}

--- a/tests/unit/rules/java/stdlib/java_security/examples/SecureRandomSHA1PRNG.java
+++ b/tests/unit/rules/java/stdlib/java_security/examples/SecureRandomSHA1PRNG.java
@@ -1,0 +1,17 @@
+// level: WARNING
+// start_line: 12
+// end_line: 12
+// start_column: 55
+// end_column: 65
+import java.security.*;
+
+
+public class SecureRandomSHA1PRNG {
+    public static void main(String[] args) {
+        try {
+            SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
+        } catch (NoSuchAlgorithmException e) {
+            System.err.println("SHA1PRNG random algorithm not available.");
+        }
+    }
+}

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Secure Saurce LLC
+import os
+
+from parameterized import parameterized
+
+from precli.core.level import Level
+from precli.parsers import java
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class SecureRandomWeakRandomTests(test_case.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule_id = "JAV004"
+        self.parser = java.Java()
+        self.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "java",
+            "stdlib",
+            "java_security",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        self.assertEqual(self.rule_id, rule.id)
+        self.assertEqual("weak_prng", rule.name)
+        self.assertEqual(
+            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        )
+        self.assertEqual(True, rule.default_config.enabled)
+        self.assertEqual(Level.WARNING, rule.default_config.level)
+        self.assertEqual(-1.0, rule.default_config.rank)
+        self.assertEqual("338", rule.cwe.cwe_id)
+
+    @parameterized.expand(
+        [
+            "SecureRandomDefault.java",
+            "SecureRandomSHA1PRNG.java",
+        ]
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
The usage of algorithm SHA1PRNG is considered weak and should be avoided.