### PR TITLE
Fix typo in the nntplib no timeout docstring

### DIFF
--- a/precli/rules/python/stdlib/nntplib_no_timeout.py
+++ b/precli/rules/python/stdlib/nntplib_no_timeout.py
@@ -61,8 +61,8 @@ nntp.starttls(ssl.create_default_context())
 # See also
 
 !!! info
-    - [nntplib.NNTP — nntplib — IMAP4 protocol client](https://docs.python.org/3/library/nntplib.html#nntplib.NNTP)
-    - [nntplib.NNTP_SSL — nntplib — IMAP4 protocol client](https://docs.python.org/3/library/nntplib.html#nntplib.NNTP_SSL)
+    - [nntplib.NNTP — nntplib — NNTP protocol client](https://docs.python.org/3/library/nntplib.html#nntplib.NNTP)
+    - [nntplib.NNTP_SSL — nntplib — NNTP protocol client](https://docs.python.org/3/library/nntplib.html#nntplib.NNTP_SSL)
     - [socket.setdefaulttimeout — TLS_SSL wrapper for socket objects](https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout)
     - [CWE-1088: Synchronous Access of Remote Resource without Timeout](https://cwe.mitre.org/data/definitions/1088.html)
 


### PR DESCRIPTION
Should be NNTP, not IMAP4