### PR TITLE
Add new rule around loose permission in os module

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -58,3 +58,4 @@
 | PY033 | [re — denial of service](rules/python/stdlib/re-denial-of-service.md) | Inefficient Regular Expression Complexity in `re` Module |
 | PY034 | [hmac — weak key](rules/python/stdlib/hmac-weak-key.md) | Insufficient `hmac` Key Size |
 | PY035 | [hashlib — improper prng](rules/python/stdlib/hashlib-improper-prng.md) | Improper Randomness for Cryptographic `hashlib` Functions |
+| PY036 | [hashlib — improper prng](rules/python/stdlib/os-loose-file-perm.md) | Incorrect Permission Assignment for Critical Resource using `os` Module |

--- a/docs/rules/python/stdlib/os-loose-file-perm.md
+++ b/docs/rules/python/stdlib/os-loose-file-perm.md
@@ -1,0 +1,10 @@
+---
+id: PY036
+title: os — incorrect permission
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/PY036
+---
+
+::: precli.rules.python.stdlib.os_loose_file_perm

--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -33,10 +33,18 @@ class Parser(ABC):
         language = tree_sitter.Language(tree_sitter_lang.language())
         self.tree_sitter_parser = tree_sitter.Parser(language)
         self.rules = {}
+        self.wildcards = {}
 
         discovered_rules = entry_points(group=f"precli.rules.{lang}")
         for rule in discovered_rules:
             self.rules[rule.name] = rule.load()(rule.name)
+
+            if self.rules[rule.name].wildcards:
+                for k, v in self.rules[rule.name].wildcards.items():
+                    if k in self.wildcards:
+                        self.wildcards[k] += v
+                    else:
+                        self.wildcards[k] = v
 
         def child_by_type(self, type: str) -> Node | None:
             # Return first child with type as specified

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -42,9 +42,12 @@ class Java(Parser):
 
         if len(nodes) > 3 and nodes[3].type == NodeTypes.ASTERISK:
             # "import" scoped_identifier "." asterisk ";"
