### PR TITLE
Use extension loader to load renderers

### DIFF
--- a/docs/man/precli.md
+++ b/docs/man/precli.md
@@ -3,8 +3,8 @@
 ## SYNOPSIS
 
 ```
-precli [-h] [-d] [-r] [--enable ENABLE | --disable DISABLE] [--json] [--plain]
-       [--markdown] [--gist] [-o OUTPUT] [--no-color] [-q] [--version]
+precli [-h] [-d] [-r] [--enable ENABLE | --disable DISABLE] [--json | --plain | --markdown]
+       [--gist] [-o OUTPUT] [--no-color] [-q] [--version]
        [targets ...]
 ```
 

--- a/precli/core/loader.py
+++ b/precli/core/loader.py
@@ -2,12 +2,15 @@
 from importlib.metadata import entry_points
 
 
-def load_parsers() -> dict:
-    parsers = {}
+def load_extension(group: str, name: str = ""):
+    if not name:
+        extensions = {}
 
-    discovered_plugins = entry_points(group="precli.parsers")
-    for plugin in discovered_plugins:
-        parser = plugin.load()()
-        parsers[parser.lexer] = parser
+        for entry_point in entry_points(group=group):
+            extension = entry_point.load()()
+            extensions[entry_point.name] = extension
 
-    return parsers
+        return extensions
+    else:
+        (entry_point,) = entry_points(group=group, name=name)
+        return entry_point.load()

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -30,7 +30,7 @@ from precli.rules import Rule
 
 LOG = logging.getLogger(__name__)
 PROGRESS_THRESHOLD = 50
-parsers = loader.load_parsers()
+parsers = loader.load_extension(group="precli.parsers")
 
 
 def parse_file(

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,19 @@ project_urls =
 console_scripts =
     precli = precli.cli.main:main
 
+precli.renderers =
+    # precli/renderers/detailed.py
+    detailed = precli.renderers.detailed:Detailed
+
+    # precli/renderers/json.py
+    json = precli.renderers.json:Json
+
+    # precli/renderers/markdown.py
+    markdown = precli.renderers.markdown:Markdown
+
+    # precli/renderers/plain.py
+    plain = precli.renderers.plain:Plain
+
 precli.parsers =
     # precli/parsers/go.py
     go = precli.parsers.go:Go


### PR DESCRIPTION
The renderers should ideally be loaded via the extension mechanism rather than hard-coding the load of each class.

This also enables the ability to add future renderers without changes to the code that loads them.

Closes #541