### PR TITLE
Replace open source with source available

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ vulnerabilities.
 
     [:octicons-arrow-right-24: Rules](rules.md)
 
--   :material-scale-balance:{ .lg .middle } __Open Source, BSL__
+-   :material-scale-balance:{ .lg .middle } __Source Available, BSL__
 
     ---
 


### PR DESCRIPTION
Technically, BSL is not open source according to OSI. As such, this change updates that statement to put Source Available, a more accurate description of the license.