### PR TITLE
Remove some docstring comments on return and params

### DIFF
--- a/precli/core/argument.py
+++ b/precli/core/argument.py
@@ -35,12 +35,7 @@ class Argument:
 
     @property
     def node(self) -> Node:
-        """
-        The node representing this argument.
-
-        :return: node for the argument
-        :rtype: Node
-        """
+        """The node representing this argument."""
         return self._node
 
     @property
@@ -51,9 +46,6 @@ class Argument:
         For example, if the function is:
             a.b.c()
         The identifier node would be c
-
-        :return: identifier of the argument
-        :rtype: Node
         """
         return self._ident_node
 
@@ -64,9 +56,6 @@ class Argument:
 
         If this argument is a keyword argument, then name is the
         name component of the name-value pair.
-
-        :return: name of keyword arg
-        :rtype: str
         """
         return self._name
 
@@ -77,38 +66,20 @@ class Argument:
 
         If this argument is a positional, then position references
         the index in the arg list of the argument.
-
-        :return: index in arg list
-        :rtype: int
         """
         return self._position
 
     @property
     def is_str(self) -> bool:
-        """
-        True if the value is a true string.
-
-        :return: if value is a string
-        :rtype: bool
-        """
+        """True if the value is a true string."""
         return self._is_str
 
     @property
     def value(self):
-        """
-        The value of the argument.
-
-        :return: value of argument
-        :rtype: object
-        """
+        """The value of the argument."""
         return self._value
 
     @property
     def value_str(self) -> str:
-        """
-        The value as a true string.
-
-        :return: value as string
-        :rtype: str
-        """
+        """The value as a true string."""
         return self._value_str

--- a/precli/core/artifact.py
+++ b/precli/core/artifact.py
@@ -11,76 +11,40 @@ class Artifact:
 
     @property
     def file_name(self) -> str:
-        """
-        The name of the file.
-
-        :return: file name
-        :rtype: str
-        """
+        """The name of the file."""
         return self._file_name
 
     @file_name.setter
     def file_name(self, file_name):
-        """
-        Set the file name
-
-        :param str file_name: file name
-        """
+        """Set the file name"""
         self._file_name = file_name
 
     @property
     def uri(self) -> str:
-        """
-        The URI of the artifact.
-
-        :return: URI
-        :rtype: str
-        """
+        """The URI of the artifact."""
         return self._uri
 
     @uri.setter
     def uri(self, uri):
-        """
-        Set the artifact URI.
-
-        :param str uri: URI
-        """
+        """Set the artifact URI."""
         self._uri = uri
 
     @property
     def contents(self) -> str:
-        """
-        The contents of the artifact.
-
-        :return: typically file contents
-        :rtype: str
-        """
+        """The contents of the artifact."""
         return self._contents
 
     @contents.setter
     def contents(self, contents) -> str:
-        """
-        Set the contents (for typically the file).
-
-        :param str contents: file contents
-        """
+        """Set the contents (for typically the file)."""
         self._contents = contents
 
     @property
     def language(self) -> str:
-        """
-        The programming language for this artifact.
-
-        :return: programming language name
-        :rtype: str
-        """
+        """The programming language for this artifact."""
         return self._language
 
     @language.setter
     def language(self, language) -> str:
-        """
-        Set the programming language.
-
-        :param str language: program language
-        """
+        """Set the programming language."""
         self._language = language

--- a/precli/core/call.py
+++ b/precli/core/call.py
@@ -30,12 +30,7 @@ class Call:
 
     @property
     def node(self) -> Node:
-        """
-        The node representing this call.
-
-        :return: node for the call
-        :rtype: Node
-        """
+        """The node representing this call."""
         return self._node
 
     @property
@@ -46,9 +41,6 @@ class Call:
         For example, if the function call is:
             a.b.c()
         The function node would be a.b
-
-        :return: function for the call
-        :rtype: Node
         """
         return self._var_node
 
@@ -60,9 +52,6 @@ class Call:
         For example, if the function call is:
             a.b.c()
         The function node would be a.b.c
-
-        :return: function for the call
-        :rtype: Node
         """
         return self._func_node
 
@@ -74,30 +63,17 @@ class Call:
         For example, if the function call is:
             a.b.c()
         The identifier node would be c
-
-        :return: identifier of the function
-        :rtype: Node
         """
         return self._ident_node
 
     @property
     def name(self) -> str:
-        """
-        The name of the function call.
-
-        :return: name of function
-        :rtype: str
-        """
+        """The name of the function call."""
         return self._name
 
     @property
     def name_qualified(self) -> str:
