### PR TITLE
Add example code to Readme for clear example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,29 @@ Run precli on a single test example:
 
     precli tests/unit/rules/python/stdlib/hmac/examples/hmac_timing_attack.py
 
+Example code:
+
+.. code-block:: python
+
+    # level: ERROR
+    # start_line: 18
+    # end_line: 18
+    # start_column: 13
+    # end_column: 15
+    import hmac
+    
+    
+    received_digest = (
+        b"\xe2\x93\x08\x19T8\xdc\x80\xef\x87\x90m\x1f\x9d\xf7\xf2"
+        b"\xf5\x10>\xdbf\xa2\xaf\xf7x\xcdX\xdf"
+    )
+    
+    key = b"my-super-duper-secret-key-string"
+    password = b"pass"
+    digest = hmac.digest(key, password, digest="sha224")
+    
+    print(digest == received_digest)
+    
 Example result:
 
 .. image:: https://raw.githubusercontent.com/securesauce/precli/main/images/example.gif


### PR DESCRIPTION
In order to make the example scenario more clear, this change also adds the example code so stakeholders can see what code was analyzed and how the result relates.