### PR TITLE
New Python rule checks ftplib use without a timeout

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -68,3 +68,4 @@
 | PY042 | [nntplib — no timeout](rules/python/stdlib/nntplib-no-timeout.md) | Synchronous Access of `NNTP` without Timeout |
 | PY043 | [poplib — no timeout](rules/python/stdlib/poplib-no-timeout.md) | Synchronous Access of `POP3` without Timeout |
 | PY044 | [telnetlib — no timeout](rules/python/stdlib/telnetlib-no-timeout.md) | Synchronous Access of `Telnet` without Timeout |
+| PY045 | [ftplib — no timeout](rules/python/stdlib/ftplib-no-timeout.md) | Synchronous Access of `FTP` without Timeout |

--- a/docs/rules/python/stdlib/ftplib-no-timeout.md
+++ b/docs/rules/python/stdlib/ftplib-no-timeout.md
@@ -1,0 +1,10 @@
+---
+id: PY045
+title: ftplib — no timeout
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/PY045
+---
+
+::: precli.rules.python.stdlib.ftplib_no_timeout

--- a/precli/rules/python/stdlib/ftplib_no_timeout.py
+++ b/precli/rules/python/stdlib/ftplib_no_timeout.py
@@ -1,0 +1,166 @@
+# Copyright 2024 Secure Sauce LLC
+r"""
+# Synchronous Access of `FTP` without Timeout
+
+The `ftplib.FTP` and `ftplib.FTP_TLS` classes are used to establish FTP
+connections for transferring files over the network. These classes, along
+with the `ftplib.FTP.connect` method, do not enforce a timeout by default, which
+can lead to indefinite blocking if the FTP server becomes unresponsive or
+experiences a network issue. This can cause resource exhaustion, Denial of
+Service (DoS), or reduced application responsiveness, especially in production
+environments.
+
+This rule ensures that a timeout parameter is provided when creating
+instances of `ftplib.FTP`, `ftplib.FTP_TLS`, and when calling
+`ftplib.FTP.connect` to prevent the risk of indefinite blocking during FTP
+operations.
+
+Failing to specify a timeout in these classes may cause the application to
+block indefinitely while waiting for a response from the mail server. This can
+lead to Denial of Service (DoS) vulnerabilities or cause the application to
+become unresponsive.
+
+# Example
+
+```python linenums="1" hl_lines="4" title="ftplib_ftp_no_timeout.py"
+import ftplib
+
+
+ftp_server = ftplib.FTP("ftp.example.com")
+```
+
+??? example "Example Output"
+    ```
+    > precli tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_no_timeout.py
+    ⚠️  Warning on line 9 in tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_no_timeout.py
+    PY045: Synchronous Access of Remote Resource without Timeout
+    The class 'ftplib.FTP' is used without a timeout, which may cause the application to block indefinitely if the remote server does not respond.
+    ```
+
+# Remediation
+
+Always provide a timeout parameter when using `ftplib.FTP`, `ftplib.FTP_TLS`,
+or `ftplib.FTP.connect`. This ensures that if the mail server is unreachable
+or unresponsive, the connection attempt will fail after a set period,
+preventing indefinite blocking and resource exhaustion.
+
+```python linenums="1" hl_lines="4" title="ftplib_ftp_no_timeout.py"
+import ftplib
+
+
+ftp_server = ftplib.FTP("ftp.example.com", timeout=5)
+```
+
+# See also
+
+!!! info
+    - [ftplib.FTP — ftplib — FTP protocol client](https://docs.python.org/3/library/ftplib.html#ftplib.FTP)
+    - [ftplib.FTP.connect — ftplib — FTP protocol client](https://docs.python.org/3/library/ftplib.html#ftplib.FTP.connect)
+    - [ftplib.FTP_TLS — ftplib — FTP protocol client](https://docs.python.org/3/library/ftplib.html#ftplib.FTP_TLS)
+    - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
+
+_New in version 0.6.7_
+
+"""  # noqa: E501
+from precli.core.call import Call
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class FtplibNoTimeout(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="no_timeout",
+            description=__doc__,
+            cwe_id=1088,
+            message="The class '{0}' is used without a timeout, which may "
+            "cause the application to block indefinitely if the remote server "
+            "does not respond.",
+        )
+
+    def analyze_call(self, context: dict, call: Call) -> Result | None:
+        if call.name_qualified not in (
+            "ftplib.FTP",
+            "ftplib.FTP.connect",
+            "ftplib.FTP_TLS",
+        ):
+            return
+
+        if (
+            call.name_qualified in ("ftplib.FTP", "ftplib.FTP_TLS")
+            and call.get_argument(position=0, name="host").node is None
+        ):
+            return
+
+        if call.name_qualified == "ftplib.FTP":
+            # FTP(
+            #    host='',
+            #    user='',
+            #    passwd='',
+            #    acct='',
+            #    timeout=GLOBAL_TIMEOUT,
+            #    source_address=None,
+            #    *,
+            #    encoding='utf-8'
+            # )
+            argument = call.get_argument(position=4, name="timeout")
+        elif call.name_qualified in (
+            "ftplib.FTP.connect",
+            "ftplib.FTP_TLS.connect",
+        ):
+            # FTP.connect(
+            #    self,
+            #    host='',
+            #    port=0,
+            #    timeout=-999,
+            #    source_address=None
+            # )
+            argument = call.get_argument(position=2, name="timeout")
+        elif call.name_qualified == "ftplib.FTP_TLS":
+            # FTP_TLS(
+            #    host='',
+            #    user='',
+            #    passwd='',
+            #    acct='',
+            #    *,
+            #    context=None,
+            #    timeout=GLOBAL_TIMEOUT,
+            #    source_address=None,
+            #    encoding='utf-8'
+            # )
+            argument = call.get_argument(name="timeout")
+
+        timeout = argument.value
+
+        if argument.node is None:
+            arg_list_node = call.arg_list_node
+            fix_node = arg_list_node
+            args = [child.string for child in arg_list_node.named_children]
+            args.append("timeout=5")
+            content = f"({', '.join(args)})"
+            result_node = call.arg_list_node
+        elif timeout is None:
+            fix_node = argument.node
+            result_node = argument.node
+            content = "5"
+        else:
+            # If the timeout parameter is set to be zero, the class will raise
+            # a ValueError to prevent the creation of a non-blocking socket. A
+            # negative value also raises ValueError. So there is no need to
+            # check for these values.
+            return
+
+        fixes = Rule.get_fixes(
+            context=context,
+            deleted_location=Location(fix_node),
+            description="Set timeout parameter to a small number of seconds.",
+            inserted_content=content,
+        )
+        return Result(
+            rule_id=self.id,
+            location=Location(node=result_node),
+            message=self.message.format(call.name_qualified),
+            fixes=fixes,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -215,3 +215,6 @@ precli.rules.python =
 
     # precli/rules/python/stdlib/telnetlib_no_timeout.py
     PY044 = precli.rules.python.stdlib.telnetlib_no_timeout:TelnetlibNoTimeout
+
+    # precli/rules/python/stdlib/ftplib_no_timeout.py
+    PY045 = precli.rules.python.stdlib.ftplib_no_timeout:FtplibNoTimeout

--- a/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_connect_timeout_none.py
+++ b/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_connect_timeout_none.py
@@ -1,0 +1,10 @@
+# level: WARNING
+# start_line: 10
+# end_line: 10
+# start_column: 46
+# end_column: 50
+import ftplib
+
+
+ftp_server = ftplib.FTP()
+ftp_server.connect("ftp.example.com", timeout=None)

--- a/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_no_timeout.py
@@ -1,0 +1,9 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 23
+# end_column: 42
+import ftplib
+
+
+ftp_server = ftplib.FTP("ftp.example.com")

--- a/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_tls_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_tls_no_timeout.py
@@ -1,0 +1,9 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 27
+# end_column: 46
+import ftplib
+
+
+ftp_server = ftplib.FTP_TLS("ftp.example.com")

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
@@ -52,7 +52,7 @@ class TestFtpCleartext(test_case.TestCase):
         ],
     )
     def test(self, filename):
