### PR TITLE
Use f-string instead of string substitution

### DIFF
--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -136,7 +136,7 @@ class Run:
                 )
 
             if parser is not None:
-                LOG.debug("Working on file: %s", artifact.file_name)
+                LOG.debug(f"Working on file: {artifact.file_name}")
                 artifact.language = parser.lexer
                 return parser.parse(artifact)
         except KeyboardInterrupt:


### PR DESCRIPTION
Legacy use of string substitution found. Switch it to f-string.