### PR TITLE
Add SPDX license identifier to each file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 exclude: ^(docs|tests|mkdocs.yml)
 repos:
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 version: 2
 
 build:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 mkdocs
 mkdocstrings[python]
 mkdocs-material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 site_name: Precli Documentation
 repo_url: https://github.com/securesauce/precli/
 edit_uri: blob/main/docs/

--- a/precli/__init__.py
+++ b/precli/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from datetime import datetime
 from importlib import metadata
 

--- a/precli/__main__.py
+++ b/precli/__main__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from precli.cli import main
 
 main.main()

--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import argparse
 import logging
 import os

--- a/precli/core/argument.py
+++ b/precli/core/argument.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from typing import Optional
 
 from tree_sitter import Node

--- a/precli/core/artifact.py
+++ b/precli/core/artifact.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from typing import Optional
 
 

--- a/precli/core/call.py
+++ b/precli/core/call.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from typing import Optional
 
 from tree_sitter import Node

--- a/precli/core/comparison.py
+++ b/precli/core/comparison.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from tree_sitter import Node
 
 

--- a/precli/core/config.py
+++ b/precli/core/config.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from precli.core.level import Level
 
 

--- a/precli/core/cwe.py
+++ b/precli/core/cwe.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 
 
 class Cwe:

--- a/precli/core/fix.py
+++ b/precli/core/fix.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from typing import Optional
 
 from precli.core.location import Location

--- a/precli/core/kind.py
+++ b/precli/core/kind.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import enum
 
 

--- a/precli/core/level.py
+++ b/precli/core/level.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import enum
 
 

--- a/precli/core/linecache.py
+++ b/precli/core/linecache.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import linecache
 
 

--- a/precli/core/loader.py
+++ b/precli/core/loader.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import sys
 from importlib.metadata import entry_points
 

--- a/precli/core/location.py
+++ b/precli/core/location.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from typing import Optional
 
 from tree_sitter import Node

--- a/precli/core/metrics.py
+++ b/precli/core/metrics.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 
 
 class Metrics:

--- a/precli/core/redos.py
+++ b/precli/core/redos.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Secure Sauce LLC
 # Copyright 2019 Duo Security
+# SPDX-License-Identifier: BUSL-1.1
 import collections
 import itertools
 import sys

--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from typing import Optional
 
 from precli.core.artifact import Artifact

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import datetime
 import io
 import logging

--- a/precli/core/status.py
+++ b/precli/core/status.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import enum
 
 

--- a/precli/core/suppression.py
+++ b/precli/core/suppression.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from typing import Optional
 
 from precli.core.location import Location

--- a/precli/core/symtab.py
+++ b/precli/core/symtab.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import sys
 from typing import Optional
 

