### PR TITLE
Use tabbed code blocks when there are multiple examples

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,3 +32,5 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -21,38 +21,46 @@ as `SHA256` and `SHA512`.
 
 ## Examples
 
-```python linenums="1" hl_lines="4"
-import crypt
+=== "crypt.crypt"
+
+    ```python linenums="1" hl_lines="4"
+    import crypt
 
 
-crypt.crypt("password", salt=crypt.METHOD_MD5)
-```
+    crypt.crypt("password", salt=crypt.METHOD_MD5)
+    ```
 
-```python linenums="1" hl_lines="4"
-import crypt
+=== "crypt.mksalt"
+
+    ```python linenums="1" hl_lines="4"
+    import crypt
 
 
-crypt.mksalt(crypt.METHOD_CRYPT)
-```
+    crypt.mksalt(crypt.METHOD_CRYPT)
+    ```
 
 ## Remediation
 
 The recommendation is to swap the insecure hashing method to one of the more
 secure alternatives, `SHA256` or `SHA512`.
 
-```python linenums="1" hl_lines="4"
-import crypt
+=== "crypt.crypt"
+
+    ```python linenums="1" hl_lines="4"
+    import crypt
 
 
-crypt.crypt("password", salt=crypt.METHOD_SHA256)
-```
+    crypt.crypt("password", salt=crypt.METHOD_SHA256)
+    ```
 
-```python linenums="1" hl_lines="4"
-import crypt
+=== "crypt.mksalt"
+
+    ```python linenums="1" hl_lines="4"
+    import crypt
 
 
-crypt.mksalt(crypt.METHOD_SHA512)
-```
+    crypt.mksalt(crypt.METHOD_SHA512)
+    ```
 
 ## Alternatives to Crypt
 


### PR DESCRIPTION
Some rule docs include mulitple examples. In those cases, it's better to use a tabbed block so the page looks cleaner.