### PR TITLE
Fix raised exceptions in edge cases of incorrect permissions

### DIFF
--- a/precli/rules/python/stdlib/os_loose_file_perm.py
+++ b/precli/rules/python/stdlib/os_loose_file_perm.py
@@ -153,8 +153,8 @@ class OsLooseFilePermissions(Rule):
 
         if argument.node is not None:
             location = Location(node=argument.node)
-            message = self.message.format(oct(mode))
-        else:
+            message = self.message
+        elif call.name_qualified in ("os.mkdir", "os.open", "os.mkfifo"):
             if call.name_qualified in ("os.mkdir", "os.open"):
                 mode = 0o777
             elif call.name_qualified == "os.mkfifo":
@@ -170,5 +170,5 @@ class OsLooseFilePermissions(Rule):
                 rule_id=self.id,
                 location=location,
                 level=Level.ERROR if mode & stat.S_IWOTH else Level.WARNING,
-                message=message,
+                message=message.format(oct(mode)),
             )


### PR DESCRIPTION
This change will fix edge cases where the argument has a value of None or str and gets into conditions that expected as default mode argument.