### PR TITLE
Second pass at refactoring wildcard logic

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -33,18 +33,10 @@ class Parser(ABC):
         language = tree_sitter.Language(tree_sitter_lang.language())
         self.tree_sitter_parser = tree_sitter.Parser(language)
         self.rules = {}
-        self.wildcards = {}
 
         discovered_rules = entry_points(group=f"precli.rules.{lang}")
         for rule in discovered_rules:
             self.rules[rule.name] = rule.load()(rule.name)
-
-            if self.rules[rule.name].wildcards:
-                for k, v in self.rules[rule.name].wildcards.items():
-                    if k in self.wildcards:
-                        self.wildcards[k] += v
-                    else:
-                        self.wildcards[k] = v
 
         def child_by_type(self, type: str) -> Node | None:
             # Return first child with type as specified

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -42,12 +42,7 @@ class Java(Parser):
 
         if len(nodes) > 3 and nodes[3].type == tokens.ASTERISK:
             # "import" scoped_identifier "." asterisk ";"
-            wc_import = nodes[1].string
-
-            if f"{wc_import}.*" in self.wildcards:
-                for wc in self.wildcards[f"{wc_import}.*"]:
-                    full_import = ".".join(filter(None, [wc_import, wc]))
-                    self.current_symtab.put(wc, tokens.IMPORT, full_import)
+            self.analyze_node(tokens.WILDCARD_IMPORT, package=nodes[1].string)
         else:
             # "import" scoped_identifier ";"
             package = nodes[1].string

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -349,9 +349,7 @@ class Python(Parser):
 
         if nodes[2].type == tokens.IMPORT:
             if nodes[3].type == tokens.WILDCARD_IMPORT:
-                self.analyze_node(
-                    tokens.WILDCARD_IMPORT, from_module=from_module
-                )
+                self.analyze_node(tokens.WILDCARD_IMPORT, package=from_module)
             else:
                 result = self.import_statement(nodes[3:])
                 for key, value in result.items():

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -6,7 +6,6 @@ from precli.core.config import Config
 from precli.core.cwe import Cwe
 from precli.core.fix import Fix
 from precli.core.location import Location
-from precli.parsers import tokens
 
 
 class Rule(ABC):
@@ -127,16 +126,15 @@ class Rule(ABC):
         """
         return self._wildcards
 
-    def analyze_wildcard_import(self, context: dict, from_module: str) -> None:
+    def analyze_wildcard_import(self, context: dict, package: str) -> None:
         # FIXME(ericwb): some modules like Cryptodome permit
         # wildcard imports at various package levels like
         # from Cryptodome import *
         # from Cryptodome.Hash import *
-        if f"{from_module}.*" in self._wildcards:
-            for wc in self._wildcards[f"{from_module}.*"]:
-                full_qual = [from_module, wc]
+        if f"{package}.*" in self._wildcards:
+            for wc in self._wildcards[f"{package}.*"]:
                 context["symtab"].put(
-                    wc, tokens.IMPORT, ".".join(filter(None, full_qual))
+                    wc, "import", ".".join(filter(None, [package, wc]))
                 )
 
     @staticmethod


### PR DESCRIPTION
Need to do the same refactoring in the Java parser. Also, the base Parser class no longer needs to combine all the wildcards from various rules.