### PR TITLE
Weak hash and weak random Java rules need to guard from none

### DIFF
--- a/precli/rules/java/stdlib/java_security_weak_hash.py
+++ b/precli/rules/java/stdlib/java_security_weak_hash.py
@@ -95,7 +95,7 @@ class MessageDigestWeakHash(Rule):
         argument = call.get_argument(position=0)
         algorithm = argument.value_str
 
-        if algorithm.upper() not in WEAK_HASHES:
+        if algorithm is None or algorithm.upper() not in WEAK_HASHES:
             return
 
         fixes = Rule.get_fixes(

--- a/precli/rules/java/stdlib/java_security_weak_random.py
+++ b/precli/rules/java/stdlib/java_security_weak_random.py
@@ -92,7 +92,7 @@ class SecureRandomWeakRandom(Rule):
         argument = call.get_argument(position=0)
         algorithm = argument.value_str
 
-        if algorithm.upper() != "SHA1PRNG":
+        if algorithm is None or algorithm.upper() != "SHA1PRNG":
             return
 
         fixes = Rule.get_fixes(

--- a/tests/unit/rules/java/stdlib/java_security/examples/MessageDigestMD5Property.java
+++ b/tests/unit/rules/java/stdlib/java_security/examples/MessageDigestMD5Property.java
@@ -1,0 +1,18 @@
+// level: NONE
+// False negative
+import java.security.*;
+import java.util.*;
+
+
+public class MessageDigestMD5 {
+    public static void main(String[] args) {
+        try {
+            Properties hashProps = new Properties();
+            hashProps.setProperty("hashMd5", "MD5")
+            String algorithm = hashProps.getProperty("hashMd5", "SHA256");
+            MessageDigest md = MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            System.err.println("MD5 hashing algorithm not available.");
+        }
+    }
+}

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
@@ -40,6 +40,7 @@ class MessageDigestWeakHashTests(test_case.TestCase):
         [
             "MessageDigestMD2.java",
             "MessageDigestMD5.java",
+            "MessageDigestMD5Property.java",
             "MessageDigestSHA1.java",
             "MessageDigestSHA256.java",
         ]


### PR DESCRIPTION
The algorithm string might have a None value if the parser cannot determine its actual value.

For example, in the added testcase, if a value goes through a Properties class, the parser does track this value.