### PR TITLE
Remove the newer version check

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -12,7 +12,6 @@ from urllib.parse import urlparse
 
 import requests
 from ignorelib import IgnoreFilterManager
-from outdated import check_outdated
 from rich.console import Console
 from rich.progress import BarColumn
 from rich.progress import DownloadColumn
@@ -143,19 +142,6 @@ def setup_arg_parser():
         sys.exit(2)
 
     return args
-
-
-def check_for_update():
-    local_version = precli.__version__
-    try:
-        is_outdated, pypi_version = check_outdated("precli", local_version)
-    except (ValueError, requests.exceptions.ConnectionError):
-        # Local version is greater than the latest version on PyPI
-        is_outdated = False
-
-    if is_outdated is True:
-        print(f"A new release is available: {local_version} -> {pypi_version}")
-        print("To update, run: pip install --upgrade precli")
 
 
 def get_owner_repo(repo_url: str):
@@ -342,12 +328,6 @@ def main():
 
     # Setup the command line arguments
     args = setup_arg_parser()
-
-    # Check if a newer version is available
-    git_target = any(filter(lambda x: x.startswith(GITHUB_URL), args.targets))
-
-    if (git_target or args.gist) and not args.quiet:
-        check_for_update()
 
     enabled = args.enable.split(",") if args.enable else []
     disabled = args.disable.split(",") if args.disable else []

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ ignorelib==0.3.0
 requests==2.32.3
 sarif-om==1.0.4
 jschema-to-python==1.2.3
-outdated==0.2.2


### PR DESCRIPTION
The code to check for a new version of precli has been problemmatic. It's also not strictly required feature. So this commit removes it for now. It might be revisited later.