### PR TITLE
The smtplib starttls context arg is always a kwarg

### DIFF
--- a/precli/rules/python/stdlib/smtplib_unverified_context.py
+++ b/precli/rules/python/stdlib/smtplib_unverified_context.py
@@ -135,10 +135,7 @@ class SmtplibUnverifiedContext(Rule):
         ]:
             return
 
-        if call.name_qualified == "smtplib.SMTP_SSL":
-            ssl_context = call.get_argument(name="context")
-        else:
-            ssl_context = call.get_argument(position=0, name="context")
+        ssl_context = call.get_argument(name="context")
         if ssl_context.value is not None:
             return
 

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_none.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_starttls_context_none.py
@@ -1,8 +1,8 @@
 # level: WARNING
 # start_line: 31
 # end_line: 31
-# start_column: 16
-# end_column: 20
+# start_column: 24
+# end_column: 28
 import smtplib
 
 
@@ -28,7 +28,7 @@ while True:
 print("Message length is", len(msg))
 
 server = smtplib.SMTP("localhost", timeout=5)
-server.starttls(None)
+server.starttls(context=None)
 server.login("user", "password")
 server.set_debuglevel(1)
 server.sendmail(fromaddr, toaddrs, msg)


### PR DESCRIPTION
The context passed to starttls function is always a kwarg and not a positional. As such, the rule needs to check for it in that way.