### PR TITLE
Update README requests Python 3.10+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ If your needs go beyond the analysis of just the standard library, consider upgr
 Quick Start
 -----------
 
-To install precli (requires Python 3.12):
+To install precli (requires Python 3.10+):
 
 .. code-block:: console
 


### PR DESCRIPTION
Update the instructions in the README about the installation of precli. It should state it requires 3.10+.