### PR TITLE
Add support for Python 3.9

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -128,9 +128,10 @@ def setup_arg_parser():
         help="quiet mode, display less output",
     )
     extensions = ""
-    for dist in metadata.distributions():
-        if dist.name.startswith("precli-"):
-            extensions += f"  {dist.name} {dist.version}\n"
+    if sys.version_info >= (3, 10):
+        for dist in metadata.distributions():
+            if dist.name.startswith("precli-"):
+                extensions += f"  {dist.name} {dist.version}\n"
     python_ver = sys.version.replace("\n", "")
     parser.add_argument(
         "--version",
@@ -289,15 +290,14 @@ def discover_files(targets: list[str], recursive: bool):
 
 
 def create_gist(file, renderer: str):
-    match renderer:
-        case "json":
-            filename = "results.json"
-        case "plain":
-            filename = "results.txt"
-        case "markdown":
-            filename = "results.md"
-        case "detailed":
-            filename = "results.txt"
+    if renderer == "json":
+        filename = "results.json"
+    elif renderer == "plain":
+        filename = "results.txt"
+    elif renderer == "markdown":
+        filename = "results.md"
+    elif renderer == "detailed":
+        filename = "results.txt"
 
     with open(file.name, encoding="utf-8") as f:
         file_content = f.read()

--- a/precli/core/loader.py
+++ b/precli/core/loader.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+import sys
 from importlib.metadata import entry_points
 
 
@@ -6,11 +7,21 @@ def load_extension(group: str, name: str = ""):
     if not name:
         extensions = {}
 
-        for entry_point in entry_points(group=group):
+        if sys.version_info >= (3, 10):
+            eps = entry_points(group=group)
+        else:
+            eps = entry_points()[group]
+        for entry_point in eps:
             extension = entry_point.load()()
             extensions[entry_point.name] = extension
 
         return extensions
     else:
-        (entry_point,) = entry_points(group=group, name=name)
-        return entry_point.load()
+        if sys.version_info >= (3, 10):
+            (entry_point,) = entry_points(group=group, name=name)
+            return entry_point.load()
+        else:
+            eps = entry_points()[group]
+            for entry_point in eps:
+                if entry_point.name == name:
+                    return entry_point.load()

--- a/precli/core/redos.py
+++ b/precli/core/redos.py
@@ -130,18 +130,17 @@ class CharacterRange:
     def _parse_in_nodes(nodes: tuple):
         results = []
         for node_type, args in nodes:
-            match node_type:
-                case constants.LITERAL:
-                    results.append(CR(cr_min=args, cr_max=args))
-                case constants.RANGE:
-                    results.append(CR(cr_min=args[0], cr_max=args[1]))
-                case constants.CATEGORY:
-                    for c, r in CATEGORY_TO_RANGE.items():
-                        if args is c:
-                            results.extend(
-                                CR(cr_min=r_min, cr_max=r_max)
-                                for r_min, r_max in r
-                            )
+            if node_type == constants.LITERAL:
+                results.append(CR(cr_min=args, cr_max=args))
+            elif node_type == constants.RANGE:
+                results.append(CR(cr_min=args[0], cr_max=args[1]))
+            elif node_type == constants.CATEGORY:
+                for c, r in CATEGORY_TO_RANGE.items():
+                    if args is c:
+                        results.extend(
+                            CR(cr_min=r_min, cr_max=r_max)
+                            for r_min, r_max in r
+                        )
 
         return results
 
@@ -160,18 +159,17 @@ class CharacterRange:
 
     @classmethod
     def from_op_node(cls, node: OpNode):
-        match node.op:
-            case constants.ANY:
-                return cls.from_any(node.args)
-            case constants.LITERAL:
-                return cls.from_literal(node.args)
-            case constants.NOT_LITERAL:
-                return cls.from_not_literal(node.args)
-            case constants.IN:
-                if node.args and node.args[0] == (constants.NEGATE, None):
-                    return cls.from_not_in(node.args)
-                else:
-                    return cls.from_in(node.args)
+        if node.op == constants.ANY:
+            return cls.from_any(node.args)
+        elif node.op == constants.LITERAL:
+            return cls.from_literal(node.args)
+        elif node.op == constants.NOT_LITERAL:
+            return cls.from_not_literal(node.args)
+        elif node.op == constants.IN:
+            if node.args and node.args[0] == (constants.NEGATE, None):
+                return cls.from_not_in(node.args)
+            else:
+                return cls.from_in(node.args)
 
         # Unsupported OpNode
         return None

--- a/precli/core/symtab.py
+++ b/precli/core/symtab.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
 import sys
+from typing import Optional
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -18,7 +19,7 @@ class SymbolTable:
     def name(self) -> str:
         return self._name
 
-    def parent(self) -> Self | None:
+    def parent(self) -> Optional[Self]:
         return self._parent
 
     def put(self, name: str, type: str, value: str) -> None:

--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
 import importlib
+import sys
 from abc import ABC
 from abc import abstractmethod
 from importlib.metadata import entry_points
@@ -35,7 +36,11 @@ class Parser(ABC):
         self.rules = {}
         self.wildcards = {}
 
-        discovered_rules = entry_points(group=f"precli.rules.{lang}")
+        if sys.version_info >= (3, 10):
+            discovered_rules = entry_points(group=f"precli.rules.{lang}")
+        else:
+            eps = entry_points()
+            discovered_rules = eps[f"precli.rules.{lang}"]
         for rule in discovered_rules:
             self.rules[rule.name] = rule.load()(rule.name)
 
@@ -46,7 +51,7 @@ class Parser(ABC):
                     else:
                         self.wildcards[k] = v
 
-        def child_by_type(self, type: str) -> Node | None:
+        def child_by_type(self, type: str) -> Optional[Node]:
             # Return first child with type as specified
             child = list(filter(lambda x: x.type == type, self.named_children))
             return child[0] if child else None
@@ -217,7 +222,7 @@ class Parser(ABC):
             ),
         )
 
