### PR TITLE
Add doc for new smtplib no timeout rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -63,3 +63,4 @@
 | PY037 | [pathlib — incorrect permission](rules/python/stdlib/pathlib-loose-file-perm.md) | Incorrect Permission Assignment for Critical Resource using `pathlib` Module |
 | PY038 | [os — unnecessary privileges](rules/python/stdlib/os-setuid-root.md) | Execution with Unnecessary Privileges using `os` Module |
 | PY039 | [socket — no timeout](rules/python/stdlib/socket-no-timeout.md) | Synchronous Access of `socket` without Timeout |
+| PY040 | [smtplib — no timeout](rules/python/stdlib/smtplib-no-timeout.md) | Synchronous Access of `SMTP` without Timeout |

--- a/docs/rules/python/stdlib/smtplib-no-timeout.md
+++ b/docs/rules/python/stdlib/smtplib-no-timeout.md
@@ -1,0 +1,10 @@
+---
+id: PY040
+title: smtplib — no timeout
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/PY040
+---
+
+::: precli.rules.python.stdlib.smtplib_no_timeout


### PR DESCRIPTION
The doc for smtplib_no_timeout rule was missing. Thus this commit creates the autodoc for it and adds to the list of rules.