### PR TITLE
Return a rule ID for syntax and other errors

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -19,7 +19,6 @@ from rich.console import Console
 import precli
 from precli.core.artifact import Artifact
 from precli.core.run import Run
-from precli.core.tool import Tool
 from precli.renderers.detailed import Detailed
 from precli.renderers.json import Json
 from precli.renderers.markdown import Markdown
@@ -347,19 +346,8 @@ def main():
         highlight=False,
     )
 
-    # Initialize the run
-    tool = Tool(
-        name="Precaution",
-        download_uri=precli.__download_url__,
-        full_description=precli.__summary__,
-        information_uri=precli.__url__,
-        organization=precli.__author__,
-        short_description=precli.__summary__,
-        version=precli.__version__,
-    )
-    run = Run(tool, enabled, disabled, artifacts, console, debug)
-
     # Invoke the run
+    run = Run(enabled, disabled, artifacts, console, debug)
     run.invoke()
 
     if args.json is True:

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -31,6 +31,7 @@ parsers = loader.load_parsers()
 def parse_file(
     artifact: Artifact, enabled: list[str], disabled: list[str]
 ) -> list[Result]:
+    parser = None
     results = []
     try:
         if artifact.file_name == "-":
@@ -61,7 +62,7 @@ def parse_file(
     except OSError as e:
         results.append(
             Result(
-                "NO_RULE",
+                f"{parser.rule_prefix()}000" if parser else "NO_RULE",
                 location=Location(parser.context["node"]),
                 artifact=artifact,
                 level=Level.ERROR,
@@ -71,7 +72,7 @@ def parse_file(
     except SyntaxError as e:
         results.append(
             Result(
-                "NO_RULE",
+                f"{parser.rule_prefix()}000" if parser else "NO_RULE",
                 location=Location(
                     start_line=e.lineno,
                     end_line=e.lineno,
@@ -84,7 +85,7 @@ def parse_file(
     except UnicodeDecodeError:
         results.append(
             Result(
-                "NO_RULE",
+                f"{parser.rule_prefix()}000" if parser else "NO_RULE",
                 location=Location(parser.context["node"]),
                 artifact=artifact,
                 level=Level.ERROR,
@@ -94,7 +95,7 @@ def parse_file(
     except Exception as e:
         results.append(
             Result(
-                "NO_RULE",
+                f"{parser.rule_prefix()}000" if parser else "NO_RULE",
                 location=Location(parser.context["node"]),
                 artifact=artifact,
                 level=Level.ERROR,

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -12,6 +12,7 @@ from pygments import lexers
 from rich.console import Console
 from rich.progress import Progress
 
+import precli
 from precli.core import loader
 from precli.core.artifact import Artifact
 from precli.core.level import Level
@@ -106,14 +107,12 @@ def parse_file(
 class Run:
     def __init__(
         self,
-        tool: Tool,
         enabled: list[str],
         disabled: list[str],
         artifacts: list[Artifact],
         console: Console,
         debug,
     ):
-        self._tool = tool
         self._enabled = enabled
         self._disabled = disabled
         self._artifacts = artifacts
@@ -134,6 +133,16 @@ class Run:
         handler = logging.StreamHandler(sys.stderr)
         LOG.addHandler(handler)
         LOG.debug("logging initialized")
+
+        self._tool = Tool(
+            name="Precaution",
+            download_uri=precli.__download_url__,
+            full_description=precli.__summary__,
+            information_uri=precli.__url__,
+            organization=precli.__author__,
+            short_description=precli.__summary__,
+            version=precli.__version__,
+        )
 
     @property
     def tool(self) -> Tool:

--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -68,6 +68,10 @@ class Parser(ABC):
     def file_extensions(self) -> list[str]:
         """File extension of files this parser can handle."""
 
+    @abstractmethod
+    def rule_prefix(self) -> str:
+        """The prefix for the rule ID"""
+
     def parse(
         self, artifact: Artifact, enabled: list = None, disabled: list = None
     ) -> list[Result]:

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -22,6 +22,9 @@ class Go(Parser):
     def file_extensions(self) -> list[str]:
         return [".go"]
 
+    def rule_prefix(self) -> str:
+        return "GO"
+
     def get_file_encoding(self, file_path):
         return "utf-8"
 

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -21,6 +21,9 @@ class Java(Parser):
     def file_extensions(self) -> list[str]:
         return [".java"]
 
+    def rule_prefix(self) -> str:
+        return "JAV"
+
     def get_file_encoding(self, file_path):
         return "utf-8"
 

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -27,6 +27,9 @@ class Python(Parser):
     def file_extensions(self) -> list[str]:
         return [".py", ".pyw"]
 
+    def rule_prefix(self) -> str:
+        return "PY"
+
     def get_file_encoding(self, file_path):
         with open(file_path, "rb") as f:
             first_two_lines = f.readline() + f.readline()


### PR DESCRIPTION
This change returns a rule ID defined as <parser rule prefix>000.
This is follow on change for returning syntax and other various
errors as a result instead of something different.

Signed-off-by: Eric Brown <eric.brown@securesauce.dev>