### PR TITLE
tree-sitter-python requires manual install on arm macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,12 @@ To install precli (requires Python 3.12):
 
     pip install precli
 
+Note: If using arm based macOS, you'll also need to install this package:
+
+.. code-block:: console
+
+    pip install git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0
+
 Run precli on a single test example:
 
 .. code-block:: console

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,12 @@ To install precli:
 pip install precli
 ```
 
+Note: If using arm based macOS, you'll also need to install this package:
+
+```
+pip install git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0
+```
+
 ## Usage
 
 Run precli on a single test example:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ignorelib==0.3.0
 requests==2.32.3
 sarif-om==1.0.4
 jschema-to-python==1.2.3
-git+https://github.com/tree-sitter/tree-sitter-go@v0.21.0
-git+https://github.com/tree-sitter/tree-sitter-java@v0.21.0
-git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0
+tree-sitter-go==0.21.0
+tree-sitter-java==0.21.0
+tree-sitter-python==0.21.0; sys_platform != "darwin" and platform_machine != "arm64"
+git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0; sys_platform == "darwin" and platform_machine == "arm64"


### PR DESCRIPTION
The tree-sitter-python on PyPI unfortunately doesn't include the binaries for Arm based MacOS. As a result, the only way to get it is from the github repo.

This change updates the instructions to advise the user how to install this added dependency that won't get installed from pip fetching from PyPI.

The requirements.txt is also updated to use PyPI in all cases except if Arm based MacOS.