### PR TITLE
More typing error fixes

### DIFF
--- a/precli/core/argument.py
+++ b/precli/core/argument.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
+from typing import Optional
+
 from tree_sitter import Node
 
 from precli.core import utils
@@ -10,7 +12,7 @@ class Argument:
         self,
         node: Node,
         value,
-        name: str = None,
+        name: Optional[str] = None,
         position: int = -1,
     ):
         self._node = node

--- a/precli/core/artifact.py
+++ b/precli/core/artifact.py
@@ -1,8 +1,9 @@
 # Copyright 2024 Secure Sauce LLC
+from typing import Optional
 
 
 class Artifact:
-    def __init__(self, file_name: str, uri: str = None):
+    def __init__(self, file_name: str, uri: Optional[str] = None):
         self._file_name = file_name
         # TODO: if uri is None, use file:///
         self._uri = uri
@@ -21,7 +22,7 @@ class Artifact:
         self._file_name = file_name
 
     @property
-    def uri(self) -> str:
+    def uri(self) -> Optional[str]:
         """The URI of the artifact."""
         return self._uri
 

--- a/precli/core/call.py
+++ b/precli/core/call.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
+from typing import Optional
+
 from tree_sitter import Node
 
 from precli.core.argument import Argument
@@ -11,12 +13,12 @@ class Call:
         node: Node,
         name: str,
         name_qual: str,
-        func_node: Node = None,
-        var_node: Node = None,
-        ident_node: Node = None,
-        arg_list_node: Node = None,
-        args: list = None,
-        kwargs: dict = None,
+        func_node: Optional[Node] = None,
+        var_node: Optional[Node] = None,
+        ident_node: Optional[Node] = None,
+        arg_list_node: Optional[Node] = None,
+        args: Optional[list] = None,
+        kwargs: Optional[dict] = None,
     ):
         self._node = node
         self._name = name
@@ -34,7 +36,7 @@ class Call:
         return self._node
 
     @property
-    def var_node(self) -> Node:
+    def var_node(self) -> Optional[Node]:
         """
         The node representing the variable part of a function call.
 
@@ -45,7 +47,7 @@ class Call:
         return self._var_node
 
     @property
-    def function_node(self) -> Node:
+    def function_node(self) -> Optional[Node]:
         """
         The node representing the entire function of the call.
 
@@ -56,7 +58,7 @@ class Call:
         return self._func_node
 
     @property
-    def identifier_node(self) -> Node:
+    def identifier_node(self) -> Optional[Node]:
         """
         The node representing just the identifier of the function.
 
@@ -77,7 +79,7 @@ class Call:
         return self._name_qual
 
     @property
-    def arg_list_node(self) -> Node:
+    def arg_list_node(self) -> Optional[Node]:
         return self._arg_list_node
 
     def get_argument(

--- a/precli/core/fix.py
+++ b/precli/core/fix.py
@@ -1,4 +1,6 @@
 # Copyright 2023 Secure Sauce LLC
+from typing import Optional
+
 from precli.core.location import Location
 
 
@@ -7,7 +9,7 @@ class Fix:
         self,
         description: str,
         deleted_location: Location,
-        inserted_content: str = None,
+        inserted_content: Optional[str] = None,
     ):
         self._description = description
         self._deleted_location = deleted_location
@@ -24,6 +26,6 @@ class Fix:
         return self._deleted_location
 
     @property
-    def inserted_content(self) -> str:
+    def inserted_content(self) -> Optional[str]:
         """Content to insert at location specified by deleted_location."""
         return self._inserted_content

--- a/precli/core/location.py
+++ b/precli/core/location.py
@@ -1,11 +1,13 @@
 # Copyright 2024 Secure Sauce LLC
+from typing import Optional
+
 from tree_sitter import Node
 
 
 class Location:
     def __init__(
         self,
-        node: Node = None,
+        node: Optional[Node] = None,
         start_line: int = 0,
         end_line: int = -1,
         start_column: int = 1,

--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
+from typing import Optional
+
 from precli.core.artifact import Artifact
 from precli.core.fix import Fix
 from precli.core.kind import Kind
@@ -14,13 +16,13 @@ class Result:
         self,
         rule_id: str,
         location: Location,
-        artifact: Artifact = None,
+        artifact: Optional[Artifact] = None,
         kind: Kind = Kind.FAIL,
-        level: Level = None,
-        message: str = None,
-        fixes: list[Fix] = None,
-        suppression: Suppression = None,
-        snippet: str = None,
+        level: Optional[Level] = None,
+        message: Optional[str] = None,
+        fixes: Optional[list[Fix]] = None,
+        suppression: Optional[Suppression] = None,
+        snippet: Optional[str] = None,
     ):
         self._rule_id = rule_id
         self._artifact = artifact
@@ -70,7 +72,7 @@ class Result:
         return self._rule_id
 
     @property
-    def artifact(self) -> Artifact:
+    def artifact(self) -> Optional[Artifact]:
         """Artifact, typically the file."""
         return self._artifact
 
@@ -133,7 +135,7 @@ class Result:
         return self._fixes if self._suppression is None else []
 
     @property
-    def suppression(self) -> Suppression:
+    def suppression(self) -> Optional[Suppression]:
         """Possible suppressions of the result."""
         return self._suppression
 

--- a/precli/core/suppression.py
+++ b/precli/core/suppression.py
@@ -1,4 +1,6 @@
 # Copyright 2023 Secure Sauce LLC
+from typing import Optional
+
 from precli.core.location import Location
 from precli.core.status import Status
 
@@ -10,7 +12,7 @@ class Suppression:
         rules: set[str],
         kind: str = "inSource",
         status: Status = Status.ACCEPTED,
-        justification: str = None,
+        justification: Optional[str] = None,
     ):
         self._location = location
         self._rules = rules
@@ -43,6 +45,6 @@ class Suppression:
         return self._status
 
     @property
-    def justification(self) -> str:
+    def justification(self) -> Optional[str]:
         """User-supplied string that explains why the result was suppressed."""
         return self._justification

--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -3,6 +3,7 @@ import importlib
 from abc import ABC
 from abc import abstractmethod
 from importlib.metadata import entry_points
+from typing import Optional
 
 import tree_sitter
 from tree_sitter import Node
@@ -91,8 +92,8 @@ class Parser(ABC):
     def parse(
         self,
         artifact: Artifact,
-        enabled: list[str] = None,
-        disabled: list[str] = None,
+        enabled: Optional[list[str]] = None,
+        disabled: Optional[list[str]] = None,
     ) -> list[Result]:
         """File extension of files this parser can handle."""
         if enabled is not None:

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
 from abc import ABC
+from typing import Optional
 
 from precli.core.config import Config
 from precli.core.cwe import Cwe
@@ -17,9 +18,9 @@ class Rule(ABC):
         description: str,
         cwe_id: int,
         message: str,
-        wildcards: dict[str, list[str]] = None,
-        config: Config = None,
-        help_url: str = None,
+        wildcards: Optional[dict[str, list[str]]] = None,
+        config: Optional[Config] = None,
+        help_url: Optional[str] = None,
     ):
         self._id = id
         self._name = name
@@ -113,7 +114,7 @@ class Rule(ABC):
         return self._message
 
     @property
-    def wildcards(self) -> dict[str, list[str]]:
+    def wildcards(self) -> Optional[dict[str, list[str]]]:
         """
         Mapping of wildcard imports to concrete modules.
 


### PR DESCRIPTION
This change makes use of typing.Optional to resolve errors where pyright complains about a <type | None>.