### PR TITLE
Avoid init of parsers twice

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -16,7 +16,6 @@ from rich import progress
 from rich.console import Console
 
 import precli
-from precli.core import loader
 from precli.core.artifact import Artifact
 from precli.core.run import Run
 from precli.core.tool import Tool
@@ -328,11 +327,6 @@ def main():
     # Compile a list of the targets
     artifacts = discover_files(args.targets, args.recursive)
 
-    # TODO: Move this to Run
-    # Flatten into a list of rules for all parsers
-    parsers = loader.load_parsers()
-    rules = [r for parser in parsers.values() for r in parser.rules.values()]
-
     if args.gist is True:
         file = tempfile.NamedTemporaryFile(mode="w+t")
     else:
@@ -353,7 +347,6 @@ def main():
         organization=precli.__author__,
         short_description=precli.__summary__,
         version=precli.__version__,
-        rules=rules,
     )
     run = Run(tool, enabled, disabled, artifacts, console, debug)
 

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -19,11 +19,13 @@ from precli.core.location import Location
 from precli.core.metrics import Metrics
 from precli.core.result import Result
 from precli.core.tool import Tool
+from precli.rules import Rule
 
 
 LOG = logging.getLogger(__name__)
 PROGRESS_THRESHOLD = 50
 parsers = loader.load_parsers()
+rules = [r for parser in parsers.values() for r in parser.rules.values()]
 
 
 def parse_file(
@@ -140,6 +142,11 @@ class Run:
     def tool(self) -> Tool:
         """Get the tool associated with this run."""
         return self._tool
+
+    @property
+    def rules(self) -> list[Rule]:
+        """Set of supported rules."""
+        return rules
 
     def invoke(self):
         """Invokes a run"""

--- a/precli/core/tool.py
+++ b/precli/core/tool.py
@@ -1,7 +1,4 @@
 # Copyright 2024 Secure Sauce LLC
-from precli.rules import Rule
-
-
 class Tool:
     def __init__(
         self,
@@ -12,7 +9,6 @@ class Tool:
         organization: str,
         short_description: str,
         version: str,
-        rules: list[Rule],
     ):
         self._name = name
         self._download_uri = download_uri
@@ -21,7 +17,6 @@ class Tool:
         self._organization = organization
         self._short_description = short_description
         self._version = version
-        self._rules = rules
         self._release_date = ""
         self._extensions = []
         self._policies = []
@@ -70,11 +65,6 @@ class Tool:
     def extensions(self) -> list:
         """Extensions for the tool in use."""
         return self._extensions
-
-    @property
-    def rules(self) -> list[Rule]:
-        """Set of supported rules."""
-        return self._rules
 
     @property
     def policies(self) -> list:


### PR DESCRIPTION
Currently parsers are being created twice, once in CLI main and once in the run module.

This change moves it only in the run module.