### PR TITLE
Add more project urls

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,10 @@ classifier =
 url = https://github.com/securesauce/precli
 download_url = https://pypi.org/project/precli/#files
 project_urls =
-    Release notes = https://github.com/securesauce/precli/releases
+    Changelog = https://github.com/securesauce/precli/releases
+    Documentation = https://precli.readthedocs.io/
+    Issues = https://github.com/securesauce/precli/issues
+    Source = https://github.com/securesauce/precli
 
 [entry_points]
 console_scripts =


### PR DESCRIPTION
This change adds more links to the project_urls of setuptools so that PyPI renders them.

It adds:
* documentation link
* issues link
* source code link