### PR TITLE
SocketNoTimeout needs to check for 0 and negative timeouts

### DIFF
--- a/precli/rules/python/stdlib/socket_no_timeout.py
+++ b/precli/rules/python/stdlib/socket_no_timeout.py
@@ -97,6 +97,12 @@ class SocketNoTimeout(Rule):
             fix_node = argument.node
             result_node = argument.node
             content = "5"
+        elif (
+            isinstance(timeout, int) or isinstance(timeout, float)
+        ) and timeout <= 0:
+            fix_node = argument.node
+            result_node = argument.node
+            content = "5"
         else:
             return
 

--- a/tests/unit/rules/python/stdlib/socket/examples/socket_create_connection_timeout_0.py
+++ b/tests/unit/rules/python/stdlib/socket/examples/socket_create_connection_timeout_0.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 56
+# end_column: 57
+import socket
+
+
+s = socket.create_connection(("127.0.0.1", 80), timeout=0)
+s.recv(1024)
+s.close()

--- a/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
@@ -41,6 +41,7 @@ class TestSocketNoTimeout(test_case.TestCase):
         "filename",
         [
             "socket_create_connection.py",
+            "socket_create_connection_timeout_0.py",
             "socket_create_connection_timeout_5.py",
             "socket_create_connection_timeout_none.py",
         ],


### PR DESCRIPTION
The SocketNoTimeout rule also needs to check for timeout values of 0 or less than 0 which also equate to no timeout. The value can also be of type float.