### PR TITLE
Don't break codee with suggested fix

### DIFF
--- a/precli/rules/java/stdlib/java_security_weak_random.py
+++ b/precli/rules/java/stdlib/java_security_weak_random.py
@@ -97,11 +97,11 @@ class SecureRandomWeakRandom(Rule):
 
         fixes = Rule.get_fixes(
             context=context,
-            deleted_location=Location(node=call.node),
+            deleted_location=Location(node=argument.node),
             description="Use SecureRandom without specifying an algorithm, "
             "allowing the Java runtime to select the strongest available "
             "algorithm.",
-            inserted_content="new SecureRandom()",
+            inserted_content='"DRBG"',
         )
         return Result(
             rule_id=self.id,


### PR DESCRIPTION
The weak random Java rule currently suggests a fix that tells the user to use the constructor insteead of getInstance method. As a result, the NoSuchAlgorithmException doesn't get thrown. So the fix would create code that no longer compiles.

This change now swaps the weak random algorithm with a strong one that is known to exists for all platforms.