### PR TITLE
Get file encoding using artifact contents

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -120,10 +120,10 @@ class Parser(ABC):
 
         self.results = []
         self.context = {"artifact": artifact}
-        artifact.encoding = self.get_file_encoding(artifact.file_name)
         if artifact.contents is None:
             with open(artifact.file_name, "rb") as fdata:
                 artifact.contents = fdata.read()
+        artifact.encoding = self.get_file_encoding(artifact.contents)
         tree = self.tree_sitter_parser.parse(artifact.contents)
 
         @property

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -25,7 +25,7 @@ class Go(Parser):
     def rule_prefix(self) -> str:
         return "GO"
 
-    def get_file_encoding(self, file_path: str) -> str:
+    def get_file_encoding(self, file_contents: str) -> str:
         return "utf-8"
 
     def visit_source_file(self, nodes: list[Node]):

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -24,7 +24,7 @@ class Java(Parser):
     def rule_prefix(self) -> str:
         return "JAV"
 
-    def get_file_encoding(self, file_path: str) -> str:
+    def get_file_encoding(self, file_contents: str) -> str:
         return "utf-8"
 
     def visit_program(self, nodes: list[Node]):

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -32,19 +32,23 @@ class Python(Parser):
     def rule_prefix(self) -> str:
         return "PY"
 
-    def get_file_encoding(self, file_path: str) -> str:
-        with open(file_path, "rb") as f:
-            first_two_lines = f.readline() + f.readline()
+    def get_file_encoding(self, file_contents: str) -> str:
+        lines = file_contents.splitlines(keepends=True)
+        if len(lines) < 2:
+            return "utf-8"
+
+        first_two_lines = lines[0] + lines[1]
 
         encoding_match = re.search(rb"coding[:=]\s*([-\w.]+)", first_two_lines)
-        if encoding_match:
-            encoding = encoding_match.group(1).decode("ascii")
-            try:
-                codecs.lookup(encoding)
-            except LookupError:
-                encoding = "utf-8"
-        else:
+        if not encoding_match:
+            return "utf-8"
+
+        encoding = encoding_match.group(1).decode("ascii")
+        try:
+            codecs.lookup(encoding)
+        except LookupError:
             encoding = "utf-8"
+
         return encoding
 
     def visit_module(self, nodes: list[Node]):


### PR DESCRIPTION
This change prevents another opening and reading of a file when trying to determine the file encoding for a file. In some cases such as when run under Precaution, the file doesn't exist locally anyway, so it needs to use what is in the artifact contents.