### PR TITLE
Update to the latest tree-sitter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,6 @@ To install precli (requires Python 3.12):
 
     pip install precli
 
-Note: If using arm based macOS, you'll also need to install this package:
-
-.. code-block:: console
-
-    pip install git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0
-
 Run precli on a single test example:
 
 .. code-block:: console

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,12 +9,6 @@ To install precli:
 pip install precli
 ```
 
-Note: If using arm based macOS, you'll also need to install this package:
-
-```
-pip install git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0
-```
-
 ## Usage
 
 Run precli on a single test example:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 Pygments==2.18.0
 rich==13.8.0
-tree-sitter==0.22.3
+tree-sitter==0.23.0
 ignorelib==0.3.0
 requests==2.32.3
 sarif-om==1.0.4
 jschema-to-python==1.2.3
-tree-sitter-go==0.21.2
+tree-sitter-go==0.23.0
 tree-sitter-java==0.21.0
-tree-sitter-python==0.21.0; sys_platform != "darwin" and platform_machine != "arm64"
-git+https://github.com/tree-sitter/tree-sitter-python@v0.21.0; sys_platform == "darwin" and platform_machine == "arm64"
+tree-sitter-python==0.23.0


### PR DESCRIPTION
Updates to:
- tree-sitter 0.23.0
- tree-sitter-go 0.23.0
- tree-sitter-python 0.23.0

Note, tree-sitter-java has no new release.