-        """
-        The fully qualified name of the function.
-
-        :return: fully qualified name of function
-        :rtype: str
-        """
+        """The fully qualified name of the function."""
         return self._name_qual
 
     @property

--- a/precli/core/comparison.py
+++ b/precli/core/comparison.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Sauce LLC
+# Copyright 2024 Secure Sauce LLC
 from tree_sitter import Node
 
 
@@ -20,70 +20,35 @@ class Comparison:
 
     @property
     def node(self) -> Node:
-        """
-        The node representing this comparison.
-
-        :return: node for the comparison
-        :rtype: Node
-        """
+        """The node representing this comparison."""
         return self._node
 
     @property
     def left_node(self) -> Node:
-        """
-        The left node of the comparison.
-
-        :return: left node of comparison
-        :rtype: Node
-        """
+        """The left node of the comparison."""
         return self._left_node
 
     @property
     def operator_node(self) -> Node:
-        """
-        The operator node of this comparison.
-
-        :return: operator node of comparison
-        :rtype: Node
-        """
+        """The operator node of this comparison."""
         return self._operator_node
 
     @property
     def right_node(self) -> Node:
-        """
-        The right node of the comparison.
-
-        :return: right node of comparison
-        :rtype: Node
-        """
+        """The right node of the comparison."""
         return self._right_node
 
     @property
     def left_hand(self) -> str:
-        """
-        The left hand side of the comparison.
-
-        :return: left part of comparison
-        :rtype: str
-        """
+        """The left hand side of the comparison."""
         return self._left_hand
 
     @property
     def operator(self) -> str:
-        """
-        The operator of this comparison.
-
-        :return: operator of comparison
-        :rtype: str
-        """
+        """The operator of this comparison."""
         return self._operator
 
     @property
     def right_hand(self) -> str:
-        """
-        The right hand side of the comparison.
-
-        :return: right part of comparison
-        :rtype: str
-        """
+        """The right hand side of the comparison."""
         return self._right_hand

--- a/precli/core/config.py
+++ b/precli/core/config.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Secure Sauce LLC
+# Copyright 2024 Secure Sauce LLC
 from precli.core.level import Level
 
 
@@ -15,39 +15,20 @@ class Config:
 
     @property
     def enabled(self) -> bool:
-        """
-        Whether the configuration indicates the rule is enabled.
-
-        :return: true if rule enabled
-        :rtype: bool
-        """
+        """Whether the configuration indicates the rule is enabled."""
         return self._enabled
 
     @enabled.setter
     def enabled(self, enabled):
-        """
-        Set whether the rule is enabled
-
-        :param bool enabled: True to enable
-        """
+        """Set whether the rule is enabled"""
         self._enabled = enabled
 
     @property
     def level(self) -> Level:
-        """
-        The default severity level.
-
-        :return: severity level
-        :rtype: Level
-        """
+        """The default severity level."""
         return self._level
 
     @property
     def rank(self) -> float:
-        """
-        The default rank for the rule.
-
-        :return: rank
-        :rtype: float
-        """
+        """The default rank for the rule."""
         return self._rank

--- a/precli/core/fix.py
+++ b/precli/core/fix.py
@@ -15,30 +15,15 @@ class Fix:
 
     @property
     def description(self) -> str:
-        """
-        Describes the proposed fix.
-
-        :return: fix description
-        :rtype: str
-        """
+        """Describes the proposed fix."""
         return self._description
 
     @property
     def deleted_location(self) -> Location:
-        """
-        Specifies the location to delete.
-
-        :return: location object indicating region to delete
-        :rtype: Location
-        """
+        """Specifies the location to delete."""
         return self._deleted_location
 
     @property
     def inserted_content(self) -> str:
-        """
-        Content to insert at location specified by deleted_location.
-
-        :return: content to insert
-        :rtype: str
-        """
+        """Content to insert at location specified by deleted_location."""
         return self._inserted_content

--- a/precli/core/location.py
+++ b/precli/core/location.py
@@ -25,40 +25,20 @@ class Location:
 
     @property
     def start_line(self) -> int:
-        """
-        The starting line of the issue.
-
-        :return: starting line
-        :rtype: int
-        """
+        """The starting line of the issue."""
         return self._start_line
 
     @property
     def end_line(self) -> int:
-        """
-        The ending line of the issue.
-
-        :return: ending line
-        :rtype: int
-        """
+        """The ending line of the issue."""
         return self._end_line
 
     @property
     def start_column(self) -> int:
-        """
-        The starting column of the issue.
-
-        :return: starting column
-        :rtype: int
-        """
+        """The starting column of the issue."""
         return self._start_column
 
     @property
     def end_column(self) -> int:
-        """
-        The ending column of the issue.
-
-        :return: ending column
-        :rtype: int
-        """
+        """The ending column of the issue."""
         return self._end_column

--- a/precli/core/metrics.py
+++ b/precli/core/metrics.py
@@ -20,60 +20,30 @@ class Metrics:
 
     @property
     def files(self) -> int:
-        """
-        Number of files analyzed.
-
-        :return: number of files
-        :rtype: int
-        """
+        """Number of files analyzed."""
         return self._files
 
     @property
     def files_skipped(self) -> int:
-        """
-        Number of files skipped due to exclusion or parsing problem.
-
-        :return: number of files skipped
-        :rtype: int
-        """
+        """Number of files skipped due to exclusion or parsing problem."""
         return self._files_skipped
 
     @property
     def lines(self) -> int:
-        """
-        Total number of lines analyzed.
-
-        :return: number of lines
-        :rtype: int
-        """
+        """Total number of lines analyzed."""
         return self._lines
 
     @property
     def errors(self) -> int:
-        """
-        Total number of errors found.
-
-        :return: number of errors
-        :rtype: int
-        """
+        """Total number of errors found."""
         return self._errors
 
     @property
     def warnings(self) -> int:
-        """
-        Total number of warnings found.
-
-        :return: number of warnings
-        :rtype: int
-        """
+        """Total number of warnings found."""
         return self._warnings
 
     @property
     def notes(self) -> int:
-        """
-        Total number of notes found.
-
-        :return: number of notes
-        :rtype: int
-        """
+        """Total number of notes found."""
         return self._notes

--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -62,29 +62,17 @@ class Result:
 
         The IDs match ??XXX where ?? is language identifier and XXX is a
         unique number.
-
-        :return: rule ID
-        :rtype: str
         """
         return self._rule_id
 
     @property
     def artifact(self) -> Artifact:
-        """
-        Artifact, typically the file.
-
-        :return: the artifact
-        :rtype: Artifact
-        """
+        """Artifact, typically the file."""
         return self._artifact
 
     @artifact.setter
-    def artifact(self, artifact):
-        """
-        Set the file artifact.
-
-        :param Artifact artifact: file artifact
-        """
+    def artifact(self, artifact: Artifact):
+        """Set the file artifact."""
         self._artifact = artifact
         self._init_snippet(artifact)
 
@@ -95,9 +83,6 @@ class Result:
 
         A location object indicates coordinates within a source file where
         the issue was found.
-
-        :return: location
-        :rtype: Location
         """
         return self._location
 
@@ -108,9 +93,6 @@ class Result:
 
         Typically having a value of pass or fail to indicate the nature of
         the result.
-
-        :return: kind or nature of result
-        :rtype: Kind
         """
         return self._kind
 
@@ -120,20 +102,12 @@ class Result:
         The result severity level.
 
         If the result is being supporessed, then the level is set to NOTE.
-
-        :return: severity level
-        :rtype: Level
         """
         return self._level if self._suppression is None else Level.NOTE
 
     @property
     def message(self) -> str:
-        """
-        The result issue message.
-
-        :return: issue message
-        :rtype: str
-        """
+        """The result issue message."""
         if self._suppression is None:
             return self._message
         else:
@@ -146,47 +120,25 @@ class Result:
 
         The value defaults to the value from the default configuration of the
         rule.
