### PR TITLE
New rule to check for no timeout use in smtplib

### DIFF
--- a/precli/rules/python/stdlib/smtplib_no_timeout.py
+++ b/precli/rules/python/stdlib/smtplib_no_timeout.py
@@ -1,0 +1,155 @@
+# Copyright 2024 Secure Sauce LLC
+r"""
+# Synchronous Access of `SMTP` without Timeout
+
+The `smtplib.SMTP`, `smtplib.SMTP_SSL`, and `smtplib.LMTP` classes are used
+to send emails via the Simple Mail Transfer Protocol (SMTP). These classes
+can establish network connections to mail servers and by default do not
+specify a timeout for network operations. If a timeout is not specified,
+the connection may block indefinitely, leading to potential resource
+exhaustion or application hang-ups, particularly in production environments
+or network failure scenarios.
+
+This rule enforces that a timeout parameter must be provided when
+instantiating `smtplib.SMTP`, `smtplib.SMTP_SSL`, or `smtplib.LMTP` to prevent
+the possibility of indefinite blocking.
+
+Failing to specify a timeout in these functions may cause the application to
+block indefinitely while waiting for a response from the mail server. This can
+lead to Denial of Service (DoS) vulnerabilities or cause the application to
+become unresponsive.
+
+# Example
+
+```python linenums="1" hl_lines="5" title="smtplib_smtp_no_timeout.py"
+import smtplib
+import ssl
+
+
+server = smtplib.SMTP("smtp.example.com", 587)
+server.starttls(ssl.create_default_context())
+```
+
+??? example "Example Output"
+    ```
+    > precli tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_no_timeout.py
+    ⚠️  Warning on line 10 in tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_no_timeout.py
+    PY040: Synchronous Access of Remote Resource without Timeout
+    The class 'smtplib.SMTP' is used without a timeout, which may cause the application to block indefinitely if the remote server does not respond.
+    ```
+
+# Remediation
+
+Always provide a timeout parameter when using `smtplib.SMTP`,
+`smtplib.SMTP_SSL`, or `smtplib.LMTP`. This ensures that if the mail server
+is unreachable or unresponsive, the connection attempt will fail after a set
+period, preventing indefinite blocking and resource exhaustion.
+
+```python linenums="1" hl_lines="5" title="smtplib_smtp_no_timeout.py"
+import smtplib
+import ssl
+
+
+server = smtplib.SMTP("smtp.example.com", 587, timeout=10)
+server.starttls(ssl.create_default_context())
+```
+
+# See also
+
+!!! info
+    - [smtplib.SMTP — smtplib — SMTP protocol client](https://docs.python.org/3/library/smtplib.html#smtplib.SMTP)
+    - [smtplib.SMTP_SSL — smtplib — SMTP protocol client](https://docs.python.org/3/library/smtplib.html#smtplib.SMTP_SSL)
+    - [smtplib.LMTP — smtplib — SMTP protocol client](https://docs.python.org/3/library/smtplib.html#smtplib.LMTP)
+    - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
+
+_New in version 0.6.7_
+
+"""  # noqa: E501
+from precli.core.call import Call
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class SmtplibNoTimeout(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="no_timeout",
+            description=__doc__,
+            cwe_id=1088,
+            message="The class '{0}' is used without a timeout, which may "
+            "cause the application to block indefinitely if the remote server "
+            "does not respond.",
+        )
+
+    def analyze_call(self, context: dict, call: Call) -> Result | None:
+        if call.name_qualified not in (
+            "smtplib.SMTP",
+            "smtplib.SMTP_SSL",
+            "smtplib.LMTP",
+        ):
+            return
+
+        if call.name_qualified == "smtplib.SMTP":
+            # SMTP(
+            #    host='',
+            #    port=0,
+            #    local_hostname=None,
+            #    timeout=GLOBAL_TIMEOUT,
+            #    source_address=None
+            # )
+            argument = call.get_argument(position=3, name="timeout")
+        elif call.name_qualified == "smtplib.SMTP_SSL":
+            # SMTP_SSL(
+            #    host=''
+            #    port=0,
+            #    local_hostname=None,
+            #    *,
+            #    timeout=GLOBAL_TIMEOUT,
+            #    source_address=None,
+            #    context=None
+            # )
+            argument = call.get_argument(name="timeout")
+        elif call.name_qualified == "smtplib.LMTP":
+            # LMTP(
+            #    host=''
+            #    port=2003,
+            #    local_hostname=None,
+            #    source_address=None,
+            #    timeout=GLOBAL_TIMEOUT
+            # )
+            argument = call.get_argument(position=4, name="timeout")
+
+        timeout = argument.value
+
+        if argument.node is None:
+            arg_list_node = call.arg_list_node
+            fix_node = arg_list_node
+            args = [child.string for child in arg_list_node.named_children]
+            args.append("timeout=5")
+            content = f"({', '.join(args)})"
+            result_node = call.arg_list_node
+        elif timeout is None:
+            fix_node = argument.node
+            result_node = argument.node
+            content = "5"
+        else:
+            # If the timeout parameter is set to be zero, the class will raise
+            # a ValueError to prevent the creation of a non-blocking socket. A
+            # negative value also raises ValueError. So there is no need to
+            # check for these values.
+            return
+
+        fixes = Rule.get_fixes(
+            context=context,
+            deleted_location=Location(fix_node),
+            description="Set timeout parameter to a small number of seconds.",
+            inserted_content=content,
+        )
+        return Result(
+            rule_id=self.id,
+            location=Location(node=result_node),
+            message=self.message.format(call.name_qualified),
+            fixes=fixes,
+        )

