### PR TITLE
Suppress FutureWarnings from tree-sitter and re modules

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+import warnings
 from abc import ABC
 from abc import abstractmethod
 from importlib.metadata import entry_points
@@ -27,8 +28,16 @@ class Parser(ABC):
     def __init__(self, lang: str):
         """Initialize a new parser."""
         self._lexer = lang
-        self.tree_sitter_language = tree_sitter_languages.get_language(lang)
-        self.tree_sitter_parser = tree_sitter_languages.get_parser(lang)
+
+        # Suppress the following warning from tree-sitter
+        # FutureWarning: Language(path, name) is deprecated. Use
+        # Language(ptr, name) instead.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            self.tree_sitter_language = tree_sitter_languages.get_language(
+                lang
+            )
+            self.tree_sitter_parser = tree_sitter_languages.get_parser(lang)
         self.rules = {}
         self.wildcards = {}
 

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -2,6 +2,7 @@
 import builtins
 import codecs
 import re
+import warnings
 from collections import namedtuple
 
 from tree_sitter import Node
@@ -222,7 +223,12 @@ class Python(Parser):
                 self.current_symtab.remove(identifier)
                 self.current_symtab.put(identifier, tokens.IMPORT, module)
 
-        self.analyze_node(tokens.CALL, call=call)
+        # Suppress re module FutureWarnings. Usually a result of scanning
+        # test cases in cpython repo.
+        # For example: FutureWarning: Possible set union at position 6
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            self.analyze_node(tokens.CALL, call=call)
 
         if call.var_node is not None:
             symbol = self.current_symtab.get(call.var_node.string)


### PR DESCRIPTION
Precli is printing out FutureWarnings from tree-sitter about how it is initialized. The warning looks like the following:

```
FutureWarning: Language(path, name) is deprecated. Use Language( ptr, name) instead.
```

Similarly, the re module is also printing out a FutureWarning when precli analyzes cpython test code. It looks like the following:

```
FutureWarning: Possible set difference at position 4
FutureWarning: Possible set intersection at position 6
FutureWarning: Possible set union at position 6
FutureWarning: Possible set symmetric difference at position 5
FutureWarning: Possible nested set at position 3
```

In both cases, precli has been changed to suppress and ignore these warnings for now. There is probably no fix for the re module one, but I expect a fix for the tree-sitter module one to be necessary.