### PR TITLE
Use child_by_type for all parsers

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -63,10 +63,16 @@ class Parser(ABC):
                     else:
                         self.wildcards[k] = v
 
+        def child_by_type(self, type: str) -> Node:
+            # Return first child with type as specified
+            child = list(filter(lambda x: x.type == type, self.named_children))
+            return child[0] if child else None
+
         @property
         def utf8_text(self) -> str:
             return self.text.decode()
 
+        setattr(Node, "child_by_type", child_by_type)
         setattr(Node, "utf8_text", utf8_text)
 
     @property

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -76,7 +76,7 @@ class Go(Parser):
         return imports
 
     def visit_function_declaration(self, nodes: list[Node]):
-        func_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        func_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         func = func_id.utf8_text
         self.current_symtab = SymbolTable(func, parent=self.current_symtab)
         self.visit(nodes)

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -49,49 +49,49 @@ class Java(Parser):
             self.current_symtab.put(symbol, tokens.IMPORT, package)
 
     def visit_class_declaration(self, nodes: list[Node]):
-        class_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        class_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         cls_name = class_id.utf8_text
         self.current_symtab = SymbolTable(cls_name, parent=self.current_symtab)
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
     def visit_interface_declaration(self, nodes: list[Node]):
-        if_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        if_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         if_name = if_id.utf8_text
         self.current_symtab = SymbolTable(if_name, parent=self.current_symtab)
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
     def visit_annotation_type_declaration(self, nodes: list[Node]):
-        anno_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        anno_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         ann_name = anno_id.utf8_text
         self.current_symtab = SymbolTable(ann_name, parent=self.current_symtab)
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
     def visit_enum_declaration(self, nodes: list[Node]):
-        enum_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        enum_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         e_name = enum_id.utf8_text
         self.current_symtab = SymbolTable(e_name, parent=self.current_symtab)
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
     def visit_constructor_declaration(self, nodes: list[Node]):
-        const_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        const_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         cst_name = const_id.utf8_text
         self.current_symtab = SymbolTable(cst_name, parent=self.current_symtab)
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
     def visit_record_declaration(self, nodes: list[Node]):
-        record_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        record_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         rec_name = record_id.utf8_text
         self.current_symtab = SymbolTable(rec_name, parent=self.current_symtab)
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
     def visit_method_declaration(self, nodes: list[Node]):
-        method_id = self.child_by_type(self.context["node"], tokens.IDENTIFIER)
+        method_id = self.context["node"].child_by_type(tokens.IDENTIFIER)
         mth_name = method_id.utf8_text
         self.current_symtab = SymbolTable(mth_name, parent=self.current_symtab)
         self.visit(nodes)
@@ -244,7 +244,7 @@ class Java(Parser):
             obj_node = node.children[0]
             method_node = node.children[0]
 
-        arg_list_node = self.child_by_type(node, tokens.ARGUMENT_LIST)
+        arg_list_node = node.child_by_type(tokens.ARGUMENT_LIST)
         call_args = self.get_func_args(arg_list_node)
 
         return Call(

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -22,13 +22,6 @@ class Python(Parser):
         self.SUPPRESS_COMMENT = re.compile(r"# suppress:? (?P<rules>[^#]+)?#?")
         self.SUPPRESSED_RULES = re.compile(r"(?:(PY\d\d\d|[a-z_]+),?)+")
 
-        def child_by_type(self, type: str) -> Node:
-            # Return first child with type as specified
-            child = list(filter(lambda x: x.type == type, self.named_children))
-            return child[0] if child else None
-
-        setattr(Node, "child_by_type", child_by_type)
-
     def file_extensions(self) -> list[str]:
         return [".py", ".pyw"]
 


### PR DESCRIPTION
The tree-sitter child_by_field_name doesn't appear to return any non-None value for any of our parsers. Therefore, this change will just switch all code to use the new convenience function child_by_type.