### PR TITLE
Ignore test code in analysis

### DIFF
--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -29,6 +29,16 @@ class Go(Parser):
     def get_file_encoding(self, file_contents: str) -> str:
         return "utf-8"
 
+    def is_test_code(self) -> bool:
+        """
+        Determine if analyzing test code.
+
+        This function determines if the current position of the analysis
+        is within unit test code. The purpose of which is to potentially
+        ignore rules in test code.
+        """
+        return False
+
     def visit_source_file(self, nodes: list[Node]):
         self.suppressions = {}
         self.current_symtab = SymbolTable("<source_file>")

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -28,6 +28,16 @@ class Java(Parser):
     def get_file_encoding(self, file_contents: str) -> str:
         return "utf-8"
 
+    def is_test_code(self) -> bool:
+        """
+        Determine if analyzing test code.
+
+        This function determines if the current position of the analysis
+        is within unit test code. The purpose of which is to potentially
+        ignore rules in test code.
+        """
+        return False
+
     def visit_program(self, nodes: list[Node]):
         self.suppressions = {}
         self.current_symtab = SymbolTable("<program>")

--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -79,9 +79,8 @@ class Assert(Rule):
         )
 
     def analyze_assert(self, context: dict) -> Optional[Result]:
-        if not context["symtab"].name().startswith("test_"):
-            return Result(
-                rule_id=self.id,
-                artifact=context["artifact"],
-                location=Location(context["node"]),
-            )
+        return Result(
+            rule_id=self.id,
+            artifact=context["artifact"],
+            location=Location(context["node"]),
+        )

--- a/tests/unit/core/test_python.py
+++ b/tests/unit/core/test_python.py
@@ -5,4 +5,4 @@ from precli.parsers import python
 class TestPython:
     @classmethod
     def setup_class(cls):
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)

