### PR TITLE
Allow rule ranges on command line

### DIFF
--- a/docs/man/precli.md
+++ b/docs/man/precli.md
@@ -3,7 +3,7 @@
 ## SYNOPSIS
 
 ```
-precli [-h] [-d] [-r] [--enable ENABLE] [--disable DISABLE] [--json] [--plain]
+precli [-h] [-d] [-r] [--enable ENABLE | --disable DISABLE] [--json] [--plain]
        [--markdown] [--gist] [-o OUTPUT] [--no-color] [-q] [--version]
        [targets ...]
 ```

--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -59,7 +59,8 @@ def setup_arg_parser():
         action="store_true",
         help="find and process files in subdirectories",
     )
-    parser.add_argument(
+    enable_grp = parser.add_mutually_exclusive_group()
+    enable_grp.add_argument(
         "--enable",
         dest="enable",
         action="store",
@@ -67,7 +68,7 @@ def setup_arg_parser():
         type=str,
         help="comma-separated list of rule IDs or names to enable",
     )
-    parser.add_argument(
+    enable_grp.add_argument(
         "--disable",
         dest="disable",
         action="store",
@@ -329,8 +330,8 @@ def main():
     # Setup the command line arguments
     args = setup_arg_parser()
 
-    enabled = args.enable.split(",") if args.enable else []
-    disabled = args.disable.split(",") if args.disable else []
+    enabled = args.enable.split(",") if args.enable else None
+    disabled = args.disable.split(",") if args.disable else None
 
     # Compile a list of the targets
     artifacts = discover_files(args.targets, args.recursive)

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -98,7 +98,7 @@ class Rule(ABC):
         return self._enabled
 
     @enabled.setter
-    def enabled(self, enabled):
+    def enabled(self, enabled: bool):
         """Set whether the rule is enabled"""
         self._enabled = enabled
 


### PR DESCRIPTION
Allow the user to specify a rule list range, such as
   --enable=PY002-PY005

Also, the enabled and disabled CLI arguments are now made mutually exclusive.

Closes: #531