### PR TITLE
Add last modified time to the file artifacts

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -265,11 +265,13 @@ def discover_files(targets: list[str], recursive: bool):
                             not preignore_mgr.is_ignored(file_path)
                             and pathlib.Path(path).suffix in FILE_EXTS
                         ):
-                            artifact = Artifact(path)
                             if repo:
-                                artifact.uri = file_to_url(
+                                uri = file_to_url(
                                     owner, repo, branch, target, root, file
                                 )
+                                artifact = Artifact(path, uri)
+                            else:
+                                artifact = Artifact(path)
                             artifacts.append(artifact)
             else:
                 files = os.listdir(path=target)

--- a/precli/core/artifact.py
+++ b/precli/core/artifact.py
@@ -1,5 +1,8 @@
 # Copyright 2024 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
+import os
+from datetime import datetime
+from datetime import timezone
 from typing import Optional
 
 
@@ -11,6 +14,12 @@ class Artifact:
         self._contents = None
         self._encoding = "utf-8"
         self._language = None
+
+        if file_name != "-" or not uri:
+            modified_time = os.path.getmtime(file_name)
+            self._last_modified = datetime.fromtimestamp(
+                modified_time, tz=timezone.utc
+            )
 
     @property
     def file_name(self) -> str:
@@ -61,3 +70,8 @@ class Artifact:
     def language(self, language: str):
         """Set the programming language."""
         self._language = language
+
+    @property
+    def last_modified(self) -> datetime:
+        """The last modified time in UTC for this artifact."""
+        return self._last_modified


### PR DESCRIPTION
For future convenience, this change adds last modified time to each file artifact. In that way, Precaution can potentially avoid re-analysis of files that haven't changed since the last analysis.