### PR TITLE
Don't do a resolve on the left hand side of an assignment

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -134,13 +134,8 @@ class Python(Parser):
             tokens.FALSE,
             tokens.NONE,
         ):
-            left_hand = self.resolve(nodes[0], default=nodes[0])
+            left_hand = nodes[0].string
             right_hand = self.resolve(nodes[2], default=nodes[2])
-
-            # This is in case a variable is reassigned
-            self.current_symtab.put(
-                nodes[0].string, tokens.IDENTIFIER, right_hand
-            )
 
             # This is to help full resolution of an attribute/call.
             # This results in two entries in the symtab for this assignment.


### PR DESCRIPTION
An assignment is assigning a value to an identifier. Resolving the identifier can lead to issues when putting into the symbol name as the identifer is expected to be a name. This is what occurred when trying to add dicts to the parser's resolve(). The same would probably occur for tuple and any other non-string identifier value that it would get resolved to.

The visit_comparison_operator is still resolving left_hand, but in its case, its not put into the symbol table. It's also needed to compare left and right for things like timing attack rule that checks whether the left and right are the same type.