### PR TITLE
Add Python 3.13 to unit test matrix

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -71,7 +71,8 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          ["3.12", "312"]
+          ["3.12", "312"],
+          ["3.13", "313"],
         ]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rich==13.9.2
-tree-sitter==0.23.0
+tree-sitter==0.23.1
 ignorelib==0.3.0
 requests==2.32.3
 sarif-om==1.0.4


### PR DESCRIPTION
This change adds Python 3.13 to the test matrix. Even though it fails for now, better to start testing early and flush out bugs where possible.