### PR TITLE
Fix broken link in rules table

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -16,7 +16,7 @@
 | JAV002 | [java.security — weak hash](rules/java/stdlib/java-security-weak-hash.md) | Reversible One Way Hash in `java.security` Package |
 | JAV003 | [java.security — weak key](rules/java/stdlib/java-security-weak-key.md) | Inadequate Encryption Strength Using Weak Keys in `java.security` Package |
 | JAV004 | [java.security — weak random](rules/java/stdlib/java-security-weak-random.md) | Use of Cryptographically Weak Pseudo-Random Number Generator `SHA1PRNG` |
-| JAV005 | [javax.servlet.http — insecure cookie](rules/java/stdlib/javax-servlet-http-insecure_cookie.md) | Sensitive Cookie in HTTPS Session Without 'Secure' Attribute |
+| JAV005 | [javax.servlet.http — insecure cookie](rules/java/stdlib/javax-servlet-http-insecure-cookie.md) | Sensitive Cookie in HTTPS Session Without 'Secure' Attribute |
 
 ## Python Standard Library
 

--- a/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
+++ b/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
@@ -21,7 +21,7 @@ they are only sent via secure connections.
 ```java
 import javax.servlet.http.Cookie;
 
-public class CookieSecureFalse {
+public class SessionCookie {
     public static void main(String[] args) {
         Cookie cookie = Cookie();
         cookie.setSecure(false);
@@ -39,7 +39,7 @@ MITM attacks on the communication channel.
 ```java
 import javax.servlet.http.Cookie;
 
-public class CookieSecureFalse {
+public class SessionCookie {
     public static void main(String[] args) {
         Cookie cookie = Cookie();
         cookie.setSecure(true);


### PR DESCRIPTION
The latest java rule reference link in the rules table has a typo thus given the users a broken link.