--- a/precli/core/tool.py
+++ b/precli/core/tool.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 class Tool:
     def __init__(
         self,

--- a/precli/core/utils.py
+++ b/precli/core/utils.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 
 
 def is_str(value) -> bool:

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import ast
 import re
 from typing import Optional

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import re
 from typing import Optional
 

--- a/precli/parsers/node_types.py
+++ b/precli/parsers/node_types.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 
 
 class NodeTypes:

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import builtins
 import codecs
 import importlib

--- a/precli/renderers/detailed.py
+++ b/precli/renderers/detailed.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from rich import box
 from rich import syntax
 from rich.table import Table

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import pathlib
 import sys
 import urllib.parse as urlparse

--- a/precli/renderers/markdown.py
+++ b/precli/renderers/markdown.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import logging
 import sys
 

--- a/precli/renderers/plain.py
+++ b/precli/renderers/plain.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from rich.padding import Padding
 
 from precli.core.level import Level

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Use of a Broken or Risky Cryptographic Algorithm in `crypto` Package
 

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Reversible One Way Hash in `crypto` Package
 

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Inadequate Encryption Strength Using Weak Keys in `crypto` Package
 

--- a/precli/rules/go/stdlib/syscall_setuid_root.py
+++ b/precli/rules/go/stdlib/syscall_setuid_root.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Execution with Unnecessary Privileges using `syscall` Package
 

--- a/precli/rules/java/stdlib/java_net_insecure_cookie.py
+++ b/precli/rules/java/stdlib/java_net_insecure_cookie.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
 

--- a/precli/rules/java/stdlib/java_security_weak_hash.py
+++ b/precli/rules/java/stdlib/java_security_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Reversible One Way Hash in `java.security` Package
 

--- a/precli/rules/java/stdlib/java_security_weak_key.py
+++ b/precli/rules/java/stdlib/java_security_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Inadequate Encryption Strength Using Weak Keys in `java.security` Package
 

--- a/precli/rules/java/stdlib/java_security_weak_random.py
+++ b/precli/rules/java/stdlib/java_security_weak_random.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Use of Cryptographically Weak Pseudo-Random Number Generator `SHA1PRNG`
 

--- a/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
+++ b/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Use of a Broken or Risky Cryptographic Algorithm in `javax.crypto` Package
 

--- a/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
+++ b/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
 

--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Invocation of Process Using Visible Sensitive Information in `argparse`
 

--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Check Using `assert` Function
 

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Reversible One Way Hash in `crypt` Module
 

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Cleartext Transmission of Sensitive Information in the `ftplib` Module
 

--- a/precli/rules/python/stdlib/ftplib_no_timeout.py
+++ b/precli/rules/python/stdlib/ftplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `FTP` without Timeout
 

--- a/precli/rules/python/stdlib/ftplib_unverified_context.py
+++ b/precli/rules/python/stdlib/ftplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Certificate Validation Using `ftplib`
 

--- a/precli/rules/python/stdlib/hashlib_improper_prng.py
+++ b/precli/rules/python/stdlib/hashlib_improper_prng.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Randomness for Cryptographic `hashlib` Functions
 

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Reversible One Way Hash in `hashlib` Module
 

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 Observable Timing Discrepancy in `hmac` Module
 

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Reversible One Way Hash in `hmac` Module
 

--- a/precli/rules/python/stdlib/hmac_weak_key.py
+++ b/precli/rules/python/stdlib/hmac_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Insufficient `hmac` Key Size
 

--- a/precli/rules/python/stdlib/http_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/http_server_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Binding to an Unrestricted IP Address in `http.server` Module
 

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Use of HTTP Request Method With Sensitive Query Strings
 

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Cleartext Transmission of Sensitive Information in the `imaplib` Module
 

--- a/precli/rules/python/stdlib/imaplib_no_timeout.py
+++ b/precli/rules/python/stdlib/imaplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `IMAP4` without Timeout
 

--- a/precli/rules/python/stdlib/imaplib_unverified_context.py
+++ b/precli/rules/python/stdlib/imaplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Certificate Validation Using `imaplib`
 

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Deserialization of Untrusted Data in the `json` Module
 

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Code Injection in Logging Config
 

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Deserialization of Untrusted Data in the `marshal` Module
 

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Cleartext Transmission of Sensitive Information in the `nntplib` Module
 

--- a/precli/rules/python/stdlib/nntplib_no_timeout.py
+++ b/precli/rules/python/stdlib/nntplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `NNTP` without Timeout
 

--- a/precli/rules/python/stdlib/nntplib_unverified_context.py
+++ b/precli/rules/python/stdlib/nntplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Certificate Validation Using `nntplib`
 

--- a/precli/rules/python/stdlib/os_loose_file_perm.py
+++ b/precli/rules/python/stdlib/os_loose_file_perm.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Incorrect Permission Assignment for Critical Resource using `os` Module
 

--- a/precli/rules/python/stdlib/os_setuid_root.py
+++ b/precli/rules/python/stdlib/os_setuid_root.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Execution with Unnecessary Privileges using `os` Module
 

--- a/precli/rules/python/stdlib/pathlib_loose_file_perm.py
+++ b/precli/rules/python/stdlib/pathlib_loose_file_perm.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Incorrect Permission Assignment for Critical Resource using `pathlib` Module
 

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Deserialization of Untrusted Data in `pickle` Module
 

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Cleartext Transmission of Sensitive Information in the `poplib` Module
 

--- a/precli/rules/python/stdlib/poplib_no_timeout.py
+++ b/precli/rules/python/stdlib/poplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `POP3` without Timeout
 

--- a/precli/rules/python/stdlib/poplib_unverified_context.py
+++ b/precli/rules/python/stdlib/poplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Certificate Validation Using `poplib`
 

--- a/precli/rules/python/stdlib/re_denial_of_service.py
+++ b/precli/rules/python/stdlib/re_denial_of_service.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Inefficient Regular Expression Complexity in `re` Module
 

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Insufficient Token Length
 

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Deserialization of Untrusted Data in the `shelve` Module
 

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Cleartext Transmission of Sensitive Information in the `smtplib` Module
 

--- a/precli/rules/python/stdlib/smtplib_no_timeout.py
+++ b/precli/rules/python/stdlib/smtplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `SMTP` without Timeout
 

--- a/precli/rules/python/stdlib/smtplib_unverified_context.py
+++ b/precli/rules/python/stdlib/smtplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Certificate Validation Using `smtplib`
 

--- a/precli/rules/python/stdlib/socket_no_timeout.py
+++ b/precli/rules/python/stdlib/socket_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `socket` without Timeout
 

--- a/precli/rules/python/stdlib/socket_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socket_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Binding to an Unrestricted IP Address in `socket` Module
 

--- a/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Binding to an Unrestricted IP Address in `socketserver` Module
 

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Inadequate Encryption Strength Using Weak Keys in SSLContext
 

--- a/precli/rules/python/stdlib/ssl_create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl_create_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Improper Certificate Validation Using `ssl._create_unverified_context`
 

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Inadequate Encryption Strength Using Weak SSL Protocols
 

--- a/precli/rules/python/stdlib/ssl_no_timeout.py
+++ b/precli/rules/python/stdlib/ssl_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `ssl` without Timeout
 

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Cleartext Transmission of Sensitive Information in the `telnetlib` Module
 

--- a/precli/rules/python/stdlib/telnetlib_no_timeout.py
+++ b/precli/rules/python/stdlib/telnetlib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Synchronous Access of `Telnet` without Timeout
 

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Insecure Temporary File in the `tempfile` Module
 

--- a/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 r"""
 # Binding to an Unrestricted IP Address in `xmlrpc.server` Module
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 # The format of this file isn't really documented; just use --generate-rcfile
 
 [Messages Control]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 typing-extensions==4.12.2;python_version<"3.11"
 rich==13.9.2
 tree-sitter==0.23.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 [metadata]
 name = precli
 summary = Precaution security static analysis command line

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import setuptools
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 flake8>=4.0.0 # Apache-2.0
 pytest>=8.2.0 # MIT
 pylint>=1.9.4 # GPLv2

--- a/tests/unit/core/test_python.py
+++ b/tests/unit/core/test_python.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 from precli.parsers import python
 
 

--- a/tests/unit/parsers/test_go.py
+++ b/tests/unit/parsers/test_go.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 from precli.core.artifact import Artifact

--- a/tests/unit/parsers/test_python.py
+++ b/tests/unit/parsers/test_python.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_cipher.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_cipher.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_hash.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_key.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/go/stdlib/syscall/test_syscall_setuid_root.py
+++ b/tests/unit/rules/go/stdlib/syscall/test_syscall_setuid_root.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/java/stdlib/java_net/test_insecure_cookie.py
+++ b/tests/unit/rules/java/stdlib/java_net/test_insecure_cookie.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_key.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/java/stdlib/javax_crypto/test_weak_cipher.py
+++ b/tests/unit/rules/java/stdlib/javax_crypto/test_weak_cipher.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/java/stdlib/javax_servlet_http/test_insecure_cookie.py
+++ b/tests/unit/rules/java/stdlib/javax_servlet_http/test_insecure_cookie.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/assert/test_assert.py
+++ b/tests/unit/rules/python/stdlib/assert/test_assert.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/json/test_json_load.py
+++ b/tests/unit/rules/python/stdlib/json/test_json_load.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
+++ b/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
+++ b/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/os/test_os_setuid_root.py
+++ b/tests/unit/rules/python/stdlib/os/test_os_setuid_root.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
+++ b/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
+++ b/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
+++ b/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
+++ b/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
+++ b/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 import pytest

--- a/tests/unit/rules/test_case.py
+++ b/tests/unit/rules/test_case.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 import os
 
 from precli.core.artifact import Artifact

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 # Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
 
 [tox]
 minversion = 3.2.0


### PR DESCRIPTION
Add SPDX license short header to every source file. Also add any missing copyrights if necessary.