### PR TITLE
Enhance timeout rules ot honor the global timeout

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -235,6 +235,8 @@ class Parser(ABC):
             if hasattr(rule, fn) and rule.enabled:
                 context = self.context
                 context["symtab"] = self.current_symtab
+                if "global_symtab" in vars(self):
+                    context["global_symtab"] = self.global_symtab
 
                 analyze_fn = getattr(rule, fn)
                 result = analyze_fn(self.context, **kwargs)

--- a/precli/rules/python/stdlib/ftplib_no_timeout.py
+++ b/precli/rules/python/stdlib/ftplib_no_timeout.py
@@ -44,6 +44,10 @@ or `ftplib.FTP.connect`. This ensures that if the mail server is unreachable
 or unresponsive, the connection attempt will fail after a set period,
 preventing indefinite blocking and resource exhaustion.
 
+Alternatively, the global default timeout can be set via
+`socket.setdefaulttimeout()`. This is a good option to enforce a consistent
+timeout for any network library that uses sockets, including `ftplib`.
+
 ```python linenums="1" hl_lines="4" title="ftplib_ftp_no_timeout.py"
 import ftplib
 
@@ -57,6 +61,7 @@ ftp_server = ftplib.FTP("ftp.example.com", timeout=5)
     - [ftplib.FTP — ftplib — FTP protocol client](https://docs.python.org/3/library/ftplib.html#ftplib.FTP)
     - [ftplib.FTP.connect — ftplib — FTP protocol client](https://docs.python.org/3/library/ftplib.html#ftplib.FTP.connect)
     - [ftplib.FTP_TLS — ftplib — FTP protocol client](https://docs.python.org/3/library/ftplib.html#ftplib.FTP_TLS)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -86,6 +91,10 @@ class FtplibNoTimeout(Rule):
             "ftplib.FTP.connect",
             "ftplib.FTP_TLS",
         ):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         if (

--- a/precli/rules/python/stdlib/imaplib_no_timeout.py
+++ b/precli/rules/python/stdlib/imaplib_no_timeout.py
@@ -45,6 +45,10 @@ Always provide a timeout parameter when using `imaplib.IMAP4` or
 unresponsive, the connection attempt will fail after a set period, preventing
 indefinite blocking and resource exhaustion.
 
+Alternatively, the global default timeout can be set via
+`socket.setdefaulttimeout()`. This is a good option to enforce a consistent
+timeout for any network library that uses sockets, including `imaplib`.
+
 ```python linenums="1" hl_lines="5" title="imaplib_imap_no_timeout.py"
 import imaplib
 import ssl