-
-        :return: rank
-        :rtype: float
         """
         return self._rank
 
     @property
     def fixes(self) -> list[Fix]:
-        """
-        The suggested fixes for the issue.
-
-        :return: list of fixes
-        :rtype: list
-        """
+        """The suggested fixes for the issue."""
         return self._fixes if self._suppression is None else []
 
     @property
     def suppression(self) -> Suppression:
-        """
-        Possible suppressions of the result.
-
-        :return: suppression or None
-        :rtype: Suppression
-        """
+        """Possible suppressions of the result."""
         return self._suppression
 
     @suppression.setter
-    def suppression(self, suppression):
-        """
-        Set the suppression of this result
-
-        :param Suppression suppression: suppression
-        """
+    def suppression(self, suppression: Suppression):
+        """Set the suppression of this result"""
         self._suppression = suppression
 
     @property
     def snippet(self) -> str:
-        """
-        Snippet of context of the code.
-
-        :return: snippet of context
-        :rtype: str
-        """
+        """Snippet of context of the code."""
         return self._snippet

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -47,12 +47,7 @@ class Run:
 
     @property
     def tool(self) -> Tool:
-        """
-        Get the tool associated with this run.
-
-        :return: tool object
-        :rtype: Tool
-        """
+        """Get the tool associated with this run."""
         return self._tool
 
     def invoke(self):
@@ -165,20 +160,10 @@ class Run:
 
     @property
     def results(self) -> list[Result]:
-        """
-        Get the list of results.
-
-        :return: list of results
-        :rtype: list
-        """
+        """Get the list of results."""
         return self._results
 
     @property
     def metrics(self) -> list[Result]:
-        """
-        Get the list of results.
-
-        :return: list of results
-        :rtype: list
-        """
+        """Get the list of results."""
         return self._metrics

--- a/precli/core/suppression.py
+++ b/precli/core/suppression.py
@@ -20,22 +20,12 @@ class Suppression:
 
     @property
     def location(self) -> Location:
-        """
-        Specifies the location of the suppression.
-
-        :return: location of suppression
-        :rtype: Location
-        """
+        """Specifies the location of the suppression."""
         return self._location
 
     @property
     def rules(self) -> set[str]:
-        """
-        What rules are being suppressed.
-
-        :return: set of rule ID/names
-        :rtype: set
-        """
+        """What rules are being suppressed."""
         return self._rules
 
     @property
@@ -44,28 +34,15 @@ class Suppression:
         The kind of suppression. This can be one of two values:
             "inSource" supporessed inline in the code
             "external" suppressed in an external persistent store
-
-        :return: kind of suppression
-        :rtype: str
         """
         return self._kind
 
     @property
     def status(self) -> Status:
-        """
-        The status of the suppression.
-
-        :return: status on whether to suppress
-        :rtype: Status
-        """
+        """The status of the suppression."""
         return self._status
 
     @property
     def justification(self) -> str:
-        """
-        User-supplied string that explains why the result was suppressed.
-
-        :return: why the result was suppressed
-        :rtype: str
-        """
+        """User-supplied string that explains why the result was suppressed."""
         return self._justification

--- a/precli/core/tool.py
+++ b/precli/core/tool.py
@@ -28,110 +28,55 @@ class Tool:
 
     @property
     def name(self) -> str:
-        """
-        Name of the tool.
-
-        :return: tool name
-        :rtype: str
-        """
+        """Name of the tool."""
         return self._name
 
     @property
     def download_uri(self) -> str:
-        """
-        URI location to download tool.
-
-        :return: location of download
-        :rtype: str
-        """
+        """URI location to download tool."""
         return self._download_uri
 
     @property
     def full_description(self) -> str:
-        """
-        Full description of the tool.
-
-        :return: full description
-        :rtype: str
-        """
+        """Full description of the tool."""
         return self._full_description
 
     @property
     def information_uri(self) -> str:
-        """
-        Main page URL of the project
-
-        :return: information URI
-        :rtype: str
-        """
+        """Main page URL of the project"""
         return self._information_uri
 
     @property
     def organization(self) -> str:
-        """
-        Organization that produced the tool.
-
-        :return: organization name
-        :rtype: str
-        """
+        """Organization that produced the tool."""
         return self._organization
 
     @property
     def short_description(self) -> str:
-        """
-        Short description of the tool.
-
-        :return: short description
-        :rtype: str
-        """
+        """Short description of the tool."""
         return self._short_description
 
     @property
     def version(self) -> str:
-        """
-        Version of the tool.
-
-        :return: tool version
-        :rtype: str
-        """
+        """Version of the tool."""
         return self._version
 
     @property
     def release_date(self) -> str:
-        """
-        Release date of the tool.
-
-        :return: release date
-        :rtype: str
-        """
+        """Release date of the tool."""
         return self._release_date
 
     @property
     def extensions(self) -> list:
-        """
-        Extensions for the tool in use.
-
-        :return: extension list
-        :rtype: list
-        """
+        """Extensions for the tool in use."""
         return self._extensions
 
     @property
     def rules(self) -> list[Rule]:
-        """
-        Set of supported rules.
-
-        :return: policy list
-        :rtype: list
-        """
+        """Set of supported rules."""
         return self._rules
 
     @property
     def policies(self) -> list:
