### PR TITLE
Nit change to install part of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ If your needs go beyond the analysis of just the standard library, consider upgr
 Quick Start
 -----------
 
-To install precli:
+To install:
 
 .. code-block:: console
 


### PR DESCRIPTION
Feels somewhat redundant to have "To install precli". This change drops "precli"