### PR TITLE
Show support of Python 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Security
 url = https://github.com/securesauce/precli
 download_url = https://pypi.org/project/precli/#files

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 minversion = 3.2.0
-envlist = py312
+envlist = py312,py313
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Official tag the precli classifier to show support of Python 3.13 now that testing works successfully.