-    def child_by_type(self, node: Node, type: str) -> Node | None:
+    def child_by_type(self, node: Node, type: str) -> Optional[Node]:
         # Return first child with type as specified
         child = list(filter(lambda x: x.type == type, node.named_children))
         return child[0] if child else None

--- a/precli/renderers/detailed.py
+++ b/precli/renderers/detailed.py
@@ -13,18 +13,15 @@ from precli.rules import Rule
 class Detailed(Renderer):
     def render(self, run: Run):
         for result in run.results:
-            match result.level:
-                case Level.ERROR:
-                    emoji = ":no_entry-emoji:"
-                    style = "red"
-
-                case Level.WARNING:
-                    emoji = ":warning-emoji: "
-                    style = "yellow"
-
-                case Level.NOTE:
-                    emoji = ":information-emoji: "
-                    style = "blue"
+            if result.level == Level.ERROR:
+                emoji = ":no_entry-emoji:"
+                style = "red"
+            elif result.level == Level.WARNING:
+                emoji = ":warning-emoji: "
+                style = "yellow"
+            elif result.level == Level.NOTE:
+                emoji = ":information-emoji: "
+                style = "blue"
 
             if result.artifact.uri is not None:
                 if result.location.start_line != result.location.end_line:

--- a/precli/renderers/markdown.py
+++ b/precli/renderers/markdown.py
@@ -28,13 +28,12 @@ class Markdown(Renderer):
             except UnicodeDecodeError:
                 pass
 
-            match result.level:
-                case Level.ERROR:
-                    alert = "CAUTION"
-                case Level.WARNING:
-                    alert = "WARNING"
-                case Level.NOTE:
-                    alert = "NOTE"
+            if result.level == Level.ERROR:
+                alert = "CAUTION"
+            elif result.level == Level.WARNING:
+                alert = "WARNING"
+            elif result.level == Level.NOTE:
+                alert = "NOTE"
 
             if result.artifact.uri is not None:
                 if result.location.start_line != result.location.end_line:

--- a/precli/renderers/plain.py
+++ b/precli/renderers/plain.py
@@ -14,15 +14,12 @@ class Plain(Renderer):
 
             style = ""
             if self.console.no_color is False:
-                match result.level:
-                    case Level.ERROR:
-                        style = "red"
-
-                    case Level.WARNING:
-                        style = "yellow"
-
-                    case Level.NOTE:
-                        style = "blue"
+                if result.level == Level.ERROR:
+                    style = "red"
+                elif result.level == Level.WARNING:
+                    style = "yellow"
+                elif result.level == Level.NOTE:
+                    style = "blue"
 
             if result.artifact.uri is not None:
                 file_name = result.artifact.uri

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -121,6 +121,8 @@ func main() {
 _New in version 0.2.1_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -143,7 +145,7 @@ class WeakCipher(Rule):
 
     def analyze_call_expression(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified in [
             "crypto/des.NewCipher",
             "crypto/des.NewTripleDESCipher",

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -72,6 +72,8 @@ func main() {
 _New in version 0.2.1_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -94,7 +96,7 @@ class WeakHash(Rule):
 
     def analyze_call_expression(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified in [
             "crypto/md5.New",
             "crypto/sha1.New",

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -128,6 +128,8 @@ func main() {
 _New in version 0.2.1_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
@@ -148,7 +150,7 @@ class WeakKey(Rule):
 
     def analyze_call_expression(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified in ["crypto/dsa.GenerateParameters"]:
             argument = call.get_argument(position=2)
             sizes = argument.value

--- a/precli/rules/go/stdlib/syscall_setuid_root.py
+++ b/precli/rules/go/stdlib/syscall_setuid_root.py
@@ -87,6 +87,8 @@ func main() {
 _New in version 0.6.6_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -109,7 +111,7 @@ class SyscallSetuidRoot(Rule):
 
     def analyze_call_expression(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified != "syscall.Setuid":
             return
 

--- a/precli/rules/java/stdlib/java_net_insecure_cookie.py
+++ b/precli/rules/java/stdlib/java_net_insecure_cookie.py
@@ -68,6 +68,8 @@ public class HttpCookieSecureFalse {
 _New in version 0.5.1_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -92,7 +94,7 @@ class InsecureCookie(Rule):
 
     def analyze_method_invocation(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified not in [
             "java.net.HttpCookie.setSecure",
         ]:

--- a/precli/rules/java/stdlib/java_security_weak_hash.py
+++ b/precli/rules/java/stdlib/java_security_weak_hash.py
@@ -67,6 +67,8 @@ public class MessageDigestSHA256 {
 _New in version 0.5.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -97,7 +99,7 @@ class MessageDigestWeakHash(Rule):
 
     def analyze_method_invocation(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified not in [
             "java.security.MessageDigest.getInstance",
         ]:

--- a/precli/rules/java/stdlib/java_security_weak_key.py
+++ b/precli/rules/java/stdlib/java_security_weak_key.py
@@ -85,6 +85,8 @@ public class KeyPairGeneratorRSA {
 _New in version 0.5.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
@@ -110,7 +112,7 @@ class KeyPairGeneratorWeakKey(Rule):
 
     def analyze_method_invocation(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified not in [
             "java.security.KeyPairGenerator.getInstance.initialize"
         ]:

--- a/precli/rules/java/stdlib/java_security_weak_random.py
+++ b/precli/rules/java/stdlib/java_security_weak_random.py
@@ -70,6 +70,8 @@ public class StrongRNG {
 _New in version 0.5.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -94,7 +96,7 @@ class SecureRandomWeakRandom(Rule):
 
     def analyze_method_invocation(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified not in [
             "java.security.SecureRandom.getInstance",
         ]:

--- a/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
+++ b/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
@@ -121,6 +121,8 @@ public class Example {
 _New in version 0.5.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -151,7 +153,7 @@ class WeakCipher(Rule):
 
     def analyze_method_invocation(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified not in [
             "javax.crypto.Cipher.getInstance",
         ]:

--- a/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
+++ b/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
@@ -66,6 +66,8 @@ public class SessionCookie {
 _New in version 0.5.1_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -90,7 +92,7 @@ class InsecureCookie(Rule):
 
     def analyze_method_invocation(
         self, context: dict, call: Call
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if call.name_qualified not in [
             "javax.servlet.http.Cookie.setSecure",
         ]:

--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -75,6 +75,8 @@ _New in version 0.3.14_
 _Changed in version 0.4.1: --api-key also checked_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -95,7 +97,7 @@ class ArgparseSensitiveInfo(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "argparse.ArgumentParser.add_argument",
         ]:

--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -60,6 +60,8 @@ foobar("World")
 _New in version 0.3.8_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -76,7 +78,7 @@ class Assert(Rule):
             "enabled.",
         )
 
-    def analyze_assert(self, context: dict) -> Result:
+    def analyze_assert(self, context: dict) -> Optional[Result]:
         return Result(
             rule_id=self.id,
             artifact=context["artifact"],

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -105,6 +105,8 @@ alternatives include `bcrypt`, `pbkdf2`, and `scrypt`.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -128,7 +130,7 @@ class CryptWeakHash(Rule):
             "expectations.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["crypt.crypt"]:
             name = call.get_argument(position=1, name="salt").value
 

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -84,6 +84,8 @@ These alternatives include:
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
@@ -102,7 +104,7 @@ class FtpCleartext(Rule):
             "encryption.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["ftplib.FTP"]:
             fixes = Rule.get_fixes(
                 context=context,

--- a/precli/rules/python/stdlib/ftplib_no_timeout.py
+++ b/precli/rules/python/stdlib/ftplib_no_timeout.py
@@ -67,6 +67,8 @@ ftp_server = ftplib.FTP("ftp.example.com", timeout=5)
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -85,7 +87,7 @@ class FtplibNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "ftplib.FTP",
             "ftplib.FTP.connect",

--- a/precli/rules/python/stdlib/ftplib_unverified_context.py
+++ b/precli/rules/python/stdlib/ftplib_unverified_context.py
@@ -65,6 +65,8 @@ with ftplib.FTP_TLS(
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -85,7 +87,7 @@ class FtplibUnverifiedContext(Rule):
             "certificates when context is unset or None.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in ["ftplib.FTP_TLS"]:
             return
 

--- a/precli/rules/python/stdlib/hashlib_improper_prng.py
+++ b/precli/rules/python/stdlib/hashlib_improper_prng.py
@@ -66,6 +66,8 @@ hashlib.scrypt(password, salt=salt, n=16384, r=8, p=1)
 _New in version 0.4.3_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -83,7 +85,7 @@ class HashlibImproperPrng(Rule):
             "security purposes.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "hashlib.blake2b",
             "hashlib.blake2s",

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -80,6 +80,8 @@ _New in version 0.1.0_
 _Changed in version 0.4.1: Added md5-sha1_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.argument import Argument
 from precli.core.call import Call
 from precli.core.config import Config
@@ -111,7 +113,7 @@ class HashlibWeakHash(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in HASHLIB_WEAK_HASHES:
             used_for_security = call.get_argument(
                 name="usedforsecurity", default=Argument(None, True)

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -77,6 +77,8 @@ print(hmac.compare_digest(digest, received_digest))
 _New in version 0.1.4_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.comparison import Comparison
 from precli.core.config import Config
 from precli.core.level import Level
@@ -108,7 +110,7 @@ class HmacTimingAttack(Rule):
 
     def analyze_comparison_operator(
         self, context: dict, comparison: Comparison
-    ) -> Result | None:
+    ) -> Optional[Result]:
         if comparison.operator == "==" and (
             comparison.left_hand in TIMING_VULNERABLE
             or comparison.right_hand in TIMING_VULNERABLE

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -71,6 +71,8 @@ _New in version 0.1.0_
 _Changed in version 0.4.1: Added md5-sha1_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -101,7 +103,7 @@ class HmacWeakHash(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["hmac.new"]:
             # hmac.new(key, msg=None, digestmod='')
             argument = call.get_argument(position=2, name="digestmod")

--- a/precli/rules/python/stdlib/hmac_weak_key.py
+++ b/precli/rules/python/stdlib/hmac_weak_key.py
@@ -66,6 +66,8 @@ hmac.new(key, msg=message, digestmod=hashlib.sha3_384)
 _New in version 0.4.3_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -120,7 +122,7 @@ class HmacWeakKey(Rule):
             "for the '{2}' algorithm.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in ("hmac.new", "hmac.digest"):
             return
 

--- a/precli/rules/python/stdlib/http_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/http_server_unrestricted_bind.py
@@ -72,6 +72,8 @@ if __name__ == "__main__":
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core import utils
 from precli.core.call import Call
 from precli.core.location import Location
@@ -94,7 +96,7 @@ class HttpServerUnrestrictedBind(Rule):
             "interfaces, increasing the risk of unauthorized access.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "http.server.HTTPServer",
             "http.server.ThreadingHTTPServer",

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -59,6 +59,7 @@ response = conn.getresponse()
 _New in version 0.3.4_
 
 """  # noqa: E501
+from typing import Optional
 from urllib.parse import parse_qs
 from urllib.parse import urlsplit
 
@@ -84,7 +85,7 @@ class HttpUrlSecret(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "http.client.HTTPConnection.request",
             "http.client.HTTPSConnection.request",

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -68,6 +68,8 @@ M.logout()
 _New in version 0.1.9_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -88,7 +90,7 @@ class ImapCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "imaplib.IMAP4.authenticate",
             "imaplib.IMAP4.login",

--- a/precli/rules/python/stdlib/imaplib_no_timeout.py
+++ b/precli/rules/python/stdlib/imaplib_no_timeout.py
@@ -69,6 +69,8 @@ imap.starttls(ssl.create_default_context())
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -87,7 +89,7 @@ class ImaplibNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "imaplib.IMAP4",
             "imaplib.IMAP4_SSL",

--- a/precli/rules/python/stdlib/imaplib_unverified_context.py
+++ b/precli/rules/python/stdlib/imaplib_unverified_context.py
@@ -76,6 +76,8 @@ imap4.logout()
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -96,7 +98,7 @@ class ImaplibUnverifiedContext(Rule):
             "certificates when context is unset or None.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "imaplib.IMAP4_SSL",
             "imaplib.IMAP4.starttls",

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -40,6 +40,8 @@ should first sanitize the data to remove any potential malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.location import Location
@@ -59,7 +61,7 @@ class JsonLoad(Rule):
             config=Config(enabled=False),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in [
             "json.load",
             "json.loads",

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -52,6 +52,8 @@ thread = logging.config.listen(verify=validate)
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -69,7 +71,7 @@ class InsecureListenConfig(Rule):
             "injection.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in ["logging.config.listen"]:
             return
 

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -45,6 +45,8 @@ you should first sanitize the data to remove any potential malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -62,7 +64,7 @@ class MarshalLoad(Rule):
             "instantiation of arbitrary objects.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["marshal.load", "marshal.loads"]:
             # marshal.load(file, /)
             # marshal.loads(bytes, /)

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -54,6 +54,8 @@ with nntplib.NNTP_SSL('news.gmane.io') as n:
 _New in version 0.1.9_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -74,7 +76,7 @@ class NntpCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in ["nntplib.NNTP.login"]:
             return
 

--- a/precli/rules/python/stdlib/nntplib_no_timeout.py
+++ b/precli/rules/python/stdlib/nntplib_no_timeout.py
@@ -69,6 +69,8 @@ nntp.starttls(ssl.create_default_context())
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -87,7 +89,7 @@ class NntplibNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "nntplib.NNTP",
             "nntplib.NNTP_SSL",

--- a/precli/rules/python/stdlib/nntplib_unverified_context.py
+++ b/precli/rules/python/stdlib/nntplib_unverified_context.py
@@ -66,6 +66,8 @@ s.quit()
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -86,7 +88,7 @@ class NntplibUnverifiedContext(Rule):
             "certificates when context is unset or None.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "nntplib.NNTP_SSL",
             "nntplib.NNTP.starttls",

--- a/precli/rules/python/stdlib/os_loose_file_perm.py
+++ b/precli/rules/python/stdlib/os_loose_file_perm.py
@@ -82,6 +82,7 @@ _New in version 0.6.2_
 
 """  # noqa: E501
 import stat
+from typing import Optional
 
 from precli.core.call import Call
 from precli.core.level import Level
@@ -142,7 +143,7 @@ class OsLooseFilePermissions(Rule):
                 getattr(stat, constant),
             )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "os.fchmod",
             "os.chmod",

--- a/precli/rules/python/stdlib/os_setuid_root.py
+++ b/precli/rules/python/stdlib/os_setuid_root.py
@@ -63,6 +63,8 @@ os.setuid(1000)
 _New in version 0.6.6_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -83,7 +85,7 @@ class OsSetuidRoot(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified != "os.setuid":
             return
 

--- a/precli/rules/python/stdlib/pathlib_loose_file_perm.py
+++ b/precli/rules/python/stdlib/pathlib_loose_file_perm.py
@@ -82,6 +82,7 @@ _New in version 0.6.2_
 
 """  # noqa: E501
 import stat
+from typing import Optional
 
 from precli.core.call import Call
 from precli.core.level import Level
@@ -140,7 +141,7 @@ class PathlibLooseFilePermissions(Rule):
                 getattr(stat, constant),
             )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "pathlib.Path.chmod",
             "pathlib.Path.lchmod",

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -57,6 +57,8 @@ to be secure and cannot be used to execute malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -74,7 +76,7 @@ class PickleLoad(Rule):
             "instantiation of arbitrary objects.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in [
             "pickle.load",
             "pickle.loads",

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -63,6 +63,8 @@ for i in range(numMessages):
 _New in version 0.1.9_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -83,7 +85,7 @@ class PopCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "poplib.POP3.user",
             "poplib.POP3.pass_",

--- a/precli/rules/python/stdlib/poplib_no_timeout.py
+++ b/precli/rules/python/stdlib/poplib_no_timeout.py
@@ -69,6 +69,8 @@ pop.stls(ssl.create_default_context())
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -87,7 +89,7 @@ class PoplibNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "poplib.POP3",
             "poplib.POP3_SSL",

--- a/precli/rules/python/stdlib/poplib_unverified_context.py
+++ b/precli/rules/python/stdlib/poplib_unverified_context.py
@@ -72,6 +72,8 @@ for i in range(numMessages):
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -92,7 +94,7 @@ class PoplibUnverifiedContext(Rule):
             "certificates when context is unset or None.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "poplib.POP3_SSL",
             "poplib.POP3.stls",

--- a/precli/rules/python/stdlib/re_denial_of_service.py
+++ b/precli/rules/python/stdlib/re_denial_of_service.py
@@ -59,6 +59,8 @@ reg.search("http://[:::::::::::::::::::::::::::::::::::::::]/path")
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core import redos
 from precli.core.call import Call
 from precli.core.config import Config
@@ -81,7 +83,7 @@ class ReDenialOfService(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "re.compile",
             "re.search",

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -53,6 +53,8 @@ token = secrets.token_bytes()
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.level import Level
 from precli.core.location import Location
@@ -71,7 +73,7 @@ class SecretsWeakToken(Rule):
             "'{1}' bytes, which can be vulnerable to brute-force attacks.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "secrets.token_bytes",
             "secrets.token_hex",

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -44,6 +44,8 @@ any potential malicious code.
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -61,7 +63,7 @@ class ShelveOpen(Rule):
             "instantiation of arbitrary objects.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["shelve.open", "shelve.DbfilenameShelf"]:
             return Result(
                 rule_id=self.id,

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -99,6 +99,8 @@ server.quit()
 _New in version 0.1.9_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -119,7 +121,7 @@ class SmtpCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "smtplib.SMTP.login",
             "smtplib.SMTP.auth",

--- a/precli/rules/python/stdlib/smtplib_no_timeout.py
+++ b/precli/rules/python/stdlib/smtplib_no_timeout.py
@@ -71,6 +71,8 @@ server.starttls(context=ssl.create_default_context())
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -89,7 +91,7 @@ class SmtplibNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "smtplib.SMTP",
             "smtplib.SMTP_SSL",

--- a/precli/rules/python/stdlib/smtplib_unverified_context.py
+++ b/precli/rules/python/stdlib/smtplib_unverified_context.py
@@ -108,6 +108,8 @@ server.quit()
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -128,7 +130,7 @@ class SmtplibUnverifiedContext(Rule):
             "certificates when context is unset or None.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "smtplib.SMTP_SSL",
             "smtplib.SMTP.starttls",

--- a/precli/rules/python/stdlib/socket_no_timeout.py
+++ b/precli/rules/python/stdlib/socket_no_timeout.py
@@ -66,6 +66,8 @@ s.close()
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -84,7 +86,7 @@ class SocketNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in ("socket.create_connection",):
             return
 

--- a/precli/rules/python/stdlib/socket_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socket_unrestricted_bind.py
@@ -62,6 +62,8 @@ s.listen()
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core import utils
 from precli.core.call import Call
 from precli.core.location import Location
@@ -84,7 +86,7 @@ class SocketUnrestrictedBind(Rule):
             "interfaces, increasing the risk of unauthorized access.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "socket.create_server",
             "socket.socket.bind",

--- a/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
@@ -80,6 +80,8 @@ with socketserver.UDPServer((HOST, PORT), MyUDPHandler) as server:
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core import utils
 from precli.core.call import Call
 from precli.core.location import Location
@@ -102,7 +104,7 @@ class SocketserverUnrestrictedBind(Rule):
             "interfaces, increasing the risk of unauthorized access.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "socketserver.TCPServer",
             "socketserver.UDPServer",

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -59,6 +59,7 @@ _New in version 0.2.3_
 
 """  # noqa: E501
 import re
+from typing import Optional
 
 from precli.core.call import Call
 from precli.core.level import Level
@@ -78,7 +79,7 @@ class SslContextWeakKey(Rule):
             "vulnerable to attacks.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "ssl.SSLContext.set_ecdh_curve",
             "ssl.create_default_context.set_ecdh_curve",

--- a/precli/rules/python/stdlib/ssl_create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl_create_unverified_context.py
@@ -54,6 +54,8 @@ context = ssl.create_default_context()
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -71,7 +73,7 @@ class CreateUnverifiedContext(Rule):
             "certificates.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         """
         _create_unverified_context(
             protocol=None,

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -67,6 +67,8 @@ ssl.get_server_certificate(("localhost", 443), ssl_version=ssl.PROTOCOL_TLSv1_2)
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.argument import Argument
 from precli.core.call import Call
 from precli.core.config import Config
@@ -95,7 +97,7 @@ class InsecureTlsVersion(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["ssl.get_server_certificate"]:
             # get_server_certificate(
             #     addr,

--- a/precli/rules/python/stdlib/ssl_no_timeout.py
+++ b/precli/rules/python/stdlib/ssl_no_timeout.py
@@ -61,6 +61,8 @@ cert = ssl.get_server_certificate(("example.com", 443), timeout=5)
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -79,7 +81,7 @@ class SslNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in ("ssl.get_server_certificate",):
             return
 

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -106,6 +106,8 @@ These alternatives include:
 _New in version 0.1.0_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.config import Config
 from precli.core.level import Level
@@ -126,7 +128,7 @@ class TelnetlibCleartext(Rule):
             config=Config(level=Level.ERROR),
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["telnetlib.Telnet"]:
             return Result(
                 rule_id=self.id,

--- a/precli/rules/python/stdlib/telnetlib_no_timeout.py
+++ b/precli/rules/python/stdlib/telnetlib_no_timeout.py
@@ -64,6 +64,8 @@ telnet = telnetlib.Telnet("example.com", 23, timeout=5)
 _New in version 0.6.7_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.location import Location
 from precli.core.result import Result
@@ -82,7 +84,7 @@ class TelnetlibNoTimeout(Rule):
             "does not respond.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in (
             "telnetlib.Telnet",
             "telnetlib.Telnet.open",

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -57,6 +57,8 @@ with open(
 _New in version 0.1.9_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core.call import Call
 from precli.core.fix import Fix
 from precli.core.location import Location
@@ -76,7 +78,7 @@ class MktempRaceCondition(Rule):
             "conditions.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified in ["open"]:
             file_arg = call.get_argument(position=0, name="file")
 

--- a/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
@@ -72,6 +72,8 @@ if __name__ == "__main__":
 _New in version 0.3.14_
 
 """  # noqa: E501
+from typing import Optional
+
 from precli.core import utils
 from precli.core.call import Call
 from precli.core.location import Location
@@ -94,7 +96,7 @@ class XmlrpcServerUnrestrictedBind(Rule):
             "interfaces, increasing the risk of unauthorized access.",
         )
 
-    def analyze_call(self, context: dict, call: Call) -> Result | None:
+    def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
         if call.name_qualified not in [
             "xmlrpc.server.DocXMLRPCServer",
             "xmlrpc.server.SimpleXMLRPCServer",

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
     Operating System :: Microsoft :: Windows
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,5 @@ import setuptools
 
 
 setuptools.setup(
-    python_requires=">=3.10", setup_requires=["pbr>=2.0.0"], pbr=True
+    python_requires=">=3.9", setup_requires=["pbr>=2.0.0"], pbr=True
 )


### PR DESCRIPTION
To maximize adoption, support the full range of Python versions that are not end-of-life. So this change adds the final needed of Python 3.9.

This does affect some of the code:
* Can no longer use match statements
* Use typing.Optional instead of <type> | None
* Getting third party plugin via metadata distributions is disabled
* Modified how extensions are found by group and loaded