-        self.check(filename)
+        self.check(filename, enabled=[self.rule_id])
 
     def test_ftp_login(self):
         artifact = Artifact(os.path.join(self.base_path, "ftp_login.py"))

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
@@ -9,10 +9,10 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class TestFtplibUnverifiedContext(test_case.TestCase):
+class TestFtplibNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
-        cls.rule_id = "PY022"
+        cls.rule_id = "PY045"
         cls.parser = python.Python()
         cls.base_path = os.path.join(
             "tests",
@@ -27,7 +27,7 @@ class TestFtplibUnverifiedContext(test_case.TestCase):
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
         assert rule.id == self.rule_id
-        assert rule.name == "improper_certificate_validation"
+        assert rule.name == "no_timeout"
         assert (
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
@@ -35,14 +35,14 @@ class TestFtplibUnverifiedContext(test_case.TestCase):
         assert rule.default_config.enabled is True
         assert rule.default_config.level == Level.WARNING
         assert rule.default_config.rank == -1.0
-        assert rule.cwe.id == 295
+        assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(
         "filename",
         [
-            "ftplib_ftp_tls_context_as_var.py",
-            "ftplib_ftp_tls_context_none.py",
-            "ftplib_ftp_tls_context_unset.py",
+            "ftplib_ftp_connect_timeout_none.py",
+            "ftplib_ftp_no_timeout.py",
+            "ftplib_ftp_tls_no_timeout.py",
         ],
     )
     def test(self, filename):


### PR DESCRIPTION
PY045

The ftplib classes FTP and FTP_TLS have timeout arguments that defaul to the global timeout which defaults to None or blocking forever. FTP.connect method similarly has a timeout argument. Its important to always have a reasonable timeout set so the connections don't block forever.