### PR TITLE
Add slack link to PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ project_urls =
     Documentation = https://precli.readthedocs.io/
     Issues = https://github.com/securesauce/precli/issues
     Source = https://github.com/securesauce/precli
+    Slack = https://secure-sauce.slack.com/
 
 [entry_points]
 console_scripts =


### PR DESCRIPTION
The PyPI warehouse code will display a special icon for project_urls defined for Slack, among other things.