### PR TITLE
Migrate from stestr to pytests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 flake8>=4.0.0 # Apache-2.0
-stestr>=2.5.0 # Apache-2.0
+pytest>=8.2.0 # MIT
 pylint>=1.9.4 # GPLv2
-parameterized

--- a/tests/unit/core/test_python.py
+++ b/tests/unit/core/test_python.py
@@ -1,10 +1,8 @@
 # Copyright 2023 Secure Saurce LLC
-import testtools
-
 from precli.parsers import python
 
 
-class PythonTests(testtools.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.parser = python.Python()
+class TestPython:
+    @classmethod
+    def setup_class(cls):
+        cls.parser = python.Python()

--- a/tests/unit/parsers/test_go.py
+++ b/tests/unit/parsers/test_go.py
@@ -1,18 +1,16 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-import testtools
-
 from precli.core.artifact import Artifact
 from precli.core.level import Level
 from precli.parsers import go
 
 
-class GoTestCase(testtools.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.parser = go.Go()
-        self.base_path = os.path.join(
+class TestGo:
+    @classmethod
+    def setup_class(cls):
+        cls.parser = go.Go()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "parsers",
@@ -22,30 +20,30 @@ class GoTestCase(testtools.TestCase):
     def test_suppress(self):
         artifact = Artifact(os.path.join(self.base_path, "suppress.go"))
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(8, result.location.start_line)
-        self.assertEqual(8, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 8
+        assert result.location.end_line == 8
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_lowercase_rule(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_lowercase_rule.go")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(8, result.location.start_line)
-        self.assertEqual(8, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.ERROR, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 8
+        assert result.location.end_line == 8
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.ERROR
+        assert result.rank == -1.0
 
     def test_suppress_multiline(self):
         # TODO: not testing multiline
@@ -53,87 +51,87 @@ class GoTestCase(testtools.TestCase):
             os.path.join(self.base_path, "suppress_multiline.go")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(8, result.location.start_line)
-        self.assertEqual(8, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 8
+        assert result.location.end_line == 8
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_multiple_comments(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_multiple_comments.go")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(8, result.location.start_line)
-        self.assertEqual(8, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 8
+        assert result.location.end_line == 8
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_multiple_rules(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_multiple_rules.go")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(8, result.location.start_line)
-        self.assertEqual(8, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 8
+        assert result.location.end_line == 8
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_preceding(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_preceding.go")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(9, result.location.start_line)
-        self.assertEqual(9, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 9
+        assert result.location.end_line == 9
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_spaced_rules(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_spaced_rules.go")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(8, result.location.start_line)
-        self.assertEqual(8, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 8
+        assert result.location.end_line == 8
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_wrong_rule(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_wrong_rule.go")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("GO002", result.rule_id)
-        self.assertEqual(8, result.location.start_line)
-        self.assertEqual(8, result.location.end_line)
-        self.assertEqual(9, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.ERROR, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "GO002"
+        assert result.location.start_line == 8
+        assert result.location.end_line == 8
+        assert result.location.start_column == 9
+        assert result.location.end_column == 16
+        assert result.level == Level.ERROR
+        assert result.rank == -1.0

--- a/tests/unit/parsers/test_python.py
+++ b/tests/unit/parsers/test_python.py
@@ -1,18 +1,16 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-import testtools
-
 from precli.core.artifact import Artifact
 from precli.core.level import Level
 from precli.parsers import python
 
 
-class PythonTestCase(testtools.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestPython:
+    @classmethod
+    def setup_class(cls):
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "parsers",
@@ -24,7 +22,7 @@ class PythonTestCase(testtools.TestCase):
             os.path.join(self.base_path, "expression_list_assignment.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(0, len(results))
+        assert len(results) == 0
 
     def test_expression_list_assignment_uneven(self):
         artifact = Artifact(
@@ -33,42 +31,42 @@ class PythonTestCase(testtools.TestCase):
             )
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(0, len(results))
+        assert len(results) == 0
 
     def test_importlib_import_module(self):
         artifact = Artifact(
             os.path.join(self.base_path, "importlib_import_module.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(0, len(results))
+        assert len(results) == 0
 
     def test_suppress(self):
         artifact = Artifact(os.path.join(self.base_path, "suppress.py"))
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_lowercase_rule(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_lowercase_rule.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.ERROR, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.ERROR
+        assert result.rank == -1.0
 
     def test_suppress_multiline(self):
         # TODO: not testing multiline
@@ -76,87 +74,87 @@ class PythonTestCase(testtools.TestCase):
             os.path.join(self.base_path, "suppress_multiline.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_multiple_comments(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_multiple_comments.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_multiple_rules(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_multiple_rules.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_preceding(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_preceding.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(5, result.location.start_line)
-        self.assertEqual(5, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 5
+        assert result.location.end_line == 5
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_spaced_rules(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_spaced_rules.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.NOTE, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.NOTE
+        assert result.rank == -1.0
 
     def test_suppress_wrong_rule(self):
         artifact = Artifact(
             os.path.join(self.base_path, "suppress_wrong_rule.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1
         result = results[0]
-        self.assertEqual("PY004", result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(8, result.location.start_column)
-        self.assertEqual(11, result.location.end_column)
-        self.assertEqual(Level.ERROR, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == "PY004"
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 8
+        assert result.location.end_column == 11
+        assert result.level == Level.ERROR
+        assert result.rank == -1.0

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_cipher.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_cipher.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import go
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class CryptoWeakCipherTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "GO001"
-        self.parser = go.Go()
-        self.base_path = os.path.join(
+class TestCryptoWeakCipher(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "GO001"
+        cls.parser = go.Go()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,24 +26,24 @@ class CryptoWeakCipherTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual(
-            "use_of_a_broken_or_risky_cryptographic_algorithm", rule.name
+        assert rule.id == self.rule_id
+        assert rule.name == "use_of_a_broken_or_risky_cryptographic_algorithm"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
-        )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("327", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "327"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "crypto_weak_cipher_aes.go",
             "crypto_weak_cipher_des.go",
             "crypto_weak_cipher_rc4.go",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_hash.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_hash.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import go
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class CryptoWeakHashTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "GO002"
-        self.parser = go.Go()
-        self.base_path = os.path.join(
+class TestCryptoWeakHash(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "GO002"
+        cls.parser = go.Go()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class CryptoWeakHashTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("reversible_one_way_hash", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "reversible_one_way_hash"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("328", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "328"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "crypto_weak_hash_md5_new.go",
             "crypto_weak_hash_md5_sum.go",
@@ -44,7 +46,7 @@ class CryptoWeakHashTests(test_case.TestCase):
             "crypto_weak_hash_sha1_sum.go",
             "crypto_weak_hash_sha256_new.go",
             "crypto_weak_hash_sha256_sum.go",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_key.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_key.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import go
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class CryptoWeakKeyTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "GO003"
-        self.parser = go.Go()
-        self.base_path = os.path.join(
+class TestCryptoWeakKey(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "GO003"
+        cls.parser = go.Go()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class CryptoWeakKeyTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("inadequate_encryption_strength", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "inadequate_encryption_strength"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "crypto_weak_key_dsa_1024.go",
             "crypto_weak_key_dsa_2048.go",
@@ -45,7 +47,7 @@ class CryptoWeakKeyTests(test_case.TestCase):
             "crypto_weak_key_rsa_2048.go",
             "crypto_weak_key_rsa_4096.go",
             "crypto_weak_key_rsa_bits_as_var.go",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/java/stdlib/java_net/test_insecure_cookie.py
+++ b/tests/unit/rules/java/stdlib/java_net/test_insecure_cookie.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import java
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class InsecureCookieTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "JAV006"
-        self.parser = java.Java()
-        self.base_path = os.path.join(
+class TestInsecureCookie(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "JAV006"
+        cls.parser = java.Java()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,21 +26,23 @@ class InsecureCookieTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("insecure_cookie", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "insecure_cookie"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("614", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "614"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "HttpCookieSecureFalse.java",
             "HttpCookieSecureTrue.java",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import java
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class MessageDigestWeakHashTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "JAV002"
-        self.parser = java.Java()
-        self.base_path = os.path.join(
+class TestMessageDigestWeakHash(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "JAV002"
+        cls.parser = java.Java()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,24 +26,26 @@ class MessageDigestWeakHashTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("reversible_one_way_hash", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "reversible_one_way_hash"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("328", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "328"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "MessageDigestMD2.java",
             "MessageDigestMD5.java",
             "MessageDigestMD5Property.java",
             "MessageDigestSHA1.java",
             "MessageDigestSHA256.java",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_key.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_key.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import java
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class KeyPairGeneratorWeakkeyTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "JAV003"
-        self.parser = java.Java()
-        self.base_path = os.path.join(
+class TestKeyPairGeneratorWeakkey(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "JAV003"
+        cls.parser = java.Java()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,21 +26,23 @@ class KeyPairGeneratorWeakkeyTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("inadequate_encryption_strength", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "inadequate_encryption_strength"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "KeyPairGeneratorDSA.java",
             "KeyPairGeneratorRSA.java",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import java
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SecureRandomWeakRandomTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "JAV004"
-        self.parser = java.Java()
-        self.base_path = os.path.join(
+class TestSecureRandomWeakRandom(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "JAV004"
+        cls.parser = java.Java()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,22 +26,24 @@ class SecureRandomWeakRandomTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("weak_prng", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "weak_prng"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("338", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "338"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "JavaSecuritySecureRandomSHA1PRNG.java",
             "SecureRandomDefault.java",
             "SecureRandomSHA1PRNG.java",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/java/stdlib/javax_crypto/test_weak_cipher.py
+++ b/tests/unit/rules/java/stdlib/javax_crypto/test_weak_cipher.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import java
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class WeakCipherTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "JAV001"
-        self.parser = java.Java()
-        self.base_path = os.path.join(
+class TestWeakCipher(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "JAV001"
+        cls.parser = java.Java()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,19 +26,19 @@ class WeakCipherTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual(
-            "use_of_a_broken_or_risky_cryptographic_algorithm", rule.name
+        assert rule.id == self.rule_id
+        assert rule.name == "use_of_a_broken_or_risky_cryptographic_algorithm"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
-        )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("327", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "327"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "Cipher3DESCBC.java",
             "CipherAESCBC.java",
@@ -48,7 +48,7 @@ class WeakCipherTests(test_case.TestCase):
             "CipherRC2.java",
             "CipherRC4.java",
             "CipherRC5.java",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/java/stdlib/javax_servlet_http/test_insecure_cookie.py
+++ b/tests/unit/rules/java/stdlib/javax_servlet_http/test_insecure_cookie.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import java
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class InsecureCookieTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "JAV005"
-        self.parser = java.Java()
-        self.base_path = os.path.join(
+class TestInsecureCookie(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "JAV005"
+        cls.parser = java.Java()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,21 +26,23 @@ class InsecureCookieTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("insecure_cookie", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "insecure_cookie"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("614", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "614"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "CookieSecureFalse.java",
             "CookieSecureTrue.java",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class ArgparseSensitiveInfoTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY027"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestArgparseSensitiveInfo(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY027"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,24 +26,26 @@ class ArgparseSensitiveInfoTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("visible_sensitive_information", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "visible_sensitive_information"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("214", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "214"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "argparse_add_argument_api_key.py",
             "argparse_add_argument_default_action.py",
             "argparse_add_argument_password.py",
             "argparse_add_argument_password_file.py",
             "argparse_add_argument_password_store_true.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/assert/test_assert.py
+++ b/tests/unit/rules/python/stdlib/assert/test_assert.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class AssertTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY001"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestAssert(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY001"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,20 +26,22 @@ class AssertTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_check", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_check"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("703", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "703"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "assert.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class CryptWeakHashTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY002"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestCryptWeakHash(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY002"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class CryptWeakHashTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("reversible_one_way_hash", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "reversible_one_way_hash"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("328", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "328"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "crypt_crypt.py",
             "crypt_crypt_method_blowfish.py",
@@ -50,7 +52,7 @@ class CryptWeakHashTests(test_case.TestCase):
             "crypt_mksalt_method_md5.py",
             "crypt_mksalt_method_sha256.py",
             "crypt_mksalt_method_sha512.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.artifact import Artifact
 from precli.core.level import Level
@@ -10,12 +10,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class FtpCleartextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY003"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestFtpCleartext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY003"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -27,17 +27,19 @@ class FtpCleartextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("cleartext_transmission", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "cleartext_transmission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("319", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "319"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "ftp.py",
             "ftp_context_mgr.py",
@@ -47,7 +49,7 @@ class FtpCleartextTests(test_case.TestCase):
             "ftplib_ftp_tls.py",
             "ftplib_ftp_user_password.py",
             "ftplib_ftp_tls_user_password.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)
@@ -55,46 +57,46 @@ class FtpCleartextTests(test_case.TestCase):
     def test_ftp_login(self):
         artifact = Artifact(os.path.join(self.base_path, "ftp_login.py"))
         results = self.parser.parse(artifact)
-        self.assertEqual(2, len(results))
+        assert len(results) == 2
         result = results[0]
-        self.assertEqual(self.rule_id, result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(6, result.location.start_column)
-        self.assertEqual(9, result.location.end_column)
-        self.assertEqual(Level.WARNING, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == self.rule_id
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 6
+        assert result.location.end_column == 9
+        assert result.level == Level.WARNING
+        assert result.rank == -1.0
         result = results[1]
-        self.assertEqual(self.rule_id, result.rule_id)
-        self.assertEqual(5, result.location.start_line)
-        self.assertEqual(5, result.location.end_line)
-        self.assertEqual(4, result.location.start_column)
-        self.assertEqual(9, result.location.end_column)
-        self.assertEqual(Level.ERROR, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == self.rule_id
+        assert result.location.start_line == 5
+        assert result.location.end_line == 5
+        assert result.location.start_column == 4
+        assert result.location.end_column == 9
+        assert result.level == Level.ERROR
+        assert result.rank == -1.0
 
     def test_ftplib_ftp_login(self):
         artifact = Artifact(
             os.path.join(self.base_path, "ftplib_ftp_login.py")
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(2, len(results))
+        assert len(results) == 2
         result = results[0]
-        self.assertEqual(self.rule_id, result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(6, result.location.start_column)
-        self.assertEqual(16, result.location.end_column)
-        self.assertEqual(Level.WARNING, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == self.rule_id
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 6
+        assert result.location.end_column == 16
+        assert result.level == Level.WARNING
+        assert result.rank == -1.0
         result = results[1]
-        self.assertEqual(self.rule_id, result.rule_id)
-        self.assertEqual(5, result.location.start_line)
-        self.assertEqual(5, result.location.end_line)
-        self.assertEqual(4, result.location.start_column)
-        self.assertEqual(9, result.location.end_column)
-        self.assertEqual(Level.ERROR, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == self.rule_id
+        assert result.location.start_line == 5
+        assert result.location.end_line == 5
+        assert result.location.start_column == 4
+        assert result.location.end_column == 9
+        assert result.level == Level.ERROR
+        assert result.rank == -1.0
 
     def test_ftplib_ftp_login_single_statement(self):
         artifact = Artifact(
@@ -103,20 +105,20 @@ class FtpCleartextTests(test_case.TestCase):
             )
         )
         results = self.parser.parse(artifact)
-        self.assertEqual(2, len(results))
+        assert len(results) == 2
         result = results[0]
-        self.assertEqual(self.rule_id, result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(32, result.location.start_column)
-        self.assertEqual(37, result.location.end_column)
-        self.assertEqual(Level.ERROR, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == self.rule_id
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 32
+        assert result.location.end_column == 37
+        assert result.level == Level.ERROR
+        assert result.rank == -1.0
         result = results[1]
-        self.assertEqual(self.rule_id, result.rule_id)
-        self.assertEqual(4, result.location.start_line)
-        self.assertEqual(4, result.location.end_line)
-        self.assertEqual(0, result.location.start_column)
-        self.assertEqual(10, result.location.end_column)
-        self.assertEqual(Level.WARNING, result.level)
-        self.assertEqual(-1.0, result.rank)
+        assert result.rule_id == self.rule_id
+        assert result.location.start_line == 4
+        assert result.location.end_line == 4
+        assert result.location.start_column == 0
+        assert result.location.end_column == 10
+        assert result.level == Level.WARNING
+        assert result.rank == -1.0

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class FtplibUnverifiedContextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY022"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestFtplibUnverifiedContext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY022"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,22 +26,24 @@ class FtplibUnverifiedContextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_certificate_validation", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_certificate_validation"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("295", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "295"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "ftplib_ftp_tls_context_as_var.py",
             "ftplib_ftp_tls_context_none.py",
             "ftplib_ftp_tls_context_unset.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class HashlibImproperPrngTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY035"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestHashlibImproperPrng(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY035"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,23 +26,25 @@ class HashlibImproperPrngTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_random", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_random"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("330", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "330"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "hashlib_improper_prng_blake2b.py",
             "hashlib_improper_prng_blake2s.py",
             "hashlib_improper_prng_pbkdf2_hmac.py",
             "hashlib_improper_prng_scrypt.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class HashlibWeakHashTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY004"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestHashlibWeakHash(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY004"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class HashlibWeakHashTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("reversible_one_way_hash", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "reversible_one_way_hash"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("328", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "328"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "hashlib_blake2b.py",
             "hashlib_blake2s.py",
@@ -94,7 +96,7 @@ class HashlibWeakHashTests(test_case.TestCase):
             "hashlib_sha_usedforsecurity_false.py",
             "hashlib_shake_128.py",
             "hashlib_shake_256.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class HmacTimingAttackTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY005"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestHmacTimingAttack(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY005"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,23 +26,25 @@ class HmacTimingAttackTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("observable_timing_discrepancy", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "observable_timing_discrepancy"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("208", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "208"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "hmac_timing_attack.py",
             "hmac_timing_attack_class.py",
             "hmac_timing_attack_class_hexdigest.py",
             "hmac_timing_attack_compare_digest.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class HmacWeakHashTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY006"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestHmacWeakHash(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY006"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class HmacWeakHashTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("reversible_one_way_hash", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "reversible_one_way_hash"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("328", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "328"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "hmac_digest_blake2b.py",
             "hmac_digest_blake2s.py",
@@ -108,7 +110,7 @@ class HmacWeakHashTests(test_case.TestCase):
             "hmac_new_digestmod_sha512.py",
             "hmac_new_digestmod_shake_128.py",
             "hmac_new_digestmod_shake_256.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class HmacWeakKeyTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY034"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestHmacWeakKey(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY034"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class HmacWeakKeyTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("insufficient_key_size", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "insufficient_key_size"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "hmac_digest_weak_key_hashlib_blake2b.py",
             "hmac_digest_weak_key_hashlib_sha3_256.py",
@@ -50,7 +52,7 @@ class HmacWeakKeyTests(test_case.TestCase):
             "hmac_new_weak_key_hashlib_sha3_512.py",
             "hmac_new_weak_key_sha384.py",
             "hmac_new_weak_key_sha512_256.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class HttpServerUnrestrictedBindTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY031"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestHttpServerUnrestrictedBind(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY031"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,21 +26,23 @@ class HttpServerUnrestrictedBindTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("unrestricted_bind", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "unrestricted_bind"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("1327", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "1327"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "http_server_http_server.py",
             "http_server_threading_http_server.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class HttpUrlSecretTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY007"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestHttpUrlSecret(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY007"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class HttpUrlSecretTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("sensitive_query_strings", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "sensitive_query_strings"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("598", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "598"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "http_url_secret_apikey.py",
             "http_url_secret_apikey_in_header.py",
@@ -44,7 +46,7 @@ class HttpUrlSecretTests(test_case.TestCase):
             "http_url_secret_basic_auth_as_var.py",
             "http_url_secret_password.py",
             "http_url_secret_username.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class ImapCleartextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY008"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestImapCleartext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY008"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class ImapCleartextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("cleartext_transmission", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "cleartext_transmission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("319", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "319"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "imaplib_imap4_authenticate.py",
             "imaplib_imap4_context_mgr.py",
@@ -45,7 +47,7 @@ class ImapCleartextTests(test_case.TestCase):
             "imaplib_imap4_ssl.py",
             "imaplib_imap4_starttls.py",
             "imaplib_imap4_stream.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class ImaplibUnverifiedContextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY023"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestImaplibUnverifiedContext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY023"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class ImaplibUnverifiedContextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_certificate_validation", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_certificate_validation"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("295", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "295"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "imaplib_imap4_ssl_context_as_var.py",
             "imaplib_imap4_ssl_context_none.py",
@@ -44,7 +46,7 @@ class ImaplibUnverifiedContextTests(test_case.TestCase):
             "imaplib_imap4_starttls_context_as_var.py",
             "imaplib_imap4_starttls_context_none.py",
             "imaplib_imap4_starttls_context_unset.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/json/test_json_load.py
+++ b/tests/unit/rules/python/stdlib/json/test_json_load.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class JsonLoadTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY009"
-        self.parser = python.Python(enabled=[self.rule_id])
-        self.base_path = os.path.join(
+class TestJsonLoad(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY009"
+        cls.parser = python.Python(enabled=[cls.rule_id])
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,22 +26,24 @@ class JsonLoadTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("deserialization_of_untrusted_data", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "deserialization_of_untrusted_data"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("502", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "502"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "json_jsondecoder_decode.py",
             "json_load.py",
             "json_loads.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
+++ b/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class InsecureListenConfigTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY010"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestInsecureListenConfig(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY010"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class InsecureListenConfigTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("code_injection", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "code_injection"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("94", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "94"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "insecure_listen_config_empty_args.py",
             "insecure_listen_config_port.py",
@@ -45,7 +47,7 @@ class InsecureListenConfigTests(test_case.TestCase):
             "insecure_listen_config_verify_none.py",
             "insecure_listen_config_verify_none_port.py",
             "insecure_listen_config_verify_set.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
+++ b/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class MarshalLoadTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY011"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestMarshalLoad(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY011"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,21 +26,23 @@ class MarshalLoadTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("deserialization_of_untrusted_data", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "deserialization_of_untrusted_data"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("502", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "502"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "marshal_load.py",
             "marshal_loads.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class NntpCleartextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY012"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestNntpCleartext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY012"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,23 +26,25 @@ class NntpCleartextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("cleartext_transmission", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "cleartext_transmission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("319", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "319"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "nntplib_nntp_context_mgr.py",
             "nntplib_nntp_login.py",
             "nntplib_nntp_ssl.py",
             "nntplib_nntp_starttls.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class NntplibUnverifiedContextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY024"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestNntplibUnverifiedContext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY024"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class NntplibUnverifiedContextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_certificate_validation", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_certificate_validation"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("295", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "295"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "nntplib_nntp_ssl_context_as_var.py",
             "nntplib_nntp_ssl_context_none.py",
@@ -44,7 +46,7 @@ class NntplibUnverifiedContextTests(test_case.TestCase):
             "nntplib_nntp_starttls_context_as_var.py",
             "nntplib_nntp_starttls_context_none.py",
             "nntplib_nntp_starttls_context_unset.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
+++ b/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class PickleLoadTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY013"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestPickleLoad(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY013"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,22 +26,24 @@ class PickleLoadTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("deserialization_of_untrusted_data", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "deserialization_of_untrusted_data"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("502", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "502"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "pickle_load.py",
             "pickle_loads.py",
             "pickle_unpickler.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class PopCleartextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY014"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestPopCleartext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY014"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class PopCleartextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("cleartext_transmission", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "cleartext_transmission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("319", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "319"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "poplib_pop3_apop.py",
             "poplib_pop3_context_mgr.py",
@@ -45,7 +47,7 @@ class PopCleartextTests(test_case.TestCase):
             "poplib_pop3_ssl.py",
             "poplib_pop3_stls.py",
             "poplib_pop3_user.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class PoplibUnverifiedContextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY025"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestPoplibUnverifiedContext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY025"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class PoplibUnverifiedContextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_certificate_validation", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_certificate_validation"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("295", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "295"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "poplib_pop3_ssl_context_as_var.py",
             "poplib_pop3_ssl_context_none.py",
@@ -44,7 +46,7 @@ class PoplibUnverifiedContextTests(test_case.TestCase):
             "poplib_pop3_stls_context_as_var.py",
             "poplib_pop3_stls_context_none.py",
             "poplib_pop3_stls_context_unset.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
+++ b/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class ReDenialOfService(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY033"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestReDenialOfService(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY033"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class ReDenialOfService(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("regex_denial_of_service", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "regex_denial_of_service"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("1333", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "1333"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "re_compile.py",
             "re_compile_good.py",
@@ -49,7 +51,7 @@ class ReDenialOfService(test_case.TestCase):
             "re_finditer.py",
             "re_sub.py",
             "re_subn.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
+++ b/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SecretsWeakTokenTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY028"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSecretsWeakToken(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY028"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,24 +26,26 @@ class SecretsWeakTokenTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("insufficient_token_length", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "insufficient_token_length"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "secrets_token_bytes.py",
             "secrets_token_bytes_default.py",
             "secrets_token_bytes_size_var.py",
             "secrets_token_hex.py",
             "secrets_token_urlsafe.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
+++ b/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class ShelveOpenTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY015"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestShelveOpen(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY015"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,22 +26,24 @@ class ShelveOpenTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("deserialization_of_untrusted_data", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "deserialization_of_untrusted_data"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("502", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "502"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "shelve_dbfilenameshelf.py",
             "shelve_open.py",
             "shelve_open_context_mgr.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SmtpCleartextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY016"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSmtpCleartext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY016"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,24 +26,26 @@ class SmtpCleartextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("cleartext_transmission", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "cleartext_transmission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("319", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "319"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "smtplib_smtp_auth.py",
             "smtplib_smtp_context_mgr.py",
             "smtplib_smtp_login.py",
             "smtplib_smtp_ssl.py",
             "smtplib_smtp_starttls.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SmtplibUnverifiedContextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY026"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSmtplibUnverifiedContext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY026"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class SmtplibUnverifiedContextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_certificate_validation", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_certificate_validation"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("295", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "295"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "smtplib_smtp_ssl_context_as_var.py",
             "smtplib_smtp_ssl_context_none.py",
@@ -44,7 +46,7 @@ class SmtplibUnverifiedContextTests(test_case.TestCase):
             "smtplib_smtp_starttls_context_as_var.py",
             "smtplib_smtp_starttls_context_none.py",
             "smtplib_smtp_starttls_context_unset.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SocketUnrestrictedBindTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY029"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSocketUnrestrictedBind(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY029"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,23 +26,25 @@ class SocketUnrestrictedBindTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("unrestricted_bind", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "unrestricted_bind"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("1327", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "1327"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "socket_create_server.py",
             "socket_socket_bind.py",
             "socket_socket_bind_as_var.py",
             "socket_socket_bind_as_vars.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SocketserverUnrestrictedBindTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY030"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSocketserverUnrestrictedBind(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY030"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class SocketserverUnrestrictedBindTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("unrestricted_bind", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "unrestricted_bind"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("1327", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "1327"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "socketserver_tcp_server.py",
             "socketserver_udp_server.py",
@@ -44,7 +46,7 @@ class SocketserverUnrestrictedBindTests(test_case.TestCase):
             "socketserver_forking_udp_server.py",
             "socketserver_threading_tcp_server.py",
             "socketserver_threading_udp_server.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SslSocketTlsVersionTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY018"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSslSocketTlsVersion(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY018"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class SslSocketTlsVersionTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("inadequate_encryption_strength", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "inadequate_encryption_strength"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "ssl_context_sslv2.py",
             "ssl_context_sslv23.py",
@@ -44,7 +46,7 @@ class SslSocketTlsVersionTests(test_case.TestCase):
             "ssl_context_tlsv1.py",
             "ssl_context_tlsv11.py",
             "ssl_context_tlsv12.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SslSocketWeakKeyTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY019"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSslSocketWeakKey(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY019"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class SslSocketWeakKeyTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("inadequate_encryption_strength", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "inadequate_encryption_strength"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "ssl_context_set_ecdh_curve_brainpoolP256r1.py",
             "ssl_context_set_ecdh_curve_brainpoolP384r1.py",
@@ -53,7 +55,7 @@ class SslSocketWeakKeyTests(test_case.TestCase):
             "ssl_context_set_ecdh_curve_typed_default_param.py",
             "ssl_context_set_ecdh_curve_typed_param.py",
             "ssl_context_set_ecdh_curve_unverified_context.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class SslCreateContextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY017"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestSslCreateContext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY017"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,21 +26,23 @@ class SslCreateContextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("improper_certificate_validation", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "improper_certificate_validation"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("295", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "295"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "create_default_context.py",
             "create_unverified_context.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class GetServerCertificateTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY018"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestGetServerCertificate(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY018"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class GetServerCertificateTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("inadequate_encryption_strength", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "inadequate_encryption_strength"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "get_server_certificate_sslv2.py",
             "get_server_certificate_sslv23.py",
@@ -44,7 +46,7 @@ class GetServerCertificateTests(test_case.TestCase):
             "get_server_certificate_tlsv1.py",
             "get_server_certificate_tlsv11.py",
             "get_server_certificate_tlsv12.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class WrapSocketTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY018"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestWrapSocket(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY018"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class WrapSocketTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("inadequate_encryption_strength", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "inadequate_encryption_strength"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("326", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "326"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "wrap_socket_sslv2.py",
             "wrap_socket_sslv23.py",
@@ -45,7 +47,7 @@ class WrapSocketTests(test_case.TestCase):
             "wrap_socket_tlsv1.py",
             "wrap_socket_tlsv11.py",
             "wrap_socket_tlsv12.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class TelnetlibCleartextTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY020"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestTelnetlibCleartext(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY020"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,22 +26,24 @@ class TelnetlibCleartextTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("cleartext_transmission", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "cleartext_transmission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.ERROR, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("319", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "319"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "telnet.py",
             "telnetlib_telnet.py",
             "telnetlib_telnet_context_mgr.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
+++ b/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class MktempRaceConditionTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY021"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestMktempRaceCondition(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY021"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,17 +26,19 @@ class MktempRaceConditionTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("insecure_temporary_file", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "insecure_temporary_file"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("377", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "377"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "tempfile_mktemp.py",
             "tempfile_mktemp_args_open.py",
@@ -45,7 +47,7 @@ class MktempRaceConditionTests(test_case.TestCase):
             "tempfile_mktemp_walrus_open.py",
             "tempfile_mktemp_with_open.py",
             "tempfile_mktemp_with_open_multiline.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-from parameterized import parameterized
+import pytest
 
 from precli.core.level import Level
 from precli.parsers import python
@@ -9,12 +9,12 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class XmlrpcServerUnrestrictedBindTests(test_case.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.rule_id = "PY032"
-        self.parser = python.Python()
-        self.base_path = os.path.join(
+class TestXmlrpcServerUnrestrictedBind(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY032"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
             "tests",
             "unit",
             "rules",
@@ -26,21 +26,23 @@ class XmlrpcServerUnrestrictedBindTests(test_case.TestCase):
 
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
-        self.assertEqual(self.rule_id, rule.id)
-        self.assertEqual("unrestricted_bind", rule.name)
-        self.assertEqual(
-            f"https://docs.securesauce.dev/rules/{self.rule_id}", rule.help_url
+        assert rule.id == self.rule_id
+        assert rule.name == "unrestricted_bind"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        self.assertEqual(True, rule.default_config.enabled)
-        self.assertEqual(Level.WARNING, rule.default_config.level)
-        self.assertEqual(-1.0, rule.default_config.rank)
-        self.assertEqual("1327", rule.cwe.cwe_id)
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.cwe_id == "1327"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "filename",
         [
             "xmlrpc_server_doc_xml_rpc_server.py",
             "xmlrpc_server_simple_xml_rpc_server.py",
-        ]
+        ],
     )
     def test(self, filename):
         self.check(filename)

--- a/tests/unit/rules/test_case.py
+++ b/tests/unit/rules/test_case.py
@@ -1,16 +1,11 @@
 # Copyright 2024 Secure Saurce LLC
 import os
 
-import testtools
-
 from precli.core.artifact import Artifact
 from precli.core.level import Level
 
 
-class TestCase(testtools.TestCase):
-    def setUp(self):
-        super().setUp()
-
+class TestCase:
     def expected(self, filename):
         with open(os.path.join(self.base_path, filename)) as f:
             level = f.readline().strip()
@@ -49,15 +44,15 @@ class TestCase(testtools.TestCase):
         artifact = Artifact(os.path.join(self.base_path, filename))
         results = self.parser.parse(artifact)
         if level == Level.NONE:
-            self.assertEqual(0, len(results))
+            assert len(results) == 0
         else:
             results = list(filter(lambda x: x.level != Level.NOTE, results))
-            self.assertEqual(1, len(results))
+            assert len(results) == 1
             result = results[0]
-            self.assertEqual(self.rule_id, result.rule_id)
-            self.assertEqual(start_line, result.location.start_line)
-            self.assertEqual(end_line, result.location.end_line)
-            self.assertEqual(start_column, result.location.start_column)
-            self.assertEqual(end_column, result.location.end_column)
-            self.assertEqual(level, result.level)
-            self.assertEqual(-1.0, result.rank)
+            assert result.rule_id == self.rule_id
+            assert result.location.start_line == start_line
+            assert result.location.end_line == end_line
+            assert result.location.start_column == start_column
+            assert result.location.end_column == end_column
+            assert result.level == level
+            assert result.rank == -1.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-    stestr run {posargs}
+    pytest {posargs}
 passenv = http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, NO_PROXY
 
 [testenv:format]
@@ -44,3 +44,9 @@ commands =
 skip_install = true
 deps = pyclean
 commands = pyclean {posargs:. --debris}
+
+[pytest]
+minversion = 6.0
+addopts = -v
+testpaths =
+    tests


### PR DESCRIPTION
This large commit switches over the test framework from stestr to the more common and popular pytest. We're able to drop a test dependency of parameterized because pytest provides the same function.

This will enable us to do performance benchmark testing later using pytest.