--- a/tests/unit/parsers/test_python.py
+++ b/tests/unit/parsers/test_python.py
@@ -11,7 +11,7 @@ from precli.parsers import python
 class TestPython:
     @classmethod
     def setup_class(cls):
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -13,7 +13,7 @@ class TestArgparseSensitiveInfo(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY027"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/assert/examples/assert_test_func.py
+++ b/tests/unit/rules/python/stdlib/assert/examples/assert_test_func.py
@@ -1,7 +1,0 @@
-# level: NONE
-def test_foobar(a: str = None):
-    assert a is not None
-    return f"Hello {a}"
-
-
-foobar(None)

--- a/tests/unit/rules/python/stdlib/assert/test_assert.py
+++ b/tests/unit/rules/python/stdlib/assert/test_assert.py
@@ -13,7 +13,7 @@ class TestAssert(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY001"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",
@@ -41,7 +41,6 @@ class TestAssert(test_case.TestCase):
         "filename",
         [
             "assert.py",
-            "assert_test_func.py",
         ],
     )
     def test(self, filename):

--- a/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
@@ -13,7 +13,7 @@ class TestCryptWeakHash(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY002"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
@@ -14,7 +14,7 @@ class TestFtpCleartext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY003"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
@@ -13,7 +13,7 @@ class TestFtplibNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY045"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
@@ -13,7 +13,7 @@ class TestFtplibUnverifiedContext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY022"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
@@ -13,7 +13,7 @@ class TestHashlibImproperPrng(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY035"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
@@ -13,7 +13,7 @@ class TestHashlibWeakHash(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY004"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
@@ -13,7 +13,7 @@ class TestHmacTimingAttack(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY005"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
@@ -13,7 +13,7 @@ class TestHmacWeakHash(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY006"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
@@ -13,7 +13,7 @@ class TestHmacWeakKey(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY034"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
@@ -13,7 +13,7 @@ class TestHttpServerUnrestrictedBind(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY031"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
@@ -13,7 +13,7 @@ class TestHttpUrlSecret(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY007"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
@@ -13,7 +13,7 @@ class TestImapCleartext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY008"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
@@ -13,7 +13,7 @@ class TestImaplibNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY041"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
@@ -13,7 +13,7 @@ class TestImaplibUnverifiedContext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY023"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/json/test_json_load.py
+++ b/tests/unit/rules/python/stdlib/json/test_json_load.py
@@ -13,7 +13,7 @@ class TestJsonLoad(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY009"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
+++ b/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
@@ -13,7 +13,7 @@ class TestInsecureListenConfig(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY010"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
+++ b/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
@@ -13,7 +13,7 @@ class TestMarshalLoad(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY011"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
@@ -13,7 +13,7 @@ class TestNntpCleartext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY012"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
@@ -13,7 +13,7 @@ class TestNntplibNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY042"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
@@ -13,7 +13,7 @@ class TestNntplibUnverifiedContext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY024"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
@@ -13,7 +13,7 @@ class TestOsLooseFilePermissions(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY036"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/os/test_os_setuid_root.py
+++ b/tests/unit/rules/python/stdlib/os/test_os_setuid_root.py
@@ -13,7 +13,7 @@ class TestOsSetuidRoot(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY038"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
@@ -13,7 +13,7 @@ class TestPathlibLooseFilePermissions(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY037"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
+++ b/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
@@ -13,7 +13,7 @@ class TestPickleLoad(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY013"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
@@ -13,7 +13,7 @@ class TestPopCleartext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY014"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
@@ -13,7 +13,7 @@ class TestPoplibNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY043"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
@@ -13,7 +13,7 @@ class TestPoplibUnverifiedContext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY025"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
+++ b/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
@@ -13,7 +13,7 @@ class TestReDenialOfService(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY033"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
+++ b/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
@@ -13,7 +13,7 @@ class TestSecretsWeakToken(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY028"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
+++ b/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
@@ -13,7 +13,7 @@ class TestShelveOpen(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY015"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
@@ -13,7 +13,7 @@ class TestSmtpCleartext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY016"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
@@ -13,7 +13,7 @@ class TestSmtplibNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY040"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
@@ -13,7 +13,7 @@ class TestSmtplibUnverifiedContext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY026"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
@@ -13,7 +13,7 @@ class TestSocketNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY039"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
@@ -13,7 +13,7 @@ class TestSocketUnrestrictedBind(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY029"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
@@ -13,7 +13,7 @@ class TestSocketserverUnrestrictedBind(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY030"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
@@ -13,7 +13,7 @@ class TestSslSocketTlsVersion(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY018"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
@@ -13,7 +13,7 @@ class TestSslSocketWeakKey(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY019"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
@@ -13,7 +13,7 @@ class TestSslCreateContext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY017"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
@@ -13,7 +13,7 @@ class TestGetServerCertificate(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY018"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
@@ -13,7 +13,7 @@ class TestSslNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY046"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
@@ -13,7 +13,7 @@ class TestWrapSocket(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY018"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
@@ -13,7 +13,7 @@ class TestTelnetlibCleartext(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY020"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
@@ -13,7 +13,7 @@ class TestTelnetlibNoTimeout(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY044"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
+++ b/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
@@ -13,7 +13,7 @@ class TestMktempRaceCondition(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY021"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",

--- a/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
@@ -13,7 +13,7 @@ class TestXmlrpcServerUnrestrictedBind(test_case.TestCase):
     @classmethod
     def setup_class(cls):
         cls.rule_id = "PY032"
-        cls.parser = python.Python()
+        cls.parser = python.Python(skip_tests=False)
         cls.base_path = os.path.join(
             "tests",
             "unit",


### PR DESCRIPTION
This change, Python specific, determines whether code that is being analyze is unit test or not. By default, the Python parser will not execute rules for test code.

Test code is determined if the scope is within a function that starts with "test_" or withing a "tests" directory or file name that starts with "test_".

Currently the option to skip test code is on the Python parser so that precli's own test code still works. But eventually this should become part of some configuration options for precli.