### PR TITLE
Suggest using localhost address as fix

### DIFF
--- a/precli/rules/python/stdlib/http_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/http_server_unrestricted_bind.py
@@ -95,17 +95,32 @@ class HttpServerUnrestrictedBind(Rule):
         arg = call.get_argument(position=0, name="server_address")
         server_address = arg.value
 
-        if isinstance(server_address, tuple) and utils.to_str(
-            server_address[0]
-        ) in (
-            "",
-            INADDR_ANY,
-            IN6ADDR_ANY,
-        ):
+        if not isinstance(server_address, tuple):
+            return
+
+        if utils.to_str(server_address[0]) in ("", INADDR_ANY):
+            fixes = Rule.get_fixes(
+                context=context,
+                deleted_location=Location(node=arg.node),
+                description="Use the localhost address to restrict binding.",
+                inserted_content=str(("127.0.0.1",) + server_address[1:]),
+            )
             return Result(
                 rule_id=self.id,
                 location=Location(node=arg.node),
-                message=self.message.format(
-                    "INADDR_ANY (0.0.0.0) or IN6ADDR_ANY (::)"
-                ),
+                message=self.message.format("INADDR_ANY (0.0.0.0)"),
+                fixes=fixes,
+            )
+        if utils.to_str(server_address[0]) == IN6ADDR_ANY:
+            fixes = Rule.get_fixes(
+                context=context,
+                deleted_location=Location(node=arg.node),
+                description="Use the localhost address to restrict binding.",
+                inserted_content=str(("::1",) + server_address[1:]),
+            )
+            return Result(
+                rule_id=self.id,
+                location=Location(node=arg.node),
+                message=self.message.format("IN6ADDR_ANY (::)"),
+                fixes=fixes,
             )

--- a/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
@@ -95,15 +95,32 @@ class XmlrpcServerUnrestrictedBind(Rule):
         arg = call.get_argument(position=0, name="addr")
         addr = arg.value
 
-        if isinstance(addr, tuple) and utils.to_str(addr[0]) in (
-            "",
-            INADDR_ANY,
-            IN6ADDR_ANY,
-        ):
+        if not isinstance(addr, tuple):
+            return
+
+        if utils.to_str(addr[0]) in ("", INADDR_ANY):
+            fixes = Rule.get_fixes(
+                context=context,
+                deleted_location=Location(node=arg.node),
+                description="Use the localhost address to restrict binding.",
+                inserted_content=str(("127.0.0.1",) + addr[1:]),
+            )
             return Result(
                 rule_id=self.id,
                 location=Location(node=arg.node),
-                message=self.message.format(
-                    "INADDR_ANY (0.0.0.0) or IN6ADDR_ANY (::)"
-                ),
+                message=self.message.format("INADDR_ANY (0.0.0.0)"),
+                fixes=fixes,
+            )
+        if utils.to_str(addr[0]) == IN6ADDR_ANY:
+            fixes = Rule.get_fixes(
+                context=context,
+                deleted_location=Location(node=arg.node),
+                description="Use the localhost address to restrict binding.",
+                inserted_content=str(("::1",) + addr[1:]),
+            )
+            return Result(
+                rule_id=self.id,
+                location=Location(node=arg.node),
+                message=self.message.format("IN6ADDR_ANY (::)"),
+                fixes=fixes,
             )


### PR DESCRIPTION
For rules that detect unrestricted binds, like 0.0.0.0, a suggested fix can be made to switch to 127.0.0.1 or ::1.

Closes #445