### PR TITLE
Use ubuntu latest for readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.12"
 


### PR DESCRIPTION
Read-the-docs has an option to use the latest ubuntu LTS release. Switching to this option is easier to maintain as new ubuntu versions get released.