-            self.analyze_node(
-                NodeTypes.WILDCARD_IMPORT, package=nodes[1].string
-            )
+            wc_import = nodes[1].string
+
+            if f"{wc_import}.*" in self.wildcards:
+                for wc in self.wildcards[f"{wc_import}.*"]:
+                    full_import = ".".join(filter(None, [wc_import, wc]))
+                    self.current_symtab.put(wc, NodeTypes.IMPORT, full_import)
         else:
             # "import" scoped_identifier ";"
             package = nodes[1].string

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -126,17 +126,6 @@ class Rule(ABC):
         """
         return self._wildcards
 
-    def analyze_wildcard_import(self, context: dict, package: str) -> None:
-        # FIXME(ericwb): some modules like Cryptodome permit
-        # wildcard imports at various package levels like
-        # from Cryptodome import *
-        # from Cryptodome.Hash import *
-        if f"{package}.*" in self._wildcards:
-            for wc in self._wildcards[f"{package}.*"]:
-                context["symtab"].put(
-                    wc, "import", ".".join(filter(None, [package, wc]))
-                )
-
     @staticmethod
     def get_fixes(
         context: dict,

--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -94,11 +94,6 @@ class ArgparseSensitiveInfo(Rule):
             cwe_id=214,
             message="{0} in CLI arguments are leaked to command history, "
             "logs, ps output, etc.",
-            wildcards={
-                "argparse.*": [
-                    "ArgumentParser",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -126,12 +126,6 @@ class CryptWeakHash(Rule):
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",
-            wildcards={
-                "crypt.*": [
-                    "crypt",
-                    "mksalt",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -100,11 +100,6 @@ class FtpCleartext(Rule):
             cwe_id=319,
             message="The FTP protocol can transmit data in cleartext without "
             "encryption.",
-            wildcards={
-                "ftplib.*": [
-                    "FTP",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/ftplib_unverified_context.py
+++ b/precli/rules/python/stdlib/ftplib_unverified_context.py
@@ -83,11 +83,6 @@ class FtplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            wildcards={
-                "ftplib.*": [
-                    "FTP_TLS",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/hashlib_improper_prng.py
+++ b/precli/rules/python/stdlib/hashlib_improper_prng.py
@@ -81,20 +81,6 @@ class HashlibImproperPrng(Rule):
             cwe_id=330,
             message="The '{0}' pseudo-random generator should not be used for "
             "security purposes.",
-            wildcards={
-                "hashlib.*": [
-                    "blake2b",
-                    "blake2s",
-                    "pbkdf2_hmac",
-                    "scrypt",
-                ],
-                "random.*": [
-                    "randbytes",
-                ],
-                "ssl.*": [
-                    "RAND_bytes",
-                ],
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -108,16 +108,6 @@ class HashlibWeakHash(Rule):
             cwe_id=328,
             message="The hash function '{0}' is vulnerable to collision and "
             "pre-image attacks.",
-            wildcards={
-                "hashlib.*": [
-                    "md4",
-                    "md5",
-                    "ripemd160",
-                    "sha",
-                    "sha1",
-                    "pbkdf2_hmac",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -103,15 +103,6 @@ class HmacTimingAttack(Rule):
             cwe_id=208,
             message="Comparing digests with the '{0}' operator is vulnerable "
             "to timing attacks.",
-            wildcards={
-                "hmac.*": [
-                    "new",
-                    "digest",
-                    "HMAC",
-                    "HMAC.digest",
-                    "HMAC.hexdigest",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -98,19 +98,6 @@ class HmacWeakHash(Rule):
             cwe_id=328,
             message="The hash function '{0}' is vulnerable to collision and "
             "pre-image attacks.",
-            wildcards={
-                "hashlib.*": [
-                    "md4",
-                    "md5",
-                    "ripemd160",
-                    "sha",
-                    "sha1",
-                ],
-                "hmac.*": [
-                    "new",
-                    "digest",
-                ],
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/hmac_weak_key.py
+++ b/precli/rules/python/stdlib/hmac_weak_key.py
@@ -118,29 +118,6 @@ class HmacWeakKey(Rule):
             cwe_id=326,
             message="The given key is only '{0}' bytes which is insufficient "
             "for the '{2}' algorithm.",
-            wildcards={
-                "hashlib.*": [
-                    "blake2s",
-                    "blake2b",
-                    "sha224",
-                    "sha256",
-                    "sha384",
-                    "sha512",
-                    "sha3_224",
-                    "sha3_256",
-                    "sha3_384",
-                    "sha3_512",
-                    "sha512_224",
-                    "sha512_256",
-                    "shake_128",
-                    "shake_256",
-                    "sm3",
-                ],
-                "hmac.*": [
-                    "new",
-                    "digest",
-                ],
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/http_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/http_server_unrestricted_bind.py
@@ -92,12 +92,6 @@ class HttpServerUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            wildcards={
-                "http.server.*": [
-                    "HTTPServer",
-                    "ThreadingHTTPServer",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -81,12 +81,6 @@ class HttpUrlSecret(Rule):
             description=__doc__,
             cwe_id=598,
             message="Secrets in URLs are vulnerable to unauthorized access.",
-            wildcards={
-                "http.client.*": [
-                    "HTTPConnection",
-                    "HTTPSConnection",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -85,11 +85,6 @@ class ImapCleartext(Rule):
             cwe_id=319,
             message="The IMAP protocol can transmit data in cleartext without "
             "encryption.",
-            wildcards={
-                "imaplib.*": [
-                    "IMAP4",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/imaplib_unverified_context.py
+++ b/precli/rules/python/stdlib/imaplib_unverified_context.py
@@ -94,12 +94,6 @@ class ImaplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            wildcards={
-                "imaplib.*": [
-                    "IMAP4",
-                    "IMAP4_SSL",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -56,12 +56,6 @@ class JsonLoad(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            wildcards={
-                "json.*": [
-                    "load",
-                    "loads",
-                ]
-            },
             config=Config(enabled=False),
         )
 

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -67,11 +67,6 @@ class InsecureListenConfig(Rule):
             cwe_id=94,
             message="Using '{0}' with unset 'verify' vulnerable to code "
             "injection.",
-            wildcards={
-                "logging.config.*": [
-                    "listen",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -60,12 +60,6 @@ class MarshalLoad(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            wildcards={
-                "marshal.*": [
-                    "load",
-                    "loads",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -71,11 +71,6 @@ class NntpCleartext(Rule):
             cwe_id=319,
             message="The NNTP protocol can transmit data in cleartext without "
             "encryption.",
-            wildcards={
-                "nntplib.*": [
-                    "NNTP",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/nntplib_unverified_context.py
+++ b/precli/rules/python/stdlib/nntplib_unverified_context.py
@@ -84,12 +84,6 @@ class NntplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            wildcards={
-                "nntplib.*": [
-                    "NNTP",
-                    "NNTP_SSL",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/os_loose_file_perm.py
+++ b/precli/rules/python/stdlib/os_loose_file_perm.py
@@ -1,0 +1,174 @@
+# Copyright 2024 Secure Sauce LLC
+r"""
+# Incorrect Permission Assignment for Critical Resource using `os` Module
+
+This rule identifies instances in code where potentially risky file or
+directory permission modes are being set using functions like chmod, fchmod,
+mknod, open, lchmod, and similar system calls. Setting inappropriate
+permission modes can lead to security vulnerabilities, including unauthorized
+access, data leakage, or privilege escalation.
+
+Setting overly permissive modes (e.g., 0777, 0666) can expose files or
+directories to unauthorized access or modification. The rule flags instances
+where the mode may pose a security risk, particularly when:
+
+ - Write permissions are granted to others (group or world): Modes like 0666
+   (read/write for everyone) or 0777 (read/write/execute for everyone) are
+   inherently dangerous.
+ - Inappropriate permissions for sensitive files: Configuration files,
+   credential files, and other sensitive files should not be globally readable
+   or writable.
+
+## Examples
+
+```python linenums="1" hl_lines="8-9" title="os_chmod_o755_binop_stat.py"
+import os
+import stat
+
+
+# 0o755 for rwxr-xr-x
+os.chmod(
+    "example.txt",
+    stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP |
+    stat.S_IROTH | stat.S_IXOTH,
+)
+```
+
+??? example "Example Output"
+    ```
+    > precli tests/unit/rules/python/stdlib/argparse/examples/os_chmod_o755_binop_stat.py
+    ⚠️  Warning on line 13 in tests/unit/rules/python/stdlib/os/examples/os_chmod_o755_binop_stat.py
+    PY036: Incorrect Permission Assignment for Critical Resource
+    Mode '0o755' grants excessive permissions, potentially allowing unauthorized access or modification.
+    ```
+
+## Remediation
+
+ - Restrict file permissions: Use more restrictive permission modes that limit
+   access to only the necessary users.
+ - Review file sensitivity: Ensure that sensitive files are protected with
+   the appropriate permissions.
+ - Apply the principle of least privilege: Only grant the minimum required
+   permissions for the intended functionality.
+
+Safer Permissions Examples:
+
+ - For general files: 0644 (read/write for owner, read-only for group and
+   others)
+ - For sensitive files: 0600 (read/write for owner only)
+ - For executable scripts: 0755 (read/write/execute for owner, read/execute
+   for group and others)
+
+```python linenums="1" hl_lines="8" title="os_chmod_o755_binop_stat.py"
+import os
+import stat
+
+
+# 0o644 for rw-r--r--
+os.chmod(
+    "example.txt",
+    stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
+)
+```
+
+## See also
+
+!!! info
+    - [os — Miscellaneous operating system interfaces — Python documentation](https://docs.python.org/3/library/os.html#os.chmod)
+    - [stat — Interpreting stat() results — Python documentation](https://docs.python.org/3/library/stat.html#stat.S_ISUID)
+    - [CWE-732: Incorrect Permission Assignment for Critical Resource](https://cwe.mitre.org/data/definitions/732.html)
+
+_New in version 0.6.2_
+
+"""  # noqa: E501
+import stat
+
+from precli.core.call import Call
+from precli.core.level import Level
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.parsers.node_types import NodeTypes
+from precli.rules import Rule
+
+
+class OsLooseFilePermissions(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="incorrect_permission",
+            description=__doc__,
+            cwe_id=732,
+            message="Mode '{0}' grants excessive permissions, potentially "
+            "allowing unauthorized access or modification.",
+        )
+
+    def _risky_mode(self, mode):
+        return (
+            mode & stat.S_IWOTH
+            or mode & stat.S_IWGRP
+            or mode & stat.S_IXGRP
+            or mode & stat.S_IXOTH
+        )
+
+    def analyze_import_statement(
+        self, context: dict, package: str, alias: str
+    ) -> None:
+        if package == "stat":
+            for constant in dir(stat):
+                if constant.startswith("S_"):
+                    context["symtab"].put(
+                        f"{alias}.{constant}",
+                        NodeTypes.IDENTIFIER,
+                        getattr(stat, constant),
+                    )
+
+    def analyze_import_from_statement(
+        self, context: dict, package: str, alias: str
+    ) -> None:
+        if package.startswith("stat."):
+            constant = package.split(".")[-1]
+            context["symtab"].put(
+                alias,
+                NodeTypes.IDENTIFIER,
+                getattr(stat, constant),
+            )
+
+    def analyze_call(self, context: dict, call: Call) -> Result | None:
+        if call.name_qualified not in (
+            "os.fchmod",
+            "os.chmod",
+            "os.lchmod",
+            "os.mkdir",  # default mode=0o777
+            "os.mkfifo",  # default mode=0o666
+            "os.mknod",  # default mode=0o600
+            "os.open",  # default mode=0o777
+        ):
+            return
+
+        argument = call.get_argument(
+            position=2 if call.name_qualified == "os.open" else 1,
+            name="mode",
+        )
+        mode = argument.value
+
+        if argument.node is not None:
+            location = Location(node=argument.node)
+            message = self.message.format(oct(mode))
+        else:
+            if call.name_qualified in ("os.mkdir", "os.open"):
+                mode = 0o777
+            elif call.name_qualified == "os.mkfifo":
+                mode = 0o666
+            location = Location(node=call.arg_list_node)
+            message = (
+                f"The default mode value of {oct(mode)} is overly permissive,"
+                " potentially allowing unauthorized access or modification."
+            )
+
+        if isinstance(mode, int) and self._risky_mode(mode):
+            return Result(
+                rule_id=self.id,
+                location=location,
+                level=Level.ERROR if mode & stat.S_IWOTH else Level.WARNING,
+                message=message,
+            )

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -72,13 +72,6 @@ class PickleLoad(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            wildcards={
-                "pickle.*": [
-                    "load",
-                    "loads",
-                    "Unpickler",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -80,11 +80,6 @@ class PopCleartext(Rule):
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",
-            wildcards={
-                "poplib.*": [
-                    "POP3",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/poplib_unverified_context.py
+++ b/precli/rules/python/stdlib/poplib_unverified_context.py
@@ -90,12 +90,6 @@ class PoplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            wildcards={
-                "poplib.*": [
-                    "POP3",
-                    "POP3_SSL",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/re_denial_of_service.py
+++ b/precli/rules/python/stdlib/re_denial_of_service.py
@@ -78,7 +78,6 @@ class ReDenialOfService(Rule):
             message="The call to '{0}'' with regex pattern '{1}'' is "
             "susceptible to catastrophic backtracking and may cause "
             "performance degradation.",
-            wildcards={},
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -69,7 +69,6 @@ class SecretsWeakToken(Rule):
             cwe_id=326,
             message="A token size of '{0}' is less than the recommended "
             "'{1}' bytes, which can be vulnerable to brute-force attacks.",
-            wildcards={},
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -59,12 +59,6 @@ class ShelveOpen(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            wildcards={
-                "shelve.*": [
-                    "open",
-                    "DbfilenameShelf",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -116,11 +116,6 @@ class SmtpCleartext(Rule):
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",
-            wildcards={
-                "smtplib.*": [
-                    "SMTP",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/smtplib_unverified_context.py
+++ b/precli/rules/python/stdlib/smtplib_unverified_context.py
@@ -126,12 +126,6 @@ class SmtplibUnverifiedContext(Rule):
             cwe_id=295,
             message="The '{0}' function does not properly validate "
             "certificates when context is unset or None.",
-            wildcards={
-                "smtplib.*": [
-                    "SMTP",
-                    "SMTP_SSL",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/socket_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socket_unrestricted_bind.py
@@ -82,12 +82,6 @@ class SocketUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            wildcards={
-                "socket.*": [
-                    "create_server",
-                    "socket",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
@@ -100,16 +100,6 @@ class SocketserverUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            wildcards={
-                "socketserver.*": [
-                    "TCPServer",
-                    "UDPServer",
-                    "ForkingTCPServer",
-                    "ForkingUDPServer",
-                    "ThreadingTCPServer",
-                    "ThreadingUDPServer",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -76,7 +76,6 @@ class SslContextWeakKey(Rule):
             cwe_id=326,
             message="Using '{0}' key sizes less than '{1}' bits is considered "
             "vulnerable to attacks.",
-            wildcards={},
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -123,11 +123,6 @@ class TelnetlibCleartext(Rule):
             cwe_id=319,
             message="The '{0}' module transmits data in cleartext without "
             "encryption.",
-            wildcards={
-                "telnetlib.*": [
-                    "Telnet",
-                ]
-            },
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -74,14 +74,6 @@ class MktempRaceCondition(Rule):
             message="The function '{0}' can allow insecure ways of creating "
             "temporary files and directories that can lead to race "
             "conditions.",
-            wildcards={
-                "os.*": [
-                    "open",
-                ],
-                "tempfile.*": [
-                    "mktemp",
-                ],
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
@@ -92,12 +92,6 @@ class XmlrpcServerUnrestrictedBind(Rule):
             cwe_id=1327,
             message="Binding to '{0}' exposes the application on all network "
             "interfaces, increasing the risk of unauthorized access.",
-            wildcards={
-                "xmlrpc.server.*": [
-                    "DocXMLRPCServer",
-                    "SimpleXMLRPCServer",
-                ]
-            },
         )
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -185,3 +185,6 @@ precli.rules.python =
 
     # precli/rules/python/stdlib/hashlib_improper_prng.py
     PY035 = precli.rules.python.stdlib.hashlib_improper_prng:HashlibImproperPrng
+
+    # precli/rules/python/stdlib/os_loose_file_perm.py
+    PY036 = precli.rules.python.stdlib.os_loose_file_perm:OsLooseFilePermissions

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_IXOTH.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 24
+# end_column: 29
+import os
+from stat import S_IXOTH as IXOTH
+
+
+os.chmod("/etc/passwd", IXOTH)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_S_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_S_IXOTH.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 24
+# end_column: 31
+import os
+from stat import S_IXOTH
+
+
+os.chmod("/etc/passwd", S_IXOTH)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_S_S_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_S_S_IXOTH.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 24
+# end_column: 33
+import os
+import stat as S
+
+
+os.chmod("/etc/passwd", S.S_IXOTH)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o111_binop_wildcard.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o111_binop_wildcard.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 24
+# end_column: 28
+import os
+from stat import *
+
+
+mode = S_IXUSR | S_IXGRP | S_IXOTH
+os.chmod("/etc/passwd", mode)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o644.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o644.py
@@ -1,0 +1,5 @@
+# level: NONE
+import os
+
+
+os.chmod("/etc/passwd", 0o644)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o7.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o7.py
@@ -1,0 +1,9 @@
+# level: ERROR
+# start_line: 9
+# end_line: 9
+# start_column: 24
+# end_column: 27
+import os
+
+
+os.chmod("/etc/passwd", 0o7)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o755_binop_stat.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o755_binop_stat.py
@@ -1,0 +1,15 @@
+# level: WARNING
+# start_line: 13
+# end_line: 14
+# start_column: 4
+# end_column: 31
+import os
+import stat
+
+
+# 0o755 for rwxr-xr-x
+os.chmod(
+    "example.txt",
+    stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP |
+    stat.S_IROTH | stat.S_IXOTH,
+)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o760.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o760.py
@@ -1,0 +1,9 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 24
+# end_column: 29
+import os
+
+
+os.chmod("/etc/passwd", 0o760)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o770.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o770.py
@@ -1,0 +1,9 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 24
+# end_column: 29
+import os
+
+
+os.chmod("/etc/passwd", 0o770)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o776.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o776.py
@@ -1,0 +1,9 @@
+# level: ERROR
+# start_line: 9
+# end_line: 9
+# start_column: 24
+# end_column: 29
+import os
+
+
+os.chmod("/etc/passwd", 0o776)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_o777.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_o777.py
@@ -1,0 +1,11 @@
+# level: ERROR
+# start_line: 11
+# end_line: 11
+# start_column: 19
+# end_column: 23
+import os
+
+
+filename = '/etc/passwd'
+mode = 0o777
+os.chmod(filename, mode)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_stat_S_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_stat_S_IXOTH.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 24
+# end_column: 36
+import os
+import stat
+
+
+os.chmod("/etc/passwd", stat.S_IXOTH)

--- a/tests/unit/rules/python/stdlib/os/examples/os_chmod_x1ff.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_chmod_x1ff.py
@@ -1,0 +1,11 @@
+# level: ERROR
+# start_line: 11
+# end_line: 11
+# start_column: 19
+# end_column: 23
+import os
+
+
+filename = '/etc/passwd'
+mode = 0x1ff
+os.chmod(filename, mode)

--- a/tests/unit/rules/python/stdlib/os/examples/os_fchmod_511.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_fchmod_511.py
@@ -1,0 +1,9 @@
+# level: ERROR
+# start_line: 9
+# end_line: 9
+# start_column: 25
+# end_column: 28
+import os
+
+
+os.fchmod("/etc/passwd", 511)

--- a/tests/unit/rules/python/stdlib/os/examples/os_lchmod_o227.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_lchmod_o227.py
@@ -1,0 +1,10 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 30
+# end_column: 34
+import os
+
+
+mode = 0o227
+os.lchmod('/etc/passwd', mode=mode)

--- a/tests/unit/rules/python/stdlib/os/examples/os_mkdir_default.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mkdir_default.py
@@ -1,0 +1,10 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 8
+# end_column: 14
+import os
+
+
+path = "examples"
+os.mkdir(path)

--- a/tests/unit/rules/python/stdlib/os/examples/os_mkdir_o750_binop.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mkdir_o750_binop.py
@@ -1,0 +1,12 @@
+# level: WARNING
+# start_line: 12
+# end_line: 12
+# start_column: 20
+# end_column: 24
+import os
+import stat
+
+
+path = "examples"
+mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+os.mkdir(path, mode=mode)

--- a/tests/unit/rules/python/stdlib/os/examples/os_mkfifo_default.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mkfifo_default.py
@@ -1,0 +1,21 @@
+# level: ERROR
+# start_line: 11
+# end_line: 11
+# start_column: 9
+# end_column: 20
+import os
+import sys
+
+
+fifo_path = "my_pipe"
+os.mkfifo(fifo_path)
+
+if os.fork() == 0:
+    with open(fifo_path, "w") as fifo:
+        fifo.write("Hello from the child process!\n")
+    sys.exit(0)
+
+with open(fifo_path, "r") as fifo:
+    print("Parent process reads:", fifo.read())
+
+os.remove(fifo_path)

--- a/tests/unit/rules/python/stdlib/os/examples/os_mkfifo_o644_binop.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mkfifo_o644_binop.py
@@ -1,0 +1,18 @@
+# level: NONE
+import os
+from stat import *
+import sys
+
+
+fifo_path = "my_pipe"
+os.mkfifo(fifo_path, mode=S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
+
+if os.fork() == 0:
+    with open(fifo_path, "w") as fifo:
+        fifo.write("Hello from the child process!\n")
+    sys.exit(0)
+
+with open(fifo_path, "r") as fifo:
+    print("Parent process reads:", fifo.read())
+
+os.remove(fifo_path)

--- a/tests/unit/rules/python/stdlib/os/examples/os_mknod_o666_binop.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mknod_o666_binop.py
@@ -1,0 +1,12 @@
+# level: ERROR
+# start_line: 12
+# end_line: 12
+# start_column: 25
+# end_column: 29
+import os
+import stat
+
+
+file_path = "my_regular_file"
+mode = 0o666 | stat.S_IFREG
+os.mknod(file_path, mode=mode)

--- a/tests/unit/rules/python/stdlib/os/examples/os_open_default.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_open_default.py
@@ -1,0 +1,15 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 12
+# end_column: 62
+import os
+
+
+file_path = 'example.txt'
+fd = os.open(file_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+
+try:
+    os.write(fd, b"Hello, world!\n")
+finally:
+    os.close(fd)

--- a/tests/unit/rules/python/stdlib/os/examples/os_open_o655.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_open_o655.py
@@ -1,0 +1,15 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 63
+# end_column: 68
+import os
+
+
+file_path = 'example.txt'
+fd = os.open(file_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o655)
+
+try:
+    os.write(fd, b"Hello, world!\n")
+finally:
+    os.close(fd)

--- a/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
@@ -1,0 +1,68 @@
+# Copyright 2024 Secure Sauce LLC
+import os
+
+import pytest
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class TestOsLooseFilePermissions(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY036"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "os",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        assert rule.id == self.rule_id
+        assert rule.name == "incorrect_permission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
+        )
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.id == 732
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "os_chmod_IXOTH.py",
+            "os_chmod_o111_binop_wildcard.py",
+            "os_chmod_o644.py",
+            "os_chmod_o7.py",
+            "os_chmod_o755_binop_stat.py",
+            "os_chmod_o760.py",
+            "os_chmod_o770.py",
+            "os_chmod_o776.py",
+            "os_chmod_o777.py",
+            "os_chmod_S_IXOTH.py",
+            "os_chmod_S_S_IXOTH.py",
+            "os_chmod_stat_S_IXOTH.py",
+            "os_chmod_x1ff.py",
+            "os_fchmod_511.py",
+            "os_lchmod_o227.py",
+            "os_mkdir_default.py",
+            "os_mkdir_o750_binop.py",
+            "os_mkfifo_default.py",
+            "os_mkfifo_o644_binop.py",
+            "os_mknod_o666_binop.py",
+            "os_open_default.py",
+            "os_open_o655.py",
+        ],
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
Any usage of os.chmod and the like, the mode for the permissions for a file should be checked to ensure the permissions are not considered loose or incorrect. Incorrect in this case is using world write, group write, world execute, group execute. Care should be taken when using those.

Partially-resolves: https://github.com/securesauce/precli/issues/217