### PR TITLE
New rule for pathlib.Path usage with loose permissions

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -58,4 +58,5 @@
 | PY033 | [re — denial of service](rules/python/stdlib/re-denial-of-service.md) | Inefficient Regular Expression Complexity in `re` Module |
 | PY034 | [hmac — weak key](rules/python/stdlib/hmac-weak-key.md) | Insufficient `hmac` Key Size |
 | PY035 | [hashlib — improper prng](rules/python/stdlib/hashlib-improper-prng.md) | Improper Randomness for Cryptographic `hashlib` Functions |
-| PY036 | [hashlib — improper prng](rules/python/stdlib/os-loose-file-perm.md) | Incorrect Permission Assignment for Critical Resource using `os` Module |
+| PY036 | [os — incorrect permission](rules/python/stdlib/os-loose-file-perm.md) | Incorrect Permission Assignment for Critical Resource using `os` Module |
+| PY037 | [pathlib — incorrect permission](rules/python/stdlib/pathlib-loose-file-perm.md) | Incorrect Permission Assignment for Critical Resource using `pathlib` Module |

--- a/docs/rules/python/stdlib/pathlib-loose-file-perm.md
+++ b/docs/rules/python/stdlib/pathlib-loose-file-perm.md
@@ -1,0 +1,10 @@
+---
+id: PY037
+title: pathlib — incorrect permission
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/PY037
+---
+
+::: precli.rules.python.stdlib.pathlib_loose_file_perm

