### PR TITLE
Fix action failure to release binary

### DIFF
--- a/.github/workflows/upload-asset.yml
+++ b/.github/workflows/upload-asset.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: read
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The recent change to add attestations also modified the permissions. I believe the contents permission needs to be write in order for this build step to function