### PR TITLE
Add --token to argparse rule

### DIFF
--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -100,6 +100,7 @@ class ArgparseSensitiveInfo(Rule):
         if (
             "--password" in [arg0.value_str, arg1.value_str]
             or "--api-key" in [arg0.value_str, arg1.value_str]
+            or "--token" in [arg0.value_str, arg1.value_str]
         ) and (action.value is None or action.value_str == "store"):
             return Result(
                 rule_id=self.id,

--- a/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_token.py
+++ b/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_token.py
@@ -1,0 +1,18 @@
+# level: ERROR
+# start_line: 13
+# end_line: 18
+# start_column: 0
+# end_column: 1
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog="ProgramName",
+    description="What the program does",
+)
+parser.add_argument(
+    "--token",
+    dest="api_key",
+    action="store",
+    help="Token to connect to the server",
+)

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -45,6 +45,7 @@ class TestArgparseSensitiveInfo(test_case.TestCase):
             "argparse_add_argument_password.py",
             "argparse_add_argument_password_file.py",
             "argparse_add_argument_password_store_true.py",
+            "argparse_add_argument_token.py",
         ],
     )
     def test(self, filename):


### PR DESCRIPTION
Sometimes --token is used on the command line to pass a secret token. Therefore this rule should also check for it.

Closes #503