### PR TITLE
Default the assert rule to be disabled

### DIFF
--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -62,6 +62,7 @@ _New in version 0.3.8_
 """  # noqa: E501
 from typing import Optional
 
+from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -76,6 +77,7 @@ class Assert(Rule):
             cwe_id=703,
             message="Assert statements are disabled when optimizations are "
             "enabled.",
+            config=Config(enabled=False),
         )
 
     def analyze_assert(self, context: dict) -> Optional[Result]:

--- a/tests/unit/rules/python/stdlib/assert/test_assert.py
+++ b/tests/unit/rules/python/stdlib/assert/test_assert.py
@@ -32,7 +32,7 @@ class TestAssert(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
+        assert rule.default_config.enabled is False
         assert rule.default_config.level == Level.WARNING
         assert rule.default_config.rank == -1.0
         assert rule.cwe.id == 703
@@ -44,4 +44,4 @@ class TestAssert(test_case.TestCase):
         ],
     )
     def test(self, filename):
-        self.check(filename)
+        self.check(filename, enabled=[self.rule_id])


### PR DESCRIPTION
The point of the assert rule is to catch scenarios where Python builtin assert is used to guard or as a conditional in functions and not realize that running Python with optimizations (-O) would remove those assert statements.

However, in practice, its unlikely folks use the optimize compile option as it doesn't provide much "optimization" anyway. Frankly it does very very little. Therefore this change defaults the assert rule to disabled to cut down on noise and probably false positives.