### PR TITLE
Bump to latest version of tree-sitter

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -1,10 +1,10 @@
 # Copyright 2024 Secure Sauce LLC
-import warnings
+import importlib
 from abc import ABC
 from abc import abstractmethod
 from importlib.metadata import entry_points
 
-import tree_sitter_languages
+import tree_sitter
 from tree_sitter import Node
 
 from precli.core.artifact import Artifact
@@ -28,16 +28,9 @@ class Parser(ABC):
     def __init__(self, lang: str):
         """Initialize a new parser."""
         self._lexer = lang
-
-        # Suppress the following warning from tree-sitter
-        # FutureWarning: Language(path, name) is deprecated. Use
-        # Language(ptr, name) instead.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            self.tree_sitter_language = tree_sitter_languages.get_language(
-                lang
-            )
-            self.tree_sitter_parser = tree_sitter_languages.get_parser(lang)
+        tree_sitter_lang = importlib.import_module(f"tree_sitter_{lang}")
+        language = tree_sitter.Language(tree_sitter_lang.language())
+        self.tree_sitter_parser = tree_sitter.Parser(language)
         self.rules = {}
         self.wildcards = {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 Pygments==2.18.0
 rich==13.7.1
-tree-sitter==0.21.3
-tree-sitter-languages==1.10.2
+tree-sitter==0.22.3
 ignorelib==0.3.0
 requests==2.32.3
 sarif-om==1.0.4
 jschema-to-python==1.2.3
+git+https://github.com/tree-sitter/tree-sitter-go@v0.21.0
+git+https://github.com/tree-sitter/tree-sitter-java@v0.21.0
+git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0


### PR DESCRIPTION
* Updates to tree-sitter 0.22.3
* In order to accomplish this update, needed to switch to pip installing of git releases instead of PyPI since the binaries MacOS ARM are missing.
* Removes the need to suppress the warning from tree-sitter