### PR TITLE
New Python rule checks for ssl use with no timeout

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -69,3 +69,4 @@
 | PY043 | [poplib — no timeout](rules/python/stdlib/poplib-no-timeout.md) | Synchronous Access of `POP3` without Timeout |
 | PY044 | [telnetlib — no timeout](rules/python/stdlib/telnetlib-no-timeout.md) | Synchronous Access of `Telnet` without Timeout |
 | PY045 | [ftplib — no timeout](rules/python/stdlib/ftplib-no-timeout.md) | Synchronous Access of `FTP` without Timeout |
+| PY046 | [ssl — no timeout](rules/python/stdlib/ssl-no-timeout.md) | Synchronous Access of `ssl` without Timeout |

--- a/docs/rules/python/stdlib/ssl-no-timeout.md
+++ b/docs/rules/python/stdlib/ssl-no-timeout.md
@@ -1,0 +1,10 @@
+---
+id: PY046
+title: ssl — no timeout
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/PY046
+---
+
+::: precli.rules.python.stdlib.ssl_no_timeout

--- a/precli/rules/python/stdlib/ssl_no_timeout.py
+++ b/precli/rules/python/stdlib/ssl_no_timeout.py
@@ -1,0 +1,123 @@
+# Copyright 2024 Secure Sauce LLC
+r"""
+# Synchronous Access of `ssl` without Timeout
+
+The `ssl.get_server_certificate()` function is used to retrieve the
+certificate from an SSL-enabled server. By default, this function does not
+enforce a timeout on the network connection, which means that an application
+could block indefinitely if the server is unresponsive or experiences a
+network issue. This can result in resource exhaustion, Denial of Service
+(DoS), or unresponsive behavior in the application, especially in production
+environments.
+
+This rule ensures that a timeout parameter is provided when calling
+`ssl.get_server_certificate()` to prevent the risk of indefinite blocking
+during the SSL certificate retrieval process.
+
+If no timeout is specified in `ssl.get_server_certificate()`, the application
+may block indefinitely while waiting for a response from the server. This can
+lead to resource exhaustion, slow performance, or unresponsive behavior in the
+application.
+
+# Example
+
+```python linenums="1" hl_lines="4" title="get_server_certificate_no_timeout.py"
+import ssl
+
+
+cert = ssl.get_server_certificate(("example.com", 443))
+```
+
+??? example "Example Output"
+    ```
+    > precli tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_no_timeout.py
+    ⚠️  Warning on line 9 in tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_no_timeout.py
+    PY046: Synchronous Access of Remote Resource without Timeout
+    The function 'ssl.get_server_certificate' is used without a timeout, which may cause the application to block indefinitely if the remote server does not respond.
+    ```
+
+# Remediation
+
+ - Python 3.10 and Later: Always provide a timeout parameter when using
+   `ssl.get_server_certificate()`.
+ - Python Versions Before 3.10: Use `socket.setdefaulttimeout()` to globally
+   enforce a timeout for all socket connections, including those made by
+   `ssl.get_server_certificate()`.
+
+```python linenums="1" hl_lines="4" title="get_server_certificate_no_timeout.py"
+import ssl
+
+
+cert = ssl.get_server_certificate(("example.com", 443), timeout=5)
+```
+
+# See also
+
+!!! info
+    - [ssl.get_server_certificate — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/ssl.html#ssl.get_server_certificate)
+    - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
+
+_New in version 0.6.7_
+
+"""  # noqa: E501
+from precli.core.call import Call
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.rules import Rule
+
+
+class SslNoTimeout(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="no_timeout",
+            description=__doc__,
+            cwe_id=1088,
+            message="The function '{0}' is used without a timeout, which may "
+            "cause the application to block indefinitely if the remote server "
+            "does not respond.",
+        )
+
+    def analyze_call(self, context: dict, call: Call) -> Result | None:
+        if call.name_qualified not in ("ssl.get_server_certificate",):
+            return
+
+        # get_server_certificate(
+        #    addr,
+        #    ssl_version=PROTOCOL_TLS_CLIENT,
+        #    ca_certs=None,
+        #    timeout=GLOBAL_TIMEOUT,
+        # )
+        argument = call.get_argument(position=3, name="timeout")
+        timeout = argument.value
+
+        if argument.node is None:
+            arg_list_node = call.arg_list_node
+            fix_node = arg_list_node
+            args = [child.string for child in arg_list_node.named_children]
+            args.append("timeout=5")
+            content = f"({', '.join(args)})"
+            result_node = call.arg_list_node
+        elif timeout is None:
+            fix_node = argument.node
+            result_node = argument.node
+            content = "5"
+        else:
+            # If the timeout parameter is set to be zero, the class will raise
+            # a ValueError to prevent the creation of a non-blocking socket. A
+            # negative value also raises ValueError. So there is no need to
+            # check for these values.
+            return
+
+        fixes = Rule.get_fixes(
+            context=context,
+            deleted_location=Location(fix_node),
+            description="Set timeout parameter to a small number of seconds.",
+            inserted_content=content,
+        )
+        return Result(
+            rule_id=self.id,
+            location=Location(node=result_node),
+            message=self.message.format(call.name_qualified),
+            fixes=fixes,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -218,3 +218,6 @@ precli.rules.python =
 
     # precli/rules/python/stdlib/ftplib_no_timeout.py
     PY045 = precli.rules.python.stdlib.ftplib_no_timeout:FtplibNoTimeout
+
+    # precli/rules/python/stdlib/ssl_no_timeout.py
+    PY046 = precli.rules.python.stdlib.ssl_no_timeout:SslNoTimeout

--- a/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_no_timeout.py
@@ -1,0 +1,9 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 33
+# end_column: 55
+import ssl
+
+
+cert = ssl.get_server_certificate(("example.com", 443))

--- a/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_timeout_5.py
+++ b/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_timeout_5.py
@@ -1,0 +1,5 @@
+# level: NONE
+import ssl
+
+
+cert = ssl.get_server_certificate(("example.com", 443), timeout=5.0)

--- a/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_timeout_none.py
+++ b/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_timeout_none.py
@@ -1,0 +1,9 @@
+# level: WARNING
+# start_line: 9
+# end_line: 9
+# start_column: 64
+# end_column: 68
+import ssl
+
+
+cert = ssl.get_server_certificate(("example.com", 443), timeout=None)

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
@@ -9,10 +9,10 @@ from precli.rules import Rule
 from tests.unit.rules import test_case
 
 
-class TestGetServerCertificate(test_case.TestCase):
+class TestSslNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
-        cls.rule_id = "PY018"
+        cls.rule_id = "PY046"
         cls.parser = python.Python()
         cls.base_path = os.path.join(
             "tests",
@@ -27,25 +27,22 @@ class TestGetServerCertificate(test_case.TestCase):
     def test_rule_meta(self):
         rule = Rule.get_by_id(self.rule_id)
         assert rule.id == self.rule_id
-        assert rule.name == "inadequate_encryption_strength"
+        assert rule.name == "no_timeout"
         assert (
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
         assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
+        assert rule.default_config.level == Level.WARNING
         assert rule.default_config.rank == -1.0
-        assert rule.cwe.id == 326
+        assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(
         "filename",
         [
-            "get_server_certificate_sslv2.py",
-            "get_server_certificate_sslv23.py",
-            "get_server_certificate_sslv3.py",
-            "get_server_certificate_tlsv1.py",
-            "get_server_certificate_tlsv11.py",
-            "get_server_certificate_tlsv12.py",
+            "get_server_certificate_no_timeout.py",
+            "get_server_certificate_timeout_5.py",
+            "get_server_certificate_timeout_none.py",
         ],
     )
     def test(self, filename):


### PR DESCRIPTION
The ssl.get_server_certificate function has a timeout parameter that defaults to the global timeout which itself defaults to None. When the value is None, the socket blocks forever.

Note: the timeout parameter wasn't added till Python 3.10. To fix this on earlier Python versions, someone would need to adjust the global timeout value.

PY046