@@ -59,6 +63,7 @@ imap.starttls(ssl.create_default_context())
 !!! info
     - [imaplib.IMAP4 — imaplib — IMAP4 protocol client](https://docs.python.org/3/library/imaplib.html#imaplib.IMAP4)
     - [imaplib.IMAP4_SSL — imaplib — IMAP4 protocol client](https://docs.python.org/3/library/imaplib.html#imaplib.IMAP4_SSL)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -87,6 +92,10 @@ class ImaplibNoTimeout(Rule):
             "imaplib.IMAP4",
             "imaplib.IMAP4_SSL",
         ):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         if call.name_qualified == "imaplib.IMAP4":

--- a/precli/rules/python/stdlib/nntplib_no_timeout.py
+++ b/precli/rules/python/stdlib/nntplib_no_timeout.py
@@ -45,6 +45,10 @@ Always provide a timeout parameter when using `nntplib.NNTP` or
 unresponsive, the connection attempt will fail after a set period, preventing
 indefinite blocking and resource exhaustion.
 
+Alternatively, the global default timeout can be set via
+`socket.setdefaulttimeout()`. This is a good option to enforce a consistent
+timeout for any network library that uses sockets, including `nntplib`.
+
 ```python linenums="1" hl_lines="5" title="nntplib_nntp_no_timeout.py"
 import nntplib
 import ssl
@@ -59,6 +63,7 @@ nntp.starttls(ssl.create_default_context())
 !!! info
     - [nntplib.NNTP — nntplib — IMAP4 protocol client](https://docs.python.org/3/library/nntplib.html#nntplib.NNTP)
     - [nntplib.NNTP_SSL — nntplib — IMAP4 protocol client](https://docs.python.org/3/library/nntplib.html#nntplib.NNTP_SSL)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -87,6 +92,10 @@ class NntplibNoTimeout(Rule):
             "nntplib.NNTP",
             "nntplib.NNTP_SSL",
         ):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         if call.name_qualified == "nntplib.NNTP":

--- a/precli/rules/python/stdlib/poplib_no_timeout.py
+++ b/precli/rules/python/stdlib/poplib_no_timeout.py
@@ -45,6 +45,10 @@ Always provide a timeout parameter when using `poplib.POP3` or
 unresponsive, the connection attempt will fail after a set period, preventing
 indefinite blocking and resource exhaustion.
 
+Alternatively, the global default timeout can be set via
+`socket.setdefaulttimeout()`. This is a good option to enforce a consistent
+timeout for any network library that uses sockets, including `poplib`.
+
 ```python linenums="1" hl_lines="5" title="poplib_pop3_no_timeout.py"
 import poplib
 import ssl
@@ -59,6 +63,7 @@ pop.stls(ssl.create_default_context())
 !!! info
     - [poplib.POP3 — poplib — POP3 protocol client](https://docs.python.org/3/library/poplib.html#poplib.POP3)
     - [poplib.POP3_SSL — poplib — POP3 protocol client](https://docs.python.org/3/library/poplib.html#poplib.POP3_SSL)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -87,6 +92,10 @@ class PoplibNoTimeout(Rule):
             "poplib.POP3",
             "poplib.POP3_SSL",
         ):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         if call.name_qualified == "poplib.POP3":

--- a/precli/rules/python/stdlib/smtplib_no_timeout.py
+++ b/precli/rules/python/stdlib/smtplib_no_timeout.py
@@ -45,6 +45,11 @@ Always provide a timeout parameter when using `smtplib.SMTP`,
 is unreachable or unresponsive, the connection attempt will fail after a set
 period, preventing indefinite blocking and resource exhaustion.
 
+Alternatively, the global default timeout can be set via
+`socket.setdefaulttimeout()`. This is a good option to enforce a consistent
+timeout for any network library that uses sockets, including `smtplib`.
+
+
 ```python linenums="1" hl_lines="5" title="smtplib_smtp_no_timeout.py"
 import smtplib
 import ssl
@@ -60,6 +65,7 @@ server.starttls(context=ssl.create_default_context())
     - [smtplib.SMTP — smtplib — SMTP protocol client](https://docs.python.org/3/library/smtplib.html#smtplib.SMTP)
     - [smtplib.SMTP_SSL — smtplib — SMTP protocol client](https://docs.python.org/3/library/smtplib.html#smtplib.SMTP_SSL)
     - [smtplib.LMTP — smtplib — SMTP protocol client](https://docs.python.org/3/library/smtplib.html#smtplib.LMTP)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -89,6 +95,10 @@ class SmtplibNoTimeout(Rule):
             "smtplib.SMTP_SSL",
             "smtplib.LMTP",
         ):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         if call.name_qualified == "smtplib.SMTP":

--- a/precli/rules/python/stdlib/socket_no_timeout.py
+++ b/precli/rules/python/stdlib/socket_no_timeout.py
@@ -43,6 +43,10 @@ This ensures that if the remote host is unreachable or unresponsive, the
 connection attempt will fail after a certain period, releasing resources
 and preventing indefinite blocking.
 
+Alternatively, the global default timeout can be set via
+`socket.setdefaulttimeout()`. This is a good option to enforce a consistent
+timeout for any network library that uses sockets.
+
 ```python linenums="1" hl_lines="4" title="socket_create_connection.py"
 import socket
 
@@ -56,6 +60,7 @@ s.close()
 
 !!! info
     - [socket.create_connection — Low-level networking interface](https://docs.python.org/3/library/socket.html#socket.create_connection)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -81,6 +86,10 @@ class SocketNoTimeout(Rule):
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:
         if call.name_qualified not in ("socket.create_connection",):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         # create_connection(

--- a/precli/rules/python/stdlib/ssl_no_timeout.py
+++ b/precli/rules/python/stdlib/ssl_no_timeout.py
@@ -55,6 +55,7 @@ cert = ssl.get_server_certificate(("example.com", 443), timeout=5)
 
 !!! info
     - [ssl.get_server_certificate — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/ssl.html#ssl.get_server_certificate)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -80,6 +81,10 @@ class SslNoTimeout(Rule):
 
     def analyze_call(self, context: dict, call: Call) -> Result | None:
         if call.name_qualified not in ("ssl.get_server_certificate",):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         # get_server_certificate(

--- a/precli/rules/python/stdlib/telnetlib_no_timeout.py
+++ b/precli/rules/python/stdlib/telnetlib_no_timeout.py
@@ -42,6 +42,10 @@ Always provide a timeout parameter when using `telnetlib.Telnet` or
 or unresponsive, the connection attempt will fail after a set period,
 preventing indefinite blocking and resource exhaustion.
 
+Alternatively, the global default timeout can be set via
+`socket.setdefaulttimeout()`. This is a good option to enforce a consistent
+timeout for any network library that uses sockets, including `telnetlib`.
+
 ```python linenums="1" hl_lines="4" title="telnetlib_telnet_no_timeout.py"
 import telnetlib
 
@@ -54,6 +58,7 @@ telnet = telnetlib.Telnet("example.com", 23, timeout=5)
 !!! info
     - [telnetlib.Telnet — telnetlib — Telnet client](https://docs.python.org/3/library/telnetlib.html#telnetlib.Telnet)
     - [telnetlib.Telnet.open — telnetlib — Telnet client](https://docs.python.org/3/library/telnetlib.html#telnetlib.Telnet.open)
+    - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 
 _New in version 0.6.7_
@@ -82,6 +87,10 @@ class TelnetlibNoTimeout(Rule):
             "telnetlib.Telnet",
             "telnetlib.Telnet.open",
         ):
+            return
+
+        symbol = context["global_symtab"].get("GLOBAL_DEFAULT_TIMEOUT")
+        if symbol is not None and symbol.value > 0:
             return
 
         if (

--- a/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/ftplib/examples/ftplib_ftp_timeout_global.py
@@ -1,0 +1,7 @@
+# level: NONE
+import ftplib
+import socket
+
+
+socket.setdefaulttimeout(5.0)
+ftp_server = ftplib.FTP("ftp.example.com")

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
@@ -42,6 +42,7 @@ class TestFtplibNoTimeout(test_case.TestCase):
         [
             "ftplib_ftp_connect_timeout_none.py",
             "ftplib_ftp_no_timeout.py",
+            "ftplib_ftp_timeout_global.py",
             "ftplib_ftp_tls_no_timeout.py",
         ],
     )

--- a/tests/unit/rules/python/stdlib/imaplib/examples/imaplib_imap4_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/imaplib/examples/imaplib_imap4_timeout_global.py
@@ -1,0 +1,9 @@
+# level: NONE
+import imaplib
+import socket
+import ssl
+
+
+socket.setdefaulttimeout(5.0)
+imap = imaplib.IMAP4("imap.example.com", timeout=5)
+imap.starttls(ssl.create_default_context())

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
@@ -43,6 +43,7 @@ class TestImaplibNoTimeout(test_case.TestCase):
             "imaplib_imap4_no_timeout.py",
             "imaplib_imap4_ssl_timeout_none.py",
             "imaplib_imap4_timeout_5.py",
+            "imaplib_imap4_timeout_global.py",
         ],
     )
     def test(self, filename):

--- a/tests/unit/rules/python/stdlib/nntplib/examples/nntplib_nntp_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/nntplib/examples/nntplib_nntp_timeout_global.py
@@ -1,0 +1,13 @@
+# level: NONE
+import nntplib
+import socket
+import ssl
+
+
+socket.setdefaulttimeout(5.0)
+s = nntplib.NNTP("news.gmane.io", timeout=None)
+s.starttls(context=ssl.create_default_context())
+s.login("user", "password")
+f = open("article.txt", "rb")
+s.post(f)
+s.quit()

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
@@ -42,6 +42,7 @@ class TestNntplibNoTimeout(test_case.TestCase):
         [
             "nntplib_nntp_ssl_no_timeout.py",
             "nntplib_nntp_ssl_timeout_5.py",
+            "nntplib_nntp_timeout_global.py",
             "nntplib_nntp_timeout_none.py",
         ],
     )

--- a/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/poplib/examples/poplib_pop3_timeout_global.py
@@ -1,0 +1,15 @@
+# level: NONE
+import getpass
+import poplib
+import socket
+import ssl
+
+
+socket.setdefaulttimeout(5.0)
+M = poplib.POP3_SSL("localhost", context=ssl.create_default_context())
+M.user(getpass.getuser())
+M.pass_(getpass.getpass())
+numMessages = len(M.list()[1])
+for i in range(numMessages):
+    for j in M.retr(i + 1)[1]:
+        print(j)

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
@@ -41,6 +41,7 @@ class TestPoplibNoTimeout(test_case.TestCase):
         "filename",
         [
             "poplib_pop3_no_timeout.py",
+            "poplib_pop3_timeout_global.py",
             "poplib_pop3_timeout_none.py",
         ],
     )

--- a/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/smtplib/examples/smtplib_smtp_timeout_global.py
@@ -1,0 +1,9 @@
+# level: NONE
+import socket
+import smtplib
+import ssl
+
+
+socket.setdefaulttimeout(5.0)
+server = smtplib.SMTP("smtp.example.com", 587)
+server.starttls(context=ssl.create_default_context())

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
@@ -44,6 +44,7 @@ class TestSmtplibNoTimeout(test_case.TestCase):
             "smtplib_smtp_no_timeout.py",
             "smtplib_smtp_ssl_no_timeout.py",
             "smtplib_smtp_timeout_5.py",
+            "smtplib_smtp_timeout_global.py",
         ],
     )
     def test(self, filename):

--- a/tests/unit/rules/python/stdlib/socket/examples/socket_create_connection_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/socket/examples/socket_create_connection_timeout_global.py
@@ -1,0 +1,8 @@
+# level: NONE
+import socket
+
+
+socket.setdefaulttimeout(5.0)
+s = socket.create_connection(("127.0.0.1", 80))
+s.recv(1024)
+s.close()

--- a/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
@@ -42,6 +42,7 @@ class TestSocketNoTimeout(test_case.TestCase):
         [
             "socket_create_connection.py",
             "socket_create_connection_timeout_5.py",
+            "socket_create_connection_timeout_global.py",
             "socket_create_connection_timeout_none.py",
         ],
     )

--- a/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/ssl/examples/get_server_certificate_timeout_global.py
@@ -1,0 +1,7 @@
+# level: NONE
+import socket
+import ssl
+
+
+socket.setdefaulttimeout(5.0)
+cert = ssl.get_server_certificate(("example.com", 443))

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
@@ -42,6 +42,7 @@ class TestSslNoTimeout(test_case.TestCase):
         [
             "get_server_certificate_no_timeout.py",
             "get_server_certificate_timeout_5.py",
+            "get_server_certificate_timeout_global.py",
             "get_server_certificate_timeout_none.py",
         ],
     )

--- a/tests/unit/rules/python/stdlib/telnetlib/examples/telnetlib_telnet_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/examples/telnetlib_telnet_timeout_global.py
@@ -1,0 +1,7 @@
+# level: NONE
+import socket
+import telnetlib
+
+
+socket.setdefaulttimeout(5.0)
+telnet = telnetlib.Telnet("example.com", 23)

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
@@ -43,6 +43,7 @@ class TestTelnetlibNoTimeout(test_case.TestCase):
             "telnetlib_telnet_no_timeout.py",
             "telnetlib_telnet_open_timeout_none.py",
             "telnetlib_telnet_timeout_5.py",
+            "telnetlib_telnet_timeout_global.py",
         ],
     )
     def test(self, filename):


### PR DESCRIPTION
Python code can use a function socket.setdefaulttimeout() to set a global timeout value for all network classes functions that use it. Therefore, the Precli rules that check for an undefined timeout should honor this global value.

Note, currently this code will only recognize a global value of the timeout on a per-file basis. Later an inter-file global state of variables should be maintained, but this requires better analyzing of the code in the expected order of execution.