### PR TITLE
Always use latest python version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.12"
+    python: latest
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
Instead of hardcoding the version of Python, use the special "latest" keyword to always use the latest.