### PR TITLE
Fix unknown value for nbytes

### DIFF
--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -72,7 +72,7 @@ class SecretsWeakToken(Rule):
             return
 
         arg = call.get_argument(position=0, name="nbytes")
-        nbytes = int(arg.value) if arg.value else 32
+        nbytes = int(arg.value) if isinstance(arg.value, int) else 32
 
         if nbytes < 32:
             fixes = Rule.get_fixes(

--- a/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_hex_nbytes_unknown.py
+++ b/tests/unit/rules/python/stdlib/secrets/examples/secrets_token_hex_nbytes_unknown.py
@@ -1,0 +1,8 @@
+# level: NONE
+import secrets
+
+
+_SHM_SAFE_NAME_LENGTH = 14
+_SHM_NAME_PREFIX = "/psm_"
+nbytes = (_SHM_SAFE_NAME_LENGTH - len(_SHM_NAME_PREFIX)) // 2
+name = _SHM_NAME_PREFIX + secrets.token_hex(nbytes)

--- a/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
+++ b/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
@@ -44,6 +44,7 @@ class TestSecretsWeakToken(test_case.TestCase):
             "secrets_token_bytes_default.py",
             "secrets_token_bytes_size_var.py",
             "secrets_token_hex.py",
+            "secrets_token_hex_nbytes_unknown.py",
             "secrets_token_urlsafe.py",
         ],
     )


### PR DESCRIPTION
If the nbytes argument to token_hex cannot be determined from the symbols, analysis should not fail with an error, and just continue.

Fixes: #474