### PR TITLE
Add start_time to SARIF output

### DIFF
--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Saurce LLC
+import datetime
 import io
 import logging
 import os
@@ -28,6 +29,8 @@ class Run:
         self._parsers = parsers
         self._artifacts = artifacts
         self._init_logger(debug)
+        self._start_time = None
+        self._endt_time = None
 
     def _init_logger(self, log_level=logging.INFO):
         """Initialize the logger.
@@ -54,6 +57,8 @@ class Run:
 
     def invoke(self):
         """Invokes a run"""
+        self._start_time = datetime.datetime.now(datetime.UTC)
+
         # if we have problems with a file, we'll remove it from the file_list
         # and add it to the skipped list instead
         new_artifacts = list(self._artifacts)
@@ -98,6 +103,15 @@ class Run:
             notes=sum(result.level == Level.NOTE for result in results),
         )
         self._results = results
+        self._end_time = datetime.datetime.now(datetime.UTC)
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
 
     def parse_file(
         self,

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -2,7 +2,6 @@
 import pathlib
 import sys
 import urllib.parse as urlparse
-from datetime import datetime
 
 import sarif_om
 from jschema_to_python.to_json import to_json
@@ -116,7 +115,8 @@ class Json(Renderer):
                     tool=sarif_om.Tool(driver=self.create_tool_component(run)),
                     invocations=[
                         sarif_om.Invocation(
-                            end_time_utc=datetime.utcnow().strftime(TS_FORMAT),
+                            start_time_utc=run.start_time.strftime(TS_FORMAT),
+                            end_time_utc=run.end_time.strftime(TS_FORMAT),
                             execution_successful=True,
                         )
                     ],


### PR DESCRIPTION
The SARIF output currently shows only the end_time of an innovation. This change will also add start_time. It also moves these times into the run object.