### PR TITLE
Remove unnecessary init of wildcards

### DIFF
--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -138,7 +138,6 @@ class WeakCipher(Rule):
             cwe_id=327,
             message="Weak ciphers like '{0}' should be avoided due to their "
             "known vulnerabilities and weaknesses.",
-            wildcards={},
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -89,7 +89,6 @@ class WeakHash(Rule):
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",
-            wildcards={},
             config=Config(level=Level.ERROR),
         )
 

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -144,7 +144,6 @@ class WeakKey(Rule):
             cwe_id=326,
             message="Using '{0}' key sizes less than '{1}' bits is considered "
             "vulnerable to attacks.",
-            wildcards={},
         )
 
     def analyze_call_expression(


### PR DESCRIPTION
No need to pass empty dict as the wildcards parameter of the initialization of a Rule.