### PR TITLE
Only load file if artifact content is none

### DIFF
--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -60,8 +60,9 @@ def parse_file(
         if parser:
             LOG.debug(f"Working on file: {artifact.file_name}")
             artifact.language = parser.lexer
-            with open(artifact.file_name, "rb") as f:
-                artifact.contents = f.read()
+            if artifact.contents is None:
+                with open(artifact.file_name, "rb") as f:
+                    artifact.contents = f.read()
             return parser.parse(artifact, enabled, disabled)
     except OSError as e:
         results.append(


### PR DESCRIPTION
The Run class should only load data from the artifact file if the contents is None. This in particular affects services such as Precaution. It also prevents an error when a file is loaded as stdin.