### PR TITLE
Nicer output using rich.console

### DIFF
--- a/precli/renderers/__init__.py
+++ b/precli/renderers/__init__.py
@@ -1,22 +1,15 @@
 # Copyright 2024 Secure Sauce LLC
-import sys
 from abc import ABC
 from abc import abstractmethod
 
-from rich import console
+from rich.console import Console
 
 from precli.core.run import Run
 
 
 class Renderer(ABC):
-    def __init__(self, file: sys.stdout, no_color: bool = False):
-        self._file = file
-        self._no_color = True if file.name != sys.stdout.name else no_color
-        self.console = console.Console(
-            file=file,
-            no_color=no_color,
-            highlight=False,
-        )
+    def __init__(self, console: Console):
+        self.console = console
 
     @abstractmethod
     def render(self, run: Run):

--- a/precli/renderers/detailed.py
+++ b/precli/renderers/detailed.py
@@ -1,8 +1,7 @@
 # Copyright 2024 Secure Sauce LLC
-import sys
-
 from rich import box
 from rich import syntax
+from rich.console import Console
 from rich.table import Table
 
 from precli.core.level import Level
@@ -13,8 +12,8 @@ from precli.rules import Rule
 
 
 class Detailed(Renderer):
-    def __init__(self, file: sys.stdout, no_color: bool = False):
-        super().__init__(file=file, no_color=no_color)
+    def __init__(self, console: Console):
+        super().__init__(console)
 
     def render(self, run: Run):
         for result in run.results:

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -1,11 +1,11 @@
 # Copyright 2024 Secure Sauce LLC
 import pathlib
-import sys
 import urllib.parse as urlparse
 from importlib import metadata
 
 import sarif_om
 from jschema_to_python.to_json import to_json
+from rich.console import Console
 
 from precli.core.fix import Fix
 from precli.core.result import Result
@@ -20,8 +20,8 @@ TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class Json(Renderer):
-    def __init__(self, file: sys.stdout, no_color: bool = False):
-        super().__init__(file=file, no_color=no_color)
+    def __init__(self, console: Console):
+        super().__init__(console)
 
     def to_uri(self, file):
         path = pathlib.PurePath(file)

--- a/precli/renderers/markdown.py
+++ b/precli/renderers/markdown.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 from rich import markdown
+from rich.console import Console
 
 from precli.core.level import Level
 from precli.core.linecache import LineCache
@@ -15,8 +16,8 @@ logging.getLogger("markdown_it").setLevel(logging.INFO)
 
 
 class Markdown(Renderer):
-    def __init__(self, file: sys.stdout, no_color: bool = False):
-        super().__init__(file=file, no_color=no_color)
+    def __init__(self, console: Console):
+        super().__init__(console)
 
     def render(self, run: Run):
         output = ""

--- a/precli/renderers/plain.py
+++ b/precli/renderers/plain.py
@@ -1,6 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
-import sys
-
+from rich.console import Console
 from rich.padding import Padding
 
 from precli.core.level import Level
@@ -10,8 +9,8 @@ from precli.rules import Rule
 
 
 class Plain(Renderer):
-    def __init__(self, file: sys.stdout, no_color: bool = False):
-        super().__init__(file=file, no_color=no_color)
+    def __init__(self, console: Console):
+        super().__init__(console)
 
     def render(self, run: Run):
         for result in run.results:


### PR DESCRIPTION
This change makes use of a more global rich.console Console for output. The console object is passed to renderers instead of created in them.

The unexpected exceptions and errors are now printed with rich. This makes for better readability.