### PR TITLE
Delete .stestr.conf

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,3 +1,0 @@
-[DEFAULT]
-test_path=tests
-top_dir=./


### PR DESCRIPTION
This is no longer needed after the migration from stestr to pytest