### PR TITLE
Remove unnecessary sphinx config in tox.ini

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -169,6 +169,3 @@ precli.rules.python =
 
     # precli/rules/python/stdlib/hashlib_improper_prng.py
     PY035 = precli.rules.python.stdlib.hashlib_improper_prng:HashlibImproperPrng
-
-[build_sphinx]
-all_files = 1


### PR DESCRIPTION
The docs have been migrated to mkdocs, so there is no longer any need for sphinx settings.