### PR TITLE
Remove inconsistent divider in argparse rule

### DIFF
--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -2,8 +2,6 @@
 r"""
 # Invocation of Process Using Visible Sensitive Information in `argparse`
 
----
-
 Do not read secrets directly from command line arguments. When a command
 accepts a secret like via a `--password` argument or `--api-key`, the argument
 value will leak the secret into ps output and shell history. This also


### PR DESCRIPTION
The argparse rule was the only rule with a divider after the title. This change simply removes it for consistent look and feel to the docs.