### PR TITLE
Fix augmented assignment

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -124,7 +124,7 @@ class Python(Parser):
     def visit_augmented_assignment(self, nodes: list[Node]):
         left_hand = nodes[0].string
         symbol = self.current_symtab.get(left_hand)
-        if symbol is not None:
+        if symbol is not None and isinstance(symbol.value, int):
             if nodes[0].type == NodeTypes.IDENTIFIER and nodes[2].type in (
                 NodeTypes.PARENTHESIZED_EXPRESSION,
                 NodeTypes.ATTRIBUTE,


### PR DESCRIPTION
It's possible that part of the expression of an augmented assignment doesn't resolve to an int. In such a case, the current code tries to bitwise compute the values anyway. This of course results in a syntax error.

This fix in this change ensures both left and right side of the expression resolve to an int value. Other bitwise computable values in the future could also be added.