### PR TITLE
Add support of mkdocs macros

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,14 +64,12 @@ precli -h
 ## Version control integration
 
 Use [pre-commit](https://pre-commit.com/). Once you have it installed, add
-this to the `.pre-commit-config.yaml` in your repository
-(be sure to update `rev` to point to a real git tag/revision!):
-
+this to the `.pre-commit-config.yaml` in your repository:
 
 ```
 repos:
 - repo: https://github.com/securesauce/precli
-  rev: '' # Update me!
+  rev: '{{ git.short_tag }}'
   hooks:
   - id: precli
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs
 mkdocstrings[python]
 mkdocs-material
+mkdocs-macros-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ theme:
 plugins:
   - mkdocstrings
   - search
+  - macros
 
 nav:
   - Home: index.md


### PR DESCRIPTION
The mkdocs macros plugin also us to add variables in the markdown, including some predefined variables such as those from git metadata.

In this case, the git short tag is used to automatically have the revision tag up-to-date with the latest version in the pre-commit config.

https://github.com/fralau/mkdocs-macros-plugin
https://mkdocs-macros-plugin.readthedocs.io/en/latest/git_info/
https://jimandreas.github.io/mkdocs-material/reference/variables/#using-predefined-variables