### PR TITLE
Fix some bugs using Python 3.10

### DIFF
--- a/precli/core/redos.py
+++ b/precli/core/redos.py
@@ -4,13 +4,11 @@ import collections
 import itertools
 import sys
 
-try:
+if sys.version_info >= (3, 11):
     from re import _constants as constants
-except ImportError:
-    import sre_constants as constants
-try:
     from re import _parser as parser
-except ImportError:
+else:
+    import sre_constants as constants
     import sre_parse as parser
 
 

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -162,7 +162,10 @@ class Run:
 
     def invoke(self):
         """Invokes a run"""
-        self._start_time = datetime.datetime.now(datetime.UTC)
+        if sys.version_info >= (3, 11):
+            self._start_time = datetime.datetime.now(datetime.UTC)
+        else:
+            self._start_time = datetime.datetime.utcnow()
         LOG.debug(f"Run started at {self._start_time}")
         results = []
         lines = 0
@@ -215,7 +218,11 @@ class Run:
             notes=sum(result.level == Level.NOTE for result in results),
         )
         self._results = results
-        self._end_time = datetime.datetime.now(datetime.UTC)
+
+        if sys.version_info >= (3, 11):
+            self._end_time = datetime.datetime.now(datetime.UTC)
+        else:
+            self._end_time = datetime.datetime.utcnow()
         LOG.debug(f"Run ended at {self._end_time}")
 
     @property

--- a/precli/core/symtab.py
+++ b/precli/core/symtab.py
@@ -1,7 +1,9 @@
 # Copyright 2024 Secure Sauce LLC
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     from typing import Self
-except ImportError:
+else:
     from typing_extensions import Self
 
 from precli.core.call import Call


### PR DESCRIPTION
Fixes a traceback caused by using a new datetime.UTC attribute not availabe in Python 3.10.

This also switches the try-exept ImportError logic with specific sys.version_info conditionals in the importing so its obvious what Python version affects that import.

Fixes #630