--- a/precli/rules/python/stdlib/socket_no_timeout.py
+++ b/precli/rules/python/stdlib/socket_no_timeout.py
@@ -2,11 +2,11 @@
 r"""
 # Synchronous Access of `socket` without Timeout
 
-The function socket.create_connection() in Python establishes a TCP connection
-to a remote host. By default, this function operates synchronously, meaning it
-will block indefinitely if no timeout is specified. This behavior can lead to
-resource exhaustion or unresponsive applications if the remote host is slow
-or unresponsive, creating the risk of a Denial of Service (DoS).
+The function `socket.create_connection()` in Python establishes a TCP
+connection to a remote host. By default, this function operates synchronously,
+meaning it will block indefinitely if no timeout is specified. This behavior
+can lead to resource exhaustion or unresponsive applications if the remote
+host is slow or unresponsive, creating the risk of a Denial of Service (DoS).
 
 This rule ensures that a timeout is always specified when using
 `socket.create_connection()` to prevent indefinite blocking and resource
@@ -82,6 +82,14 @@ class SocketNoTimeout(Rule):
     def analyze_call(self, context: dict, call: Call) -> Result | None:
         if call.name_qualified not in ("socket.create_connection",):
             return
+
+        # create_connection(
+        #    address,
+        #    timeout=GLOBAL_TIMEOUT,
+        #    source_address=None,
+        #    *,
+        #    all_errors=False
+        # )
 
         argument = call.get_argument(position=1, name="timeout")
         timeout = argument.value

--- a/setup.cfg
+++ b/setup.cfg
@@ -200,3 +200,6 @@ precli.rules.python =
 
     # precli/rules/python/stdlib/socket_no_timeout.py
     PY039 = precli.rules.python.stdlib.socket_no_timeout:SocketNoTimeout
+
+    # precli/rules/python/stdlib/smtplib_no_timeout.py
+    PY040 = precli.rules.python.stdlib.smtplib_no_timeout:SmtplibNoTimeout

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_lmtp_timeout_none.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_lmtp_timeout_none.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 55
+# end_column: 59
+import smtplib
+import ssl
+
+
+server = smtplib.LMTP("smtp.example.com", 587, timeout=None)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_auth.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_auth.py
@@ -27,7 +27,7 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP("localhost")
+server = smtplib.SMTP("localhost", timeout=5)
 authobject = object()
 server.auth("LOGIN", authobject)
 server.set_debuglevel(1)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_context_mgr.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_context_mgr.py
@@ -6,6 +6,6 @@
 import smtplib
 
 
-with smtplib.SMTP("domain.org") as smtp:
+with smtplib.SMTP("domain.org", timeout=5) as smtp:
     smtp.noop()
     smtp.login("user", "password")

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_login.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_login.py
@@ -27,7 +27,7 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP("localhost")
+server = smtplib.SMTP("localhost", timeout=5)
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_no_timeout.py
@@ -1,0 +1,11 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 21
+# end_column: 46
+import smtplib
+import ssl
+
+
+server = smtplib.SMTP("smtp.example.com", 587)
+server.starttls(context=ssl.create_default_context())

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl.py
@@ -24,7 +24,7 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP_SSL("localhost", context=ssl.create_default_context())
+server = smtplib.SMTP_SSL("localhost", context=ssl.create_default_context(), timeout=5)
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_context_as_var.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_context_as_var.py
@@ -28,7 +28,7 @@ while True:
 print("Message length is", len(msg))
 
 context = None
-server = smtplib.SMTP_SSL("localhost", context=context)
+server = smtplib.SMTP_SSL("localhost", context=context, timeout=5)
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_context_none.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_context_none.py
@@ -27,7 +27,7 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP_SSL("localhost", context=None)
+server = smtplib.SMTP_SSL("localhost", context=None, timeout=5)
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_context_unset.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_context_unset.py
@@ -27,7 +27,7 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP_SSL("localhost")
+server = smtplib.SMTP_SSL("localhost", timeout=5)
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_ssl_no_timeout.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 25
+# end_column: 88
+import smtplib
+import ssl
+
+
+server = smtplib.SMTP_SSL("smtp.example.com", 587, context=ssl.create_default_context())

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls.py
@@ -24,8 +24,8 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP("localhost")
-server.starttls(ssl.create_default_context())
+server = smtplib.SMTP("localhost", timeout=5)
+server.starttls(context=ssl.create_default_context())
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_as_var.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_as_var.py
@@ -1,8 +1,8 @@
 # level: WARNING
 # start_line: 32
 # end_line: 32
-# start_column: 16
-# end_column: 23
+# start_column: 24
+# end_column: 31
 import smtplib
 
 
@@ -27,9 +27,9 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP("localhost")
+server = smtplib.SMTP("localhost", timeout=5)
 context = None
-server.starttls(context)
+server.starttls(context=context)
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_none.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_none.py
@@ -27,7 +27,7 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP("localhost")
+server = smtplib.SMTP("localhost", timeout=5)
 server.starttls(None)
 server.login("user", "password")
 server.set_debuglevel(1)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_unset.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_unset.py
@@ -27,7 +27,7 @@ while True:
 
 print("Message length is", len(msg))
 
-server = smtplib.SMTP("localhost")
+server = smtplib.SMTP("localhost", timeout=5)
 server.starttls()
 server.login("user", "password")
 server.set_debuglevel(1)

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_timeout_5.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_timeout_5.py
@@ -1,0 +1,7 @@
+# level: NONE
+import smtplib
+import ssl
+
+
+server = smtplib.SMTP("smtp.example.com", 587, timeout=5)
+server.starttls(context=ssl.create_default_context())

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Secure Sauce LLC
+import os
+
+import pytest
+
+from precli.core.level import Level
+from precli.parsers import python
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class TestSmtplibNoTimeout(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "PY040"
+        cls.parser = python.Python()
+        cls.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "python",
+            "stdlib",
+            "smtplib",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        assert rule.id == self.rule_id
+        assert rule.name == "no_timeout"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
+        )
+        assert rule.default_config.enabled is True
+        assert rule.default_config.level == Level.WARNING
+        assert rule.default_config.rank == -1.0
+        assert rule.cwe.id == 1088
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "smtplib_lmtp_timeout_none.py",
+            "smtplib_smtp_no_timeout.py",
+            "smtplib_smtp_ssl_no_timeout.py",
+            "smtplib_smtp_timeout_5.py",
+        ],
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
This rule enforces that a timeout parameter must be provided when instantiating `smtplib.SMTP`, `smtplib.SMTP_SSL`, or `smtplib.LMTP` to prevent the possibility of indefinite blocking.