-        """
-        Set of rule configurations.
-
-        :return: policy list
-        :rtype: list
-        """
+        """Set of rule configurations."""
         return self._policies

--- a/precli/core/utils.py
+++ b/precli/core/utils.py
@@ -2,12 +2,7 @@
 
 
 def is_str(value) -> bool:
-    """
-    True if the value is a tree-sitter node string.
-
-    :return: if value is a string
-    :rtype: bool
-    """
+    """True if the value is a tree-sitter node string."""
     if isinstance(value, str) and (
         value.startswith('b"""')
         or value.startswith("b'''")
@@ -26,9 +21,6 @@ def to_str(value: str) -> str:
     """
     Converts a tree-sitter node string value to a
     true string.
-
-    :return: value as string
-    :rtype: str
     """
     if isinstance(value, str):
         value_str = value

--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -77,31 +77,15 @@ class Parser(ABC):
 
     @property
     def lexer(self) -> str:
-        """
-        The name of the lexer
-
-        :return: lexer name
-        :rtype: str
-        """
+        """The name of the lexer"""
         return self._lexer
 
     @abstractmethod
     def file_extensions(self) -> list[str]:
-        """
-        File extension of files this parser can handle.
-        :return: file extensions such as ".py"
-        :rtype: list
-        """
+        """File extension of files this parser can handle."""
 
     def parse(self, artifact: Artifact) -> list[Result]:
-        """
-        File extension of files this parser can handle.
-
-        :param Artifact artifact: artifact representing the file
-
-        :return: list of results
-        :rtype: list
-        """
+        """File extension of files this parser can handle."""
         self.results = []
         self.context = {"artifact": artifact}
         if artifact.contents is None:
@@ -125,8 +109,6 @@ class Parser(ABC):
 
         THis function will visit each node and attempt to call a more
         specific visit function if defined based on the node type.
-
-        :param list nodes: list of nodes
         """
         for node in nodes:
             # print(node)
@@ -207,11 +189,6 @@ class Parser(ABC):
 
         This function will iterate through all rules that are designed to
         handle the given node type (node_type).
-
-        :param str node_type: process nodes of this node type
-
-        :return: list of results
-        :rtype: list
         """
         fn = f"analyze_{node_type}"
         for rule in self.rules.values():

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -62,14 +62,7 @@ class Rule(ABC):
 
     @staticmethod
     def get_by_id(id: str) -> Self:
-        """
-        Get the rule instance by the given ID.
-
-        :param str id: rule ID
-
-        :return: rule instance
-        :rtype: Rule
-        """
+        """Get the rule instance by the given ID."""
         return Rule._rules.get(id)
 
     @property
@@ -79,70 +72,37 @@ class Rule(ABC):
 
         The rule name is an alpha string corresponding to the CWE name
         but in snake case format.
-
-        :return: rule name
-        :rtype: str
         """
         return self._name
 
     @property
     def short_description(self) -> str:
-        """
-        Short description of the rule.
-
-        :return: rule short description
-        :rtype: str
-        """
+        """Short description of the rule."""
         return self._short_descr
 
     @property
     def full_description(self) -> str:
-        """
-        Full description of the rule in markdown format.
-
-        :return: rule full description
-        :rtype: str
-        """
+        """Full description of the rule in markdown format."""
         return self._full_descr
 
     @property
     def help_url(self) -> str:
-        """
-        URL to help documentation.
-
-        :return: rule help documentation URL
-        :rtype: str
-        """
+        """URL to help documentation."""
         return self._help_url
 
     @property
     def default_config(self) -> Config:
-        """
-        Default configuration for this rule.
-
-        :return: configuration
-        :rtype: Config
-        """
+        """Default configuration for this rule."""
         return self._config
 
     @property
     def cwe(self) -> Weakness:
-        """
-        CWE weakness object for this rule.
-
-        :return: CWE weakness object
-        :rtype: Weakness
-        """
+        """CWE weakness object for this rule."""
         return self._cwe
 
     @property
     def message(self) -> str:
-        """
-        Concise description message of the found issue.
-
-        :return: issue message
-        :rtype: str
-        """
+        """Concise description message of the found issue."""
         return self._message
 
     @property
@@ -155,9 +115,6 @@ class Rule(ABC):
 
         The * must map to concrete module names in order to fully resolve
         for rule matching.
-
-        :return: mapping of wildcard imports
-        :rtype: dict
         """
         return self._wildcards
 


### PR DESCRIPTION
Any function that already uses types, doesn't really need to redundantly have docstrings that denote what the parameter or return type is.