### PR TITLE
Fix for typo in pathlib rule example output

### DIFF
--- a/precli/rules/python/stdlib/pathlib_loose_file_perm.py
+++ b/precli/rules/python/stdlib/pathlib_loose_file_perm.py
@@ -38,7 +38,7 @@ file_path.chmod(
     ```
     > precli tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o755_binop_stat.py
     ⚠️  Warning on line 8 in tests/unit/rules/python/stdlib/pathlib/examples/pathlib_chmod_o755_binop_stat.py
-    PY036: Incorrect Permission Assignment for Critical Resource
+    PY037: Incorrect Permission Assignment for Critical Resource
     Mode '0o755' grants excessive permissions, potentially allowing unauthorized access or modification.
     ```
 


### PR DESCRIPTION
A copy-and-paste error where PY036 should be PY037 for the pathlib loose permissions rule.