### PR TITLE
Honor umask in calculating effective mode

### DIFF
--- a/tests/unit/rules/python/stdlib/os/examples/os_mkdir_default.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mkdir_default.py
@@ -1,4 +1,4 @@
-# level: ERROR
+# level: WARNING
 # start_line: 10
 # end_line: 10
 # start_column: 8

--- a/tests/unit/rules/python/stdlib/os/examples/os_mkfifo_default.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mkfifo_default.py
@@ -1,8 +1,4 @@
-# level: ERROR
-# start_line: 11
-# end_line: 11
-# start_column: 9
-# end_column: 20
+# level: NONE
 import os
 import sys
 

--- a/tests/unit/rules/python/stdlib/os/examples/os_mknod_o666_binop.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_mknod_o666_binop.py
@@ -1,8 +1,4 @@
-# level: ERROR
-# start_line: 12
-# end_line: 12
-# start_column: 25
-# end_column: 29
+# level: NONE
 import os
 import stat
 

--- a/tests/unit/rules/python/stdlib/os/examples/os_open_default.py
+++ b/tests/unit/rules/python/stdlib/os/examples/os_open_default.py
@@ -1,4 +1,4 @@
-# level: ERROR
+# level: WARNING
 # start_line: 10
 # end_line: 10
 # start_column: 12

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_mkdir_default.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_mkdir_default.py
@@ -1,4 +1,4 @@
-# level: ERROR
+# level: WARNING
 # start_line: 10
 # end_line: 10
 # start_column: 15

--- a/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_touch_default.py
+++ b/tests/unit/rules/python/stdlib/pathlib/examples/pathlib_touch_default.py
@@ -1,8 +1,4 @@
-# level: ERROR
-# start_line: 10
-# end_line: 10
-# start_column: 15
-# end_column: 17
+# level: NONE
 from pathlib import *
 
 


### PR DESCRIPTION
Two Python loose permission rules will return results when a function is used with a default permission mode that is considered risky.

However, these rules were not accounting for the umask that is typically set in the operating system and Python honors when calculating the effective mode.

This change applies an assumed umask of 0o022, even though it can vary to calculate effective modes for cases when the default mode of a function is used.

If a mode value is passed to the function, it still uses that mode argument as the mode to evaluate.