--- a/precli/rules/python/stdlib/pathlib_loose_file_perm.py
+++ b/precli/rules/python/stdlib/pathlib_loose_file_perm.py
@@ -1,12 +1,12 @@
 # Copyright 2024 Secure Sauce LLC
 r"""
-# Incorrect Permission Assignment for Critical Resource using `os` Module
+# Incorrect Permission Assignment for Critical Resource using `pathlib` Module
 
 This rule identifies instances in code where potentially risky file or
-directory permission modes are being set using functions like chmod, fchmod,
-mknod, open, lchmod, and similar system calls. Setting inappropriate
-permission modes can lead to security vulnerabilities, including unauthorized
-access, data leakage, or privilege escalation.
+directory permission modes are being set using functions like chmod, lchmod,
+mkdir, touch, and similar system calls. Setting inappropriate permission modes
+can lead to security vulnerabilities, including unauthorized access, data
+leakage, or privilege escalation.
 
 Setting overly permissive modes (e.g., 0777, 0666) can expose files or
 directories to unauthorized access or modification. The rule flags instances
@@ -21,23 +21,23 @@ where the mode may pose a security risk, particularly when:
 
 ## Examples
 
-```python linenums="1" hl_lines="8-9" title="os_chmod_o755_binop_stat.py"
-import os
+```python linenums="1" hl_lines="8-9" title="pathlib_chmod_o755_binop_stat.py"
+import pathlib
 import stat
 
 
 # 0o755 for rwxr-xr-x
-os.chmod(
-    "example.txt",
+file_path = pathlib.Path("example.txt")
+file_path.chmod(
     stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP |
-    stat.S_IROTH | stat.S_IXOTH,
+    stat.S_IROTH | stat.S_IXOTH
 )
 ```
 
 ??? example "Example Output"
     ```
-    > precli tests/unit/rules/python/stdlib/os/examples/os_chmod_o755_binop_stat.py
-    ⚠️  Warning on line 8 in tests/unit/rules/python/stdlib/os/examples/os_chmod_o755_binop_stat.py
+    > precli tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o755_binop_stat.py
+    ⚠️  Warning on line 8 in tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o755_binop_stat.py
     PY036: Incorrect Permission Assignment for Critical Resource
     Mode '0o755' grants excessive permissions, potentially allowing unauthorized access or modification.
     ```
@@ -60,21 +60,21 @@ Safer Permissions Examples:
    for group and others)
 
 ```python linenums="1" hl_lines="8" title="os_chmod_o755_binop_stat.py"
-import os
+import pathlib
 import stat
 
 
 # 0o644 for rw-r--r--
-os.chmod(
-    "example.txt",
-    stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
+file_path = pathlib.Path("example.txt")
+file_path.chmod(
+    stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 )
 ```
 
 ## See also
 
 !!! info
-    - [os — Miscellaneous operating system interfaces — Python documentation](https://docs.python.org/3/library/os.html#os.chmod)
+    - [pathlib — Object-oriented filesystem paths — Python documentation](https://docs.python.org/3/library/pathlib.html#pathlib.Path.chmod)
     - [stat — Interpreting stat() results — Python documentation](https://docs.python.org/3/library/stat.html#stat.S_ISUID)
     - [CWE-732: Incorrect Permission Assignment for Critical Resource](https://cwe.mitre.org/data/definitions/732.html)
 
@@ -91,7 +91,7 @@ from precli.parsers.node_types import NodeTypes
 from precli.rules import Rule
 
 
-class OsLooseFilePermissions(Rule):
+class PathlibLooseFilePermissions(Rule):
     def __init__(self, id: str):
         super().__init__(
             id=id,
@@ -135,29 +135,26 @@ class OsLooseFilePermissions(Rule):
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:
         if call.name_qualified not in (
-            "os.fchmod",
-            "os.chmod",
-            "os.lchmod",
-            "os.mkdir",  # default mode=0o777
-            "os.mkfifo",  # default mode=0o666
-            "os.mknod",  # default mode=0o600
-            "os.open",  # default mode=0o777
+            "pathlib.Path.chmod",
+            "pathlib.Path.lchmod",
+            "pathlib.Path.mkdir",  # default mode=0o777
+            "pathlib.Path.touch",  # default mode=0o666
         ):
             return
 
-        argument = call.get_argument(
-            position=2 if call.name_qualified == "os.open" else 1,
-            name="mode",
-        )
+        argument = call.get_argument(position=0, name="mode")
         mode = argument.value
 
         if argument.node is not None:
             location = Location(node=argument.node)
             message = self.message
-        elif call.name_qualified in ("os.mkdir", "os.open", "os.mkfifo"):
-            if call.name_qualified in ("os.mkdir", "os.open"):
+        elif call.name_qualified in (
+            "pathlib.Path.mkdir",
+            "pathlib.Path.touch",
+        ):
+            if call.name_qualified == "pathlib.Path.mkdir":
                 mode = 0o777
-            elif call.name_qualified == "os.mkfifo":
+            elif call.name_qualified == "pathlib.Path.touch":
                 mode = 0o666
             location = Location(node=call.arg_list_node)
             message = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -188,3 +188,6 @@ precli.rules.python =
 
     # precli/rules/python/stdlib/os_loose_file_perm.py
     PY036 = precli.rules.python.stdlib.os_loose_file_perm:OsLooseFilePermissions
+
+    # precli/rules/python/stdlib/pathlib_loose_file_perm.py
+    PY037 = precli.rules.python.stdlib.pathlib_loose_file_perm:PathlibLooseFilePermissions

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_IXOTH.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 16
+# end_column: 21
+from pathlib import Path
+from stat import S_IXOTH as IXOTH
+
+
+file_path = Path("example.sh")
+file_path.chmod(IXOTH)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_S_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_S_IXOTH.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 16
+# end_column: 23
+import pathlib
+from stat import S_IXOTH
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(S_IXOTH)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_S_S_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_S_S_IXOTH.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 16
+# end_column: 25
+import pathlib
+import stat as S
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(S.S_IXOTH)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o111_binop_wildcard.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o111_binop_wildcard.py
@@ -1,0 +1,12 @@
+# level: WARNING
+# start_line: 12
+# end_line: 12
+# start_column: 16
+# end_column: 20
+from pathlib import Path
+from stat import *
+
+
+file_path = Path("/etc/passwd")
+mode = S_IXUSR | S_IXGRP | S_IXOTH
+file_path.chmod(mode)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o644.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o644.py
@@ -1,0 +1,6 @@
+# level: NONE
+import pathlib
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(0o644)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o7.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o7.py
@@ -1,0 +1,10 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 16
+# end_column: 19
+import pathlib
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(0o7)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o755_binop_stat.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o755_binop_stat.py
@@ -1,0 +1,15 @@
+# level: WARNING
+# start_line: 13
+# end_line: 14
+# start_column: 4
+# end_column: 31
+import pathlib
+import stat
+
+
+# 0o755 for rwxr-xr-x
+file_path = pathlib.Path("example.txt")
+file_path.chmod(
+    stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP |
+    stat.S_IROTH | stat.S_IXOTH
+)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o760.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o760.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 16
+# end_column: 21
+import pathlib
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(0o760)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o770.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o770.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 16
+# end_column: 21
+import pathlib
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(0o770)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o776.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o776.py
@@ -1,0 +1,10 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 16
+# end_column: 21
+import pathlib
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(0o776)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o777.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o777.py
@@ -1,0 +1,12 @@
+# level: ERROR
+# start_line: 12
+# end_line: 12
+# start_column: 21
+# end_column: 25
+import pathlib
+
+
+filename = "/etc/passwd"
+mode = 0o777
+file_path = pathlib.Path(filename)
+file_path.chmod(mode=mode)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_stat_S_IXOTH.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_stat_S_IXOTH.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 11
+# end_line: 11
+# start_column: 16
+# end_column: 28
+import pathlib
+import stat
+
+
+file_path = pathlib.Path("/etc/passwd")
+file_path.chmod(stat.S_IXOTH)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_x1ff.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_x1ff.py
@@ -1,0 +1,12 @@
+# level: ERROR
+# start_line: 12
+# end_line: 12
+# start_column: 16
+# end_column: 20
+from pathlib import Path
+
+
+filename = '/etc/passwd'
+mode = 0x1ff
+file_path = Path(filename)
+file_path.chmod(mode)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_lchmod_o227.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_lchmod_o227.py
@@ -1,0 +1,11 @@
+# level: ERROR
+# start_line: 11
+# end_line: 11
+# start_column: 22
+# end_column: 26
+from pathlib import Path
+
+
+mode = 0o227
+file_path = Path('/etc/passwd')
+file_path.lchmod(mode=mode)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_mkdir_default.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_mkdir_default.py
@@ -1,0 +1,10 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 15
+# end_column: 17
+from pathlib import Path
+
+
+file_path = Path("examples")
+file_path.mkdir()

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_mkdir_o750_binop.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_mkdir_o750_binop.py
@@ -1,0 +1,13 @@
+# level: WARNING
+# start_line: 13
+# end_line: 13
+# start_column: 21
+# end_column: 25
+from pathlib import Path
+import stat
+
+
+path = "examples"
+mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+file_path = Path(path)
+file_path.mkdir(mode=mode)

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_touch_default.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_touch_default.py
@@ -1,0 +1,10 @@
+# level: ERROR
+# start_line: 10
+# end_line: 10
+# start_column: 15
+# end_column: 17
+from pathlib import *
+
+
+file_path = Path("example.txt")
+file_path.touch()

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_touch_o750_binop.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_touch_o750_binop.py
@@ -1,0 +1,12 @@
+# level: WARNING
+# start_line: 12
+# end_line: 12
+# start_column: 21
+# end_column: 25
+from pathlib import *
+import stat
+
+
+file_path = Path("example.txt")
+mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+file_path.touch(mode=mode)

--- a/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
@@ -1,0 +1,64 @@
+# Copyright 2024 Secure Sauce LLC
+import os
+
+import pytest
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class TestPathlibLooseFilePermissions(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY037"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "pathlib",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        assert rule.id == self.rule_id
+        assert rule.name == "incorrect_permission"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
+        )
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.id == 732
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "pathlib_chmod_IXOTH.py",
+            "pathlib_chmod_o111_binop_wildcard.py",
+            "pathlib_chmod_o644.py",
+            "pathlib_chmod_o7.py",
+            "pathlib_chmod_o755_binop_stat.py",
+            "pathlib_chmod_o760.py",
+            "pathlib_chmod_o770.py",
+            "pathlib_chmod_o776.py",
+            "pathlib_chmod_o777.py",
+            "pathlib_chmod_S_IXOTH.py",
+            "pathlib_chmod_S_S_IXOTH.py",
+            "pathlib_chmod_stat_S_IXOTH.py",
+            "pathlib_chmod_x1ff.py",
+            "pathlib_lchmod_o227.py",
+            "pathlib_mkdir_default.py",
+            "pathlib_mkdir_o750_binop.py",
+            "pathlib_touch_default.py",
+            "pathlib_touch_o750_binop.py",
+        ],
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
This rule adds checks for usage of pathlib.Path functions where a file mode can be passed and the file mode is considered loose permissions. It checks functions chmod, lchmod, mkdir, and touch.

Unit tests and documentation also added.

Closes: #217