### PR TITLE
Remove the unnecessary scripts directory and contents

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-from precli import precli
-
-if __name__ == "__main__":
-    precli.main()


### PR DESCRIPTION
The entry_point defined in the setup.cfg is precli.cli.main, therefore there is no reference or need to use the scripts/main.py file.