### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -71,6 +71,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
+          ["3.11", "311"],
           ["3.12", "312"],
           ["3.13", "313"],
         ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
     Operating System :: Microsoft :: Windows
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Topic :: Security

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,5 @@ import setuptools
 
 
 setuptools.setup(
-    python_requires=">=3.12", setup_requires=["pbr>=2.0.0"], pbr=True
+    python_requires=">=3.11", setup_requires=["pbr>=2.0.0"], pbr=True
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 minversion = 3.2.0
-envlist = py312,py313
+envlist = py313
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Precli already supports 3.12 and 3.13. It should easily also be able to support 3.11.

This should help adoption by supporting more versions of Python.