### PR TITLE
Change the pattern to match for testing code

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -67,12 +67,13 @@ class Python(Parser):
         """
 
         # TODO: move these constants into configuration options
-        if self.current_symtab.name().startswith("test_"):
-            return True
-
         path = pathlib.Path(self.context["artifact"].file_name)
 
-        return "tests" in path.parts or path.name.startswith("test_")
+        return all(
+            "tests" in path.parts,
+            path.name.startswith("test_"),
+            self.current_symtab.name().startswith("test_"),
+        )
 
     def visit_module(self, nodes: list[Node]):
         self.suppressions = {}


### PR DESCRIPTION
The existing pattern to match whether the code analyzed was testing code was a little too frequent. At the very least it would always match the example code snippets in the tests of precli itself. And we can't have instructions that inform users to run precli against those examples if they always get ignored.

So this change changes the matching algorithm to filter out testing code only if all conditions are met, instead of just one. So the python file needs to be a directory path with "tests", filename beginning with "tests_", and in a function name starting with "test_".

In the future, these checks on whether it is test code or not need to be configurable in a precli configuration file of sorts.