### PR TITLE
Refactor how wildcard imports are processed

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -349,14 +349,9 @@ class Python(Parser):
 
         if nodes[2].type == tokens.IMPORT:
             if nodes[3].type == tokens.WILDCARD_IMPORT:
-                # FIXME(ericwb): some modules like Cryptodome permit
-                # wildcard imports at various package levels like
-                # from Cryptodome import *
-                # from Cryptodome.Hash import *
-                if f"{from_module}.*" in self.wildcards:
-                    for wc in self.wildcards[f"{from_module}.*"]:
-                        full_qual = [from_module, wc]
-                        imports[wc] = ".".join(filter(None, full_qual))
+                self.analyze_node(
+                    tokens.WILDCARD_IMPORT, from_module=from_module
+                )
             else:
                 result = self.import_statement(nodes[3:])
                 for key, value in result.items():

--- a/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_token.py
+++ b/tests/unit/rules/python/stdlib/argparse/examples/argparse_add_argument_token.py
@@ -3,10 +3,10 @@
 # end_line: 18
 # start_column: 0
 # end_column: 1
-import argparse
+from argparse import *
 
 
-parser = argparse.ArgumentParser(
+parser = ArgumentParser(
     prog="ProgramName",
     description="What the program does",
 )

--- a/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind.py
+++ b/tests/unit/rules/python/stdlib/socket/examples/socket_socket_bind.py
@@ -3,9 +3,9 @@
 # end_line: 10
 # start_column: 7
 # end_column: 15
-import socket
+from socket import *
 
 
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s = socket(socket.AF_INET, socket.SOCK_STREAM)
 s.bind(("", 80))
 s.listen()


### PR DESCRIPTION
This change moves the wild card processing from the particular parser into the rule class. The analyze_node() call mechanism is being reused to do wildcard processing.

This is a strategy that could later be used to actually load identifiers of an import into the symbol table as they are loaded.