### PR TITLE
Remove minimum python version text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ If your needs go beyond the analysis of just the standard library, consider upgr
 Quick Start
 -----------
 
-To install precli (requires Python 3.10+):
+To install precli:
 
 .. code-block:: console
 


### PR DESCRIPTION
No need to note which python version is needed to install as now Precli supports all non end-of-life versions.