### PR TITLE
importlib metadata distributions not available in Py3.9

### DIFF
--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
 import pathlib
+import sys
 import urllib.parse as urlparse
 from importlib import metadata
 
@@ -111,6 +112,9 @@ class Json(Renderer):
         )
 
     def get_extensions(self) -> list:
+        if sys.version_info < (3, 10):
+            return []
+
         precli_exts = []
         for dist in metadata.distributions():
             if dist.name.startswith("precli-"):


### PR DESCRIPTION
The importlib.metadata.distributions is a feature added in 3.10. As a result, the code used to find extensions won't work in 3.9.

This fix disables the SARIF output of listing extensions in Python 3.9.

Fixes: #649