### PR TITLE
Use mkdocs-material for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs
 mkdocstrings[python]
+mkdocs-material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,9 +4,13 @@ edit_uri: blob/main/docs/
 copyright: Copyright 2024 Secure Sauce LLC
 
 theme:
-  name: "readthedocs"
+  name: "material"
   locale: en
   highlightjs: true
+  features:
+    - content.code.copy
+    - content.code.select
+    - content.code.annotate
 
 plugins:
   - mkdocstrings
@@ -19,3 +23,12 @@ nav:
     - getting-started.md
   - Rules:
     - Rules: rules.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -60,7 +60,7 @@ encryption and security.
 
 ## Example
 
-```go
+```go linenums="1"
 package main
 
 import (
@@ -86,7 +86,7 @@ func main() {
 It is advisable to use stronger, more secure cryptographic algorithms such as
 AES.
 
-```go
+```go linenums="1"
 package main
 
 import (

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -18,7 +18,7 @@ passwords hashed with SHA-1 can be easily cracked by attackers.
 ## Example
 
 
-```go
+```go linenums="1"
 package main
 
 import (
@@ -38,7 +38,7 @@ func main() {
 The recommendation is to swap the insecure hashing method to one of the more
 secure alternatives, `sha256` or `sha512`.
 
-```go
+```go linenums="1"
 package main
 
 import (

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -31,7 +31,7 @@ its efficiency and strong security properties.
 
 ## Example
 
-```go
+```go linenums="1"
 package main
 
 import (
@@ -53,7 +53,7 @@ func main() {
 Its recommended to increase the key size to at least 2048 for DSA and RSA
 algorithms.
 
-```go
+```go linenums="1"
 package main
 
 import (

--- a/precli/rules/java/stdlib/java_net_insecure_cookie.py
+++ b/precli/rules/java/stdlib/java_net_insecure_cookie.py
@@ -18,7 +18,7 @@ they are only sent via secure connections.
 
 ## Example
 
-```java
+```java linenums="1"
 import java.net.HttpCookie;
 
 public class SessionCookie {
@@ -36,7 +36,7 @@ the Secure flag enabled. This practice ensures that the cookies are
 transmitted only over HTTPS, providing protection against eavesdropping and
 MITM attacks on the communication channel.
 
-```java
+```java linenums="1"
 import java.net.HttpCookie;
 
 public class SessionCookie {

--- a/precli/rules/java/stdlib/java_security_weak_hash.py
+++ b/precli/rules/java/stdlib/java_security_weak_hash.py
@@ -16,7 +16,7 @@ passwords hashed with SHA-1 can be easily cracked by attackers.
 
 ## Example
 
-```java
+```java linenums="1"
 import java.security.*;
 
 public class MessageDigestMD5 {
@@ -35,7 +35,7 @@ public class MessageDigestMD5 {
 The recommendation is to swap the insecure hashing method to one of the more
 secure alternatives, `SHA-256` or `SHA-512`.
 
-```java
+```java linenums="1"
 import java.security.*;
 
 public class MessageDigestSHA256 {

--- a/precli/rules/java/stdlib/java_security_weak_key.py
+++ b/precli/rules/java/stdlib/java_security_weak_key.py
@@ -31,7 +31,7 @@ its efficiency and strong security properties.
 
 ## Example
 
-```java
+```java linenums="1"
 import java.security.*;
 
 public class KeyPairGeneratorRSA {
@@ -52,7 +52,7 @@ public class KeyPairGeneratorRSA {
 Its recommended to increase the key size to at least 2048 for DSA and RSA
 algorithms.
 
-```java
+```java linenums="1"
 import java.security.*;
 
 public class KeyPairGeneratorRSA {

--- a/precli/rules/java/stdlib/java_security_weak_random.py
+++ b/precli/rules/java/stdlib/java_security_weak_random.py
@@ -18,7 +18,7 @@ stronger guarantees of randomness to prevent attacks.
 
 ## Example
 
-```java
+```java linenums="1"
 import java.security.*;
 
 public class WeakRNG {
@@ -40,7 +40,7 @@ explicitly specify a more secure algorithm like `NativePRNG` or `DRBG` where
 available and appropriate for the application's requirements. This ensures
 the use of secure and up-to-date algorithms for random number generation.
 
-```java
+```java linenums="1"
 import java.security.*;
 
 public class StrongRNG {

--- a/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
+++ b/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
@@ -60,7 +60,7 @@ and regulatory requirements for encryption and security.
 
 ## Example
 
-```java
+```java linenums="1"
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.*;
 
@@ -84,7 +84,7 @@ public class Example {
 It is advisable to use stronger, more secure cryptographic algorithms such as
 AES.
 
-```java
+```java linenums="1"
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.*;
 

--- a/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
+++ b/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
@@ -18,7 +18,7 @@ they are only sent via secure connections.
 
 ## Example
 
-```java
+```java linenums="1"
 import javax.servlet.http.Cookie;
 
 public class SessionCookie {
@@ -36,7 +36,7 @@ the Secure flag enabled. This practice ensures that the cookies are
 transmitted only over HTTPS, providing protection against eavesdropping and
 MITM attacks on the communication channel.
 
-```java
+```java linenums="1"
 import javax.servlet.http.Cookie;
 
 public class SessionCookie {

--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -9,7 +9,7 @@ encourages the use of insecure environment variables for secrets.
 
 ## Example
 
-```python
+```python linenums="1"
 import argparse
 
 
@@ -32,7 +32,7 @@ Consider accepting sensitive data only from an interactive hidden prompt or
 via files. A --password-file argument allows a secret to be passed in
 discreetly, in a wide variety of contexts.
 
-```python
+```python linenums="1"
 import argparse
 
 

--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -22,7 +22,7 @@ mechanisms and validations that do not get removed during optimization.
 
 ## Examples
 
-```python
+```python linenums="1"
 def foobar(a: str = None):
     assert a is not None
     return f"Hello {a}"
@@ -34,7 +34,7 @@ foobar("World")
 
 Use proper error handling mechanism appropriate for production code.
 
-```python
+```python linenums="1"
 def foobar(a: str = None):
     if a is not None:
         return f"Hello {a}"

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -21,14 +21,14 @@ as `SHA256` and `SHA512`.
 
 ## Examples
 
-```python
+```python linenums="1"
 import crypt
 
 
 crypt.crypt("password", salt=crypt.METHOD_MD5)
 ```
 
-```python
+```python linenums="1"
 import crypt
 
 
@@ -40,14 +40,14 @@ crypt.mksalt(crypt.METHOD_CRYPT)
 The recommendation is to swap the insecure hashing method to one of the more
 secure alternatives, `SHA256` or `SHA512`.
 
-```python
+```python linenums="1"
 import crypt
 
 
 crypt.crypt("password", salt=crypt.METHOD_SHA256)
 ```
 
-```python
+```python linenums="1"
 import crypt
 
 

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -15,7 +15,7 @@ ftplib for accessing sensitive data.
 
 ## Example
 
-```python
+```python linenums="1"
 import ftplib
 
 
@@ -34,7 +34,7 @@ If the FTP protocol must be used and sensitive data will be transferred, it
 is recommended to secure the connection using `FTP_TLS` class. It's also
 important to call `prot_p()` to secure the data connection.
 
-```python
+```python linenums="1"
 import ftplib
 
 

--- a/precli/rules/python/stdlib/ftplib_unverified_context.py
+++ b/precli/rules/python/stdlib/ftplib_unverified_context.py
@@ -16,7 +16,7 @@ application up to a number of security risks, including:
 
 ## Example
 
-```python
+```python linenums="1"
 import ftplib
 
 
@@ -30,7 +30,7 @@ with ftplib.FTP_TLS("ftp.us.debian.org") as ftp:
 Set the value of the `context` keyword argument to
 `ssl.create_default_context()` to ensure the connection is fully verified.
 
-```python
+```python linenums="1"
 import ftplib
 import ssl
 

--- a/precli/rules/python/stdlib/hashlib_improper_prng.py
+++ b/precli/rules/python/stdlib/hashlib_improper_prng.py
@@ -22,7 +22,7 @@ generation and creating salts for hashing functions.
 
 ## Example
 
-```python
+```python linenums="1"
 import hashlib
 import random
 
@@ -37,7 +37,7 @@ hashlib.scrypt(password, salt=salt, n=16384, r=8, p=1)
 For security or cryptographic uses use a secure pseudo-random generator such
 as `os.urandom()` or `secrets.token_bytes()`.
 
-```python
+```python linenums="1"
 import hashlib
 import os
 

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -28,7 +28,7 @@ passwords hashed with SHA-1 can be easily cracked by attackers.
 
 ## Example
 
-```python
+```python linenums="1"
 import hashlib
 
 
@@ -41,7 +41,7 @@ hash.hexdigest()
 The recommendation is to swap the insecure hashing method to one of the more
 secure alternatives, `SHA256` or `SHA512`.
 
-```python
+```python linenums="1"
 import hashlib
 
 
@@ -53,7 +53,7 @@ If an insecure hash such as MD5 must be used and not in within a security
 context, then set the keyword-only argument `usedforsecurity` in the hashes
 constructor.
 
-```python
+```python linenums="1"
 import hashlib
 
 

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -23,7 +23,7 @@ digests. This makes it more resistant to timing attacks.
 
 ## Example
 
-```python
+```python linenums="1"
 import hmac
 
 
@@ -44,7 +44,7 @@ print(digest == received_digest)
 The recommendation is to replace the == operator with the function
 `compare_digest`.
 
-```python
+```python linenums="1"
 import hmac
 
 

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -28,7 +28,7 @@ created with SHA-1 can be easily cracked by attackers.
 
 ## Example
 
-```python
+```python linenums="1"
 import hmac
 
 
@@ -44,7 +44,7 @@ mac = hmac_obj.digest()
 The recommendation is to swap the insecure hashing method to one of the more
 secure alternatives, `SHA256`, `SHA-384`, or `SHA512`.
 
-```python
+```python linenums="1"
 import hmac
 
 

--- a/precli/rules/python/stdlib/hmac_weak_key.py
+++ b/precli/rules/python/stdlib/hmac_weak_key.py
@@ -22,7 +22,7 @@ HMAC and protects the integrity of the message authentication process.
 
 ## Example
 
-```python
+```python linenums="1"
 import hashlib
 import hmac
 import secrets
@@ -37,7 +37,7 @@ hmac.new(key, msg=message, digestmod=hashlib.sha3_384)
 
 Adjust the key size to be at least the size of the digest.
 
-```python
+```python linenums="1"
 import hashlib
 import hmac
 import secrets

--- a/precli/rules/python/stdlib/http_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/http_server_unrestricted_bind.py
@@ -19,7 +19,7 @@ surface.
 
 ## Example
 
-```python
+```python linenums="1"
 from http.server import BaseHTTPRequestHandler
 from http.server import HTTPServer
 
@@ -37,7 +37,7 @@ All socket bindings MUST specify a specific network interface or localhost
 explicitly designed to be accessible from any network interface. This
 practice ensures that services are not exposed more broadly than intended.
 
-```python
+```python linenums="1"
 from http.server import BaseHTTPRequestHandler
 from http.server import HTTPServer
 

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -10,7 +10,7 @@ access.
 
 ## Example
 
-```python
+```python linenums="1"
 import http.client
 
 
@@ -25,7 +25,7 @@ response = conn.getresponse()
 To avoid this vulnerability, put sensitive information in the request as
 headers, rather than a parameter of the URL.
 
-```python
+```python linenums="1"
 import http.client
 
 

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -13,7 +13,7 @@ data when accessing IMAP servers.
 
 ## Example
 
-```python
+```python linenums="1"
 import getpass
 import imaplib
 
@@ -35,7 +35,7 @@ If the IMAP protocol must be used and sensitive data will be transferred, it
 is recommended to secure the connection using `IMAP4_SSL` class.
 Alternatively, the `starttls` function can be used to enter a secure session.
 
-```python
+```python linenums="1"
 import getpass
 import imaplib
 

--- a/precli/rules/python/stdlib/imaplib_unverified_context.py
+++ b/precli/rules/python/stdlib/imaplib_unverified_context.py
@@ -16,7 +16,7 @@ opening your application up to a number of security risks, including:
 
 ## Example
 
-```python
+```python linenums="1"
 import imaplib
 
 
@@ -30,7 +30,7 @@ with imaplib.IMAP4_SSL("domain.org") as imap4:
 Set the value of the `ssl_context` keyword argument to
 `ssl.create_default_context()` to ensure the connection is fully verified.
 
-```python
+```python linenums="1"
 import imaplib
 import ssl
 

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -10,7 +10,7 @@ and memory resources, which could lead to a denial-of-service attack.
 
 ## Example
 
-```python
+```python linenums="1"
 import json
 
 

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -11,7 +11,7 @@ allow them to execute arbitrary code.
 
 ## Example
 
-```python
+```python linenums="1"
 import logging.config
 
 
@@ -24,7 +24,7 @@ The verify argument should be set to a callable function that should verify
 whether bytes received on the socket are valid to be processed. One way to
 verify the data is to use encryption and/or signing.
 
-```python
+```python linenums="1"
 import logging.config
 
 

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -9,7 +9,7 @@ a malicious data could be used to cause the decoder to execute arbitrary code.
 
 ## Example
 
-```python
+```python linenums="1"
 import marshal
 
 

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -13,7 +13,7 @@ data when accessing NNTP servers.
 
 ## Example
 
-```python
+```python linenums="1"
 from nntplib import NNTP
 
 
@@ -27,7 +27,7 @@ If the NNTP protocol must be used and sensitive data will be transferred, it
 is recommended to secure the connection using `NNTP_SSL` class.
 Alternatively, the `starttls` function can be used to enter a secure session.
 
-```python
+```python linenums="1"
 from nntplib import NNTP
 
 

--- a/precli/rules/python/stdlib/nntplib_unverified_context.py
+++ b/precli/rules/python/stdlib/nntplib_unverified_context.py
@@ -16,7 +16,7 @@ opening your application up to a number of security risks, including:
 
 ## Example
 
-```python
+```python linenums="1"
 import nntplib
 
 
@@ -30,7 +30,7 @@ with nntplib.NNTP_SSL("news.gmane.io") as n:
 Set the value of the `context` keyword argument to
 `ssl.create_default_context()` to ensure the connection is fully verified.
 
-```python
+```python linenums="1"
 import nntplib
 import ssl
 

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -13,7 +13,7 @@ the malicious code would be executed.
 
 ## Example
 
-```python
+```python linenums="1"
 import pickle
 
 

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -13,7 +13,7 @@ data when accessing POP servers.
 
 ## Example
 
-```python
+```python linenums="1"
 import getpass
 import poplib
 
@@ -33,7 +33,7 @@ If the POP protocol must be used and sensitive data will be transferred, it
 is recommended to secure the connection using `POP3_SSL` class.
 Alternatively, the `stls` function can be used to enter a secure session.
 
-```python
+```python linenums="1"
 import getpass
 import poplib
 

--- a/precli/rules/python/stdlib/poplib_unverified_context.py
+++ b/precli/rules/python/stdlib/poplib_unverified_context.py
@@ -16,7 +16,7 @@ opening your application up to a number of security risks, including:
 
 ## Example
 
-```python
+```python linenums="1"
 import poplib
 
 
@@ -29,7 +29,7 @@ with poplib.POP3_SSL("domain.org") as pop3:
 Set the value of the `context` keyword argument to
 `ssl.create_default_context()` to ensure the connection is fully verified.
 
-```python
+```python linenums="1"
 import poplib
 import ssl
 

--- a/precli/rules/python/stdlib/re_denial_of_service.py
+++ b/precli/rules/python/stdlib/re_denial_of_service.py
@@ -16,7 +16,7 @@ causing it to hang or crash.
 
 ## Examples
 
-```python
+```python linenums="1"
 import re
 
 
@@ -31,7 +31,7 @@ that patterns are designed to avoid ambiguous repetition and nested
 quantifiers that can cause catastrophic backtracking. Regular expressions
 should be reviewed and tested for efficiency and resistance to DoS attacks.
 
-```python
+```python linenums="1"
 import re
 
 

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -17,7 +17,7 @@ token prediction or brute-force attacks.
 
 ## Example
 
-```python
+```python linenums="1"
 import secrets
 
 
@@ -29,7 +29,7 @@ token = secrets.token_bytes(16)
 Its recommended to increase the token size to at least 32 bytes or leave
 the `nbytes` parameter unset or set to None to use a default entropy.
 
-```python
+```python linenums="1"
 import secrets
 
 

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -12,7 +12,7 @@ cause the decoder to execute arbitrary code.
 
 ## Example
 
-```python
+```python linenums="1"
 import shelve
 
 

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -13,7 +13,7 @@ data when accessing SMTP servers.
 
 ## Example
 
-```python
+```python linenums="1"
 import smtplib
 
 
@@ -50,7 +50,7 @@ is recommended to secure the connection using `SMTP_SSL` class.
 Alternatively, the `starttls` function can be used to enter a secure session.
 
 
-```python
+```python linenums="1"
 import smtplib
 
 

--- a/precli/rules/python/stdlib/smtplib_unverified_context.py
+++ b/precli/rules/python/stdlib/smtplib_unverified_context.py
@@ -16,7 +16,7 @@ opening your application up to a number of security risks, including:
 
 ## Example
 
-```python
+```python linenums="1"
 import smtplib
 
 
@@ -30,7 +30,7 @@ with smtplib.SMTP_SSL("domain.org") as smtp:
 Set the value of the `context` keyword argument to
 `ssl.create_default_context()` to ensure the connection is fully verified.
 
-```python
+```python linenums="1"
 import smtplib
 import ssl
 

--- a/precli/rules/python/stdlib/socket_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socket_unrestricted_bind.py
@@ -19,7 +19,7 @@ surface.
 
 ## Example
 
-```python
+```python linenums="1"
 import socket
 
 
@@ -35,7 +35,7 @@ All socket bindings MUST specify a specific network interface or localhost
 explicitly designed to be accessible from any network interface. This
 practice ensures that services are not exposed more broadly than intended.
 
-```python
+```python linenums="1"
 import socket
 
 

--- a/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
@@ -19,7 +19,7 @@ surface.
 
 ## Example
 
-```python
+```python linenums="1"
 import socketserver
 
 
@@ -42,7 +42,7 @@ All socket bindings MUST specify a specific network interface or localhost
 explicitly designed to be accessible from any network interface. This
 practice ensures that services are not exposed more broadly than intended.
 
-```python
+```python linenums="1"
 import socketserver
 
 

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -20,7 +20,7 @@ even higher security margins.
 
 ## Example
 
-```python
+```python linenums="1"
 import ssl
 
 
@@ -32,7 +32,7 @@ context.set_ecdh_curve("prime192v1")
 
 Its recommended to increase the key size to at least 224 EC algorithms.
 
-```python
+```python linenums="1"
 import ssl
 
 

--- a/precli/rules/python/stdlib/ssl_create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl_create_unverified_context.py
@@ -16,7 +16,7 @@ up to a number of security risks, including:
 
 ## Example
 
-```python
+```python linenums="1"
 import ssl
 
 
@@ -30,7 +30,7 @@ If you need to connect to a server over HTTPS, you should use the
 the server's certificate, which will help to protect your application from
 these security risks.
 
-```python
+```python linenums="1"
 import ssl
 
 

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -29,7 +29,7 @@ protocols:
 
 ## Example
 
-```python
+```python linenums="1"
 import ssl
 
 
@@ -45,7 +45,7 @@ If you need to connect to a server over HTTPS, you should use the
 These protocols are more secure than the weak protocols and will help to
 protect your application from these security risks.
 
-```python
+```python linenums="1"
 import ssl
 
 

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -28,7 +28,7 @@ Here are some additional reasons why you should not use telnetlib:
 
 ## Example
 
-```python
+```python linenums="1"
 import getpass
 import telnetlib
 
@@ -59,7 +59,7 @@ There are better alternatives. There are a number of other Python modules
 that provide access to the telnet protocol, such as Paramiko. These modules
 are more secure than telnetlib and should be used instead.
 
-```python
+```python linenums="1"
 import getpass
 import paramiko
 

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -11,7 +11,7 @@ in your code.
 
 ## Example
 
-```python
+```python linenums="1"
 import tempfile
 
 
@@ -27,7 +27,7 @@ consider using NamedTemporaryFile. The tempfile.NamedTemporaryFile class
 automatically handles the generation of unique filenames, proper file closure,
 and cleanup when the file is no longer needed.
 
-```python
+```python linenums="1"
 import tempfile
 
 

--- a/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
@@ -19,7 +19,7 @@ surface.
 
 ## Example
 
-```python
+```python linenums="1"
 from xmlrpc.server import DocXMLRPCRequestHandler
 from xmlrpc.server import DocXMLRPCServer
 
@@ -37,7 +37,7 @@ All socket bindings MUST specify a specific network interface or localhost
 explicitly designed to be accessible from any network interface. This
 practice ensures that services are not exposed more broadly than intended.
 
-```python
+```python linenums="1"
 from xmlrpc.server import DocXMLRPCRequestHandler
 from xmlrpc.server import DocXMLRPCServer
 


### PR DESCRIPTION
The mkdocs-meterial plugin gives us a number of added features over the standard mkdocs markdown format.

Namely, the features included in this commit are:
* Line numbers on code blocks
* Copy button to copy code blocks
* Switch to material theme