### PR TITLE
Resolve hex, ord, and binary forms of an integer

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -502,9 +502,16 @@ class Python(Parser):
                     # TODO: handle f-strings? (f"{a}")
                     value = nodetext
                 case tokens.INTEGER:
-                    # TODO: hex, octal, binary
+                    if nodetext.lower().startswith("0x"):
+                        base = 16
+                    elif nodetext.lower().startswith("0o"):
+                        base = 8
+                    elif nodetext.lower().startswith("0b"):
+                        base = 2
+                    else:
+                        base = 10
                     try:
-                        value = int(nodetext)
+                        value = int(nodetext, base)
                     except ValueError:
                         value = nodetext
                 case tokens.FLOAT:


### PR DESCRIPTION
The resolve function of the python parse currently only handles base 10 decimal inteegers. This change will include alternative base forms of hexadecimal, ordinal, and binary forms.