### PR TITLE
Fix up some of the typing errors

### DIFF
--- a/precli/core/argument.py
+++ b/precli/core/argument.py
@@ -22,7 +22,7 @@ class Argument:
         self._value_str = utils.to_str(value) if self._is_str else None
 
     @staticmethod
-    def _get_func_ident(node: Node) -> Node:
+    def _get_func_ident(node: Node) -> Node | None:
         if node is None:
             return None
         # TODO(ericwb): does this function fail with nested calls?
@@ -39,7 +39,7 @@ class Argument:
         return self._node
 
     @property
-    def identifier_node(self) -> Node:
+    def identifier_node(self) -> Node | None:
         """
         The node representing just the identifier of the argument.
 
@@ -80,6 +80,6 @@ class Argument:
         return self._value
 
     @property
-    def value_str(self) -> str:
+    def value_str(self) -> str | None:
         """The value as a true string."""
         return self._value_str

--- a/precli/core/artifact.py
+++ b/precli/core/artifact.py
@@ -36,26 +36,26 @@ class Artifact:
         return self._encoding
 
     @encoding.setter
-    def encoding(self, encoding) -> str:
+    def encoding(self, encoding):
         """Set the encoding of the file."""
         self._encoding = encoding
 
     @property
-    def contents(self) -> str:
+    def contents(self) -> str | None:
         """The contents of the artifact."""
         return self._contents
 
     @contents.setter
-    def contents(self, contents) -> str:
+    def contents(self, contents):
         """Set the contents (for typically the file)."""
         self._contents = contents
 
     @property
-    def language(self) -> str:
+    def language(self) -> str | None:
         """The programming language for this artifact."""
         return self._language
 
     @language.setter
-    def language(self, language) -> str:
+    def language(self, language):
         """Set the programming language."""
         self._language = language

--- a/precli/core/cwe.py
+++ b/precli/core/cwe.py
@@ -65,7 +65,7 @@ class Cwe:
             case 1333:
                 return "Inefficient Regular Expression Complexity"
 
-        return self._id
+        return str(self._id)
 
     def url(self) -> str:
         """URL of the CWE."""

--- a/precli/core/symtab.py
+++ b/precli/core/symtab.py
@@ -13,7 +13,7 @@ class SymbolTable:
     def name(self) -> str:
         return self._name
 
-    def parent(self) -> Self:
+    def parent(self) -> Self | None:
         return self._parent
 
     def put(self, name: str, type: str, value: str) -> None:

--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -52,7 +52,7 @@ class Parser(ABC):
                     else:
                         self.wildcards[k] = v
 
-        def child_by_type(self, type: str) -> Node:
+        def child_by_type(self, type: str) -> Node | None:
             # Return first child with type as specified
             child = list(filter(lambda x: x.type == type, self.named_children))
             return child[0] if child else None
@@ -72,8 +72,15 @@ class Parser(ABC):
     def rule_prefix(self) -> str:
         """The prefix for the rule ID"""
 
+    @abstractmethod
+    def get_file_encoding(self, file_path: str) -> str:
+        """The prefix for the rule ID"""
+
     def parse(
-        self, artifact: Artifact, enabled: list = None, disabled: list = None
+        self,
+        artifact: Artifact,
+        enabled: list[str] = None,
+        disabled: list[str] = None,
     ) -> list[Result]:
         """File extension of files this parser can handle."""
         for rule in self.rules.values():
@@ -184,7 +191,7 @@ class Parser(ABC):
             ),
         )
 
-    def child_by_type(self, node: Node, type: str) -> Node:
+    def child_by_type(self, node: Node, type: str) -> Node | None:
         # Return first child with type as specified
         child = list(filter(lambda x: x.type == type, node.named_children))
         return child[0] if child else None

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -25,7 +25,7 @@ class Go(Parser):
     def rule_prefix(self) -> str:
         return "GO"
 
-    def get_file_encoding(self, file_path):
+    def get_file_encoding(self, file_path: str) -> str:
         return "utf-8"
 
     def visit_source_file(self, nodes: list[Node]):
@@ -88,7 +88,7 @@ class Go(Parser):
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
-    def _get_var_node(self, node: Node) -> Node:
+    def _get_var_node(self, node: Node) -> Node | None:
         if (
             len(node.named_children) >= 2
             and node.named_children[0].type
@@ -99,7 +99,7 @@ class Go(Parser):
         elif node.type == tokens.ATTRIBUTE:
             return self._get_var_node(node.named_children[0])
 
-    def _get_func_ident(self, node: Node) -> Node:
+    def _get_func_ident(self, node: Node) -> Node | None:
         # TODO(ericwb): does this function fail with nested calls?
         if node.type == tokens.ATTRIBUTE:
             return self._get_func_ident(node.named_children[1])
@@ -150,7 +150,7 @@ class Go(Parser):
 
         return args
 
-    def get_qual_name(self, node: Node) -> Symbol:
+    def get_qual_name(self, node: Node) -> Symbol | None:
         nodetext = node.string
         symbol = self.current_symtab.get(nodetext)
 

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -24,7 +24,7 @@ class Java(Parser):
     def rule_prefix(self) -> str:
         return "JAV"
 
-    def get_file_encoding(self, file_path):
+    def get_file_encoding(self, file_path: str) -> str:
         return "utf-8"
 
     def visit_program(self, nodes: list[Node]):
@@ -103,7 +103,7 @@ class Java(Parser):
         self.visit(nodes)
         self.current_symtab = self.current_symtab.parent()
 
-    def _get_var_node(self, node: Node) -> Node:
+    def _get_var_node(self, node: Node) -> Node | None:
         if (
             len(node.named_children) >= 2
             and node.named_children[0].type
@@ -114,7 +114,7 @@ class Java(Parser):
         elif node.type == tokens.ATTRIBUTE:
             return self._get_var_node(node.named_children[0])
 
-    def _get_func_ident(self, node: Node) -> Node:
+    def _get_func_ident(self, node: Node) -> Node | None:
         # TODO(ericwb): does this function fail with nested calls?
         if node.type == tokens.ATTRIBUTE:
             return self._get_func_ident(node.named_children[1])
@@ -274,7 +274,7 @@ class Java(Parser):
 
         return args
 
-    def get_qual_name(self, node: Node) -> Symbol:
+    def get_qual_name(self, node: Node) -> Symbol | None:
         nodetext = node.string
         symbol = self.current_symtab.get(nodetext)
 

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -31,7 +31,7 @@ class Python(Parser):
     def rule_prefix(self) -> str:
         return "PY"
 
-    def get_file_encoding(self, file_path):
+    def get_file_encoding(self, file_path: str) -> str:
         with open(file_path, "rb") as f:
             first_two_lines = f.readline() + f.readline()
 
@@ -169,7 +169,7 @@ class Python(Parser):
 
         self.visit(nodes)
 
-    def _get_var_node(self, node: Node) -> Node:
+    def _get_var_node(self, node: Node) -> Node | None:
         if (
             len(node.named_children) >= 2
             and node.named_children[0].type
@@ -180,7 +180,7 @@ class Python(Parser):
         elif node.type == tokens.ATTRIBUTE:
             return self._get_var_node(node.named_children[0])
 
-    def _get_func_ident(self, node: Node) -> Node:
+    def _get_func_ident(self, node: Node) -> Node | None:
         # TODO(ericwb): does this function fail with nested calls?
         if node.type == tokens.ATTRIBUTE:
             return self._get_func_ident(node.named_children[1])
@@ -412,7 +412,7 @@ class Python(Parser):
                 args.append(self.resolve(child, default=child))
         return args, kwargs
 
-    def get_qual_name(self, node: Node) -> Symbol:
+    def get_qual_name(self, node: Node) -> Symbol | None:
         nodetext = node.string
         symbol = self.current_symtab.get(nodetext)
         if symbol is not None:

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
 from abc import ABC
-from typing import Self
 
 from precli.core.config import Config
 from precli.core.cwe import Cwe
@@ -59,7 +58,7 @@ class Rule(ABC):
         return self._id
 
     @staticmethod
-    def get_by_id(id: str) -> Self:
+    def get_by_id(id: str):
         """Get the rule instance by the given ID."""
         return Rule._rules.get(id)
 


### PR DESCRIPTION
Pyright returns numerous typing errors in the code base. This change cleans up a significant number of them.