### PR TITLE
Add trailing slash to project_url links

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,10 @@ classifier =
 url = https://github.com/securesauce/precli
 download_url = https://pypi.org/project/precli/#files
 project_urls =
-    Changelog = https://github.com/securesauce/precli/releases
+    Changelog = https://github.com/securesauce/precli/releases/
     Documentation = https://precli.readthedocs.io/
-    Issues = https://github.com/securesauce/precli/issues
-    Source = https://github.com/securesauce/precli
+    Issues = https://github.com/securesauce/precli/issues/
+    Source = https://github.com/securesauce/precli/
     Slack = https://secure-sauce.slack.com/
 
 [entry_points]


### PR DESCRIPTION
Seems like PyPI doesn't display links that don't have a trailing slash in the URL.