### PR TITLE
Direct assert rule to ignore asserts in test functions

### DIFF
--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -79,8 +79,9 @@ class Assert(Rule):
         )
 
     def analyze_assert(self, context: dict) -> Optional[Result]:
-        return Result(
-            rule_id=self.id,
-            artifact=context["artifact"],
-            location=Location(context["node"]),
-        )
+        if not context["symtab"].name().startswith("test_"):
+            return Result(
+                rule_id=self.id,
+                artifact=context["artifact"],
+                location=Location(context["node"]),
+            )

--- a/tests/unit/rules/python/stdlib/assert/examples/assert_test_func.py
+++ b/tests/unit/rules/python/stdlib/assert/examples/assert_test_func.py
@@ -1,0 +1,7 @@
+# level: NONE
+def test_foobar(a: str = None):
+    assert a is not None
+    return f"Hello {a}"
+
+
+foobar(None)

--- a/tests/unit/rules/python/stdlib/assert/test_assert.py
+++ b/tests/unit/rules/python/stdlib/assert/test_assert.py
@@ -41,6 +41,7 @@ class TestAssert(test_case.TestCase):
         "filename",
         [
             "assert.py",
+            "assert_test_func.py",
         ],
     )
     def test(self, filename):


### PR DESCRIPTION
For several Python test frameworks, the assert builtin is required to validate the test. Precli should avoid showing results for this condition since this isn't the use case the rule is trying to find.

Fixes: #638