### PR TITLE
Make doc tables sortable

### DIFF
--- a/docs/javascripts/tablesort.js
+++ b/docs/javascripts/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function() {
+  var tables = document.querySelectorAll("article table:not([class])")
+  tables.forEach(function(table) {
+    new Tablesort(table)
+  })
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,3 +46,7 @@ markdown_extensions:
 
 extra_css:
   - stylesheets/extra.css
+
+extra_javascript:
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - javascripts/tablesort.js


### PR DESCRIPTION
The mkdocs-material docs format supports making tables alpha sortable with some changes.

https://squidfunk.github.io/mkdocs-material/reference/data-tables/#sortable-tables-mkdocsyml