### PR TITLE
Move some configuration into the docs themselves

### DIFF
--- a/precli/core/config.py
+++ b/precli/core/config.py
@@ -9,10 +9,12 @@ class Config:
         enabled: bool = True,
         level: Level = Level.WARNING,
         rank: float = -1.0,
+        parameters: dict = None,
     ):
         self._enabled = enabled
         self._level = level
         self._rank = rank
+        self._parameters = parameters
 
     @property
     def enabled(self) -> bool:
@@ -29,7 +31,22 @@ class Config:
         """The default severity level."""
         return self._level
 
+    @level.setter
+    def level(self, level: Level):
+        """Set the default severity level."""
+        self._level = level
+
     @property
     def rank(self) -> float:
         """The default rank for the rule."""
         return self._rank
+
+    @property
+    def parameters(self) -> dict:
+        """A dictionary of default parameters."""
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters: dict):
+        """Set the dictionary of default parameters."""
+        self._parameters = parameters

--- a/precli/core/result.py
+++ b/precli/core/result.py
@@ -29,7 +29,7 @@ class Result:
         self._artifact = artifact
         self._kind = kind
         rule = Rule.get_by_id(self._rule_id)
-        default_config = rule.default_config if rule else None
+        default_config = rule.config if rule else None
         self._rank = default_config.rank if default_config else -1.0
         if level:
             self._level = level

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -73,8 +73,8 @@ class Json(Renderer):
                 text=rule.short_description
             ),
             default_configuration=sarif_om.ReportingConfiguration(
-                enabled=rule.default_config.enabled,
-                level=rule.default_config.level.name.lower(),
+                enabled=rule.config.enabled,
+                level=rule.config.level.name.lower(),
             ),
             help=sarif_om.MultiformatMessageString(
                 text=rule.full_description, markdown=rule.full_description
@@ -87,7 +87,7 @@ class Json(Renderer):
                     "security",
                     f"external/cwe/cwe-{rule.cwe.id}",
                 ],
-                "security-severity": (rule.default_config.level.to_severity()),
+                "security-severity": (rule.config.level.to_severity()),
             },
         )
 

--- a/precli/rules/go/stdlib/crypto_weak_cipher.py
+++ b/precli/rules/go/stdlib/crypto_weak_cipher.py
@@ -112,6 +112,13 @@ func main() {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -125,8 +132,6 @@ _New in version 0.2.1_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -141,7 +146,6 @@ class WeakCipher(Rule):
             cwe_id=327,
             message="Weak ciphers like '{0}' should be avoided due to their "
             "known vulnerabilities and weaknesses.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call_expression(

--- a/precli/rules/go/stdlib/crypto_weak_hash.py
+++ b/precli/rules/go/stdlib/crypto_weak_hash.py
@@ -62,6 +62,13 @@ func main() {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -76,8 +83,6 @@ _New in version 0.2.1_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -92,7 +97,6 @@ class WeakHash(Rule):
             cwe_id=328,
             message="Use of weak hash function '{0}' does not meet security "
             "expectations.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call_expression(

--- a/precli/rules/go/stdlib/syscall_setuid_root.py
+++ b/precli/rules/go/stdlib/syscall_setuid_root.py
@@ -78,6 +78,13 @@ func main() {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 ## See also
 
 !!! info
@@ -91,8 +98,6 @@ _New in version 0.6.6_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -107,7 +112,6 @@ class SyscallSetuidRoot(Rule):
             cwe_id=250,
             message="The function '{0}(0)' escalates the process to run with "
             "root (superuser) privileges.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call_expression(

--- a/precli/rules/java/stdlib/java_net_insecure_cookie.py
+++ b/precli/rules/java/stdlib/java_net_insecure_cookie.py
@@ -60,6 +60,13 @@ public class HttpCookieSecureFalse {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/java/stdlib/java_security_weak_hash.py
+++ b/precli/rules/java/stdlib/java_security_weak_hash.py
@@ -58,6 +58,20 @@ public class MessageDigestSHA256 {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+parameters.weak_hashes = [
+  "MD2",
+  "MD5",
+  "SHA",
+  "SHA1",
+  "SHA-1",
+]
+```
+
 # See also
 
 !!! info
@@ -71,14 +85,9 @@ _New in version 0.5.0_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
-
-
-WEAK_HASHES = ("MD2", "MD5", "SHA", "SHA1", "SHA-1")
 
 
 class MessageDigestWeakHash(Rule):
@@ -95,7 +104,6 @@ class MessageDigestWeakHash(Rule):
                     "MessageDigest",
                 ],
             },
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_method_invocation(
@@ -109,7 +117,11 @@ class MessageDigestWeakHash(Rule):
         argument = call.get_argument(position=0)
         algorithm = argument.value_str
 
-        if algorithm is None or algorithm.upper() not in WEAK_HASHES:
+        if (
+            algorithm is None
+            or algorithm.upper()
+            not in self.config.parameters.get("weak_hashes")
+        ):
             return
 
         fixes = Rule.get_fixes(

--- a/precli/rules/java/stdlib/java_security_weak_key.py
+++ b/precli/rules/java/stdlib/java_security_weak_key.py
@@ -77,6 +77,15 @@ public class KeyPairGeneratorRSA {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+parameters.warning_key_size = 2048
+parameters.error_key_size = 1024
+```
+
 # See also
 
 !!! info
@@ -119,6 +128,9 @@ class KeyPairGeneratorWeakKey(Rule):
         ]:
             return
 
+        WARN_SIZE = self.config.parameters.get("warning_key_size")
+        ERR_SIZE = self.config.parameters.get("error_key_size")
+
         argument = call.get_argument(position=0)
         keysize = argument.value
 
@@ -133,18 +145,19 @@ class KeyPairGeneratorWeakKey(Rule):
         if algorithm is None or algorithm.upper() not in ("DSA", "RSA"):
             return
 
-        if isinstance(keysize, int) and keysize < 2048:
+        if isinstance(keysize, int) and keysize < WARN_SIZE:
             fixes = Rule.get_fixes(
                 context=context,
                 deleted_location=Location(node=argument.node),
-                description="Use a minimum key size of 2048 for RSA keys.",
-                inserted_content="2048",
+                description=f"Use a minimum key size of {WARN_SIZE} for RSA "
+                "keys.",
+                inserted_content=f"{WARN_SIZE}",
             )
 
             return Result(
                 rule_id=self.id,
                 location=Location(node=argument.node),
-                level=Level.ERROR if keysize <= 1024 else Level.WARNING,
-                message=self.message.format("RSA", 2048),
+                level=Level.ERROR if keysize <= ERR_SIZE else Level.WARNING,
+                message=self.message.format("RSA", WARN_SIZE),
                 fixes=fixes,
             )

--- a/precli/rules/java/stdlib/java_security_weak_random.py
+++ b/precli/rules/java/stdlib/java_security_weak_random.py
@@ -59,6 +59,13 @@ public class StrongRNG {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
+++ b/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
@@ -112,6 +112,22 @@ public class Example {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+parameters.weak_ciphers = [
+  "ARCFOUR",
+  "Blowfish",
+  "DES",
+  "DESede",
+  "RC2",
+  "RC4",
+  "RC5",
+]
+```
+
 # See also
 
 !!! info
@@ -125,14 +141,9 @@ _New in version 0.5.0_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
-
-
-WEAK_CIPHERS = ("ARCFOUR", "Blowfish", "DES", "DESede", "RC2", "RC4", "RC5")
 
 
 class WeakCipher(Rule):
@@ -149,7 +160,6 @@ class WeakCipher(Rule):
                     "Cipher",
                 ],
             },
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_method_invocation(
@@ -168,7 +178,7 @@ class WeakCipher(Rule):
         # DES/CBC/PKCS5Padding
         cipher, *mode_padding = transformation.split("/")
 
-        if cipher not in WEAK_CIPHERS:
+        if cipher not in self.config.parameters.get("weak_ciphers"):
             return
 
         content = "/".join(["AES"] + mode_padding)

--- a/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
+++ b/precli/rules/java/stdlib/javax_servlet_http_insecure_cookie.py
@@ -58,6 +58,13 @@ public class SessionCookie {
 }
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/assert.py
+++ b/precli/rules/python/stdlib/assert.py
@@ -51,6 +51,13 @@ def foobar(a: str = None):
 foobar("World")
 ```
 
+# Default Configuration
+
+```toml
+enabled = false
+level = "warning"
+```
+
 # See also
 
 !!! info
@@ -63,7 +70,6 @@ _New in version 0.3.8_
 """  # noqa: E501
 from typing import Optional
 
-from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -78,7 +84,6 @@ class Assert(Rule):
             cwe_id=703,
             message="Assert statements are disabled when optimizations are "
             "enabled.",
-            config=Config(enabled=False),
         )
 
     def analyze_assert(self, context: dict) -> Optional[Result]:

--- a/precli/rules/python/stdlib/crypt_weak_hash.py
+++ b/precli/rules/python/stdlib/crypt_weak_hash.py
@@ -96,6 +96,13 @@ alternatives include `bcrypt`, `pbkdf2`, and `scrypt`.
    algorithm. Scrypt is designed to be more secure than bcrypt, and it is also
    more resistant to GPU-based attacks.
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 ## See also
 
 !!! info

--- a/precli/rules/python/stdlib/ftplib_cleartext.py
+++ b/precli/rules/python/stdlib/ftplib_cleartext.py
@@ -74,6 +74,13 @@ These alternatives include:
    network protocols, including SSH. Twisted can be used to create secure
    SFTP clients and servers.
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 ## See also
 
 !!! info

--- a/precli/rules/python/stdlib/ftplib_no_timeout.py
+++ b/precli/rules/python/stdlib/ftplib_no_timeout.py
@@ -56,6 +56,13 @@ import ftplib
 ftp_server = ftplib.FTP("ftp.example.com", timeout=5)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/ftplib_unverified_context.py
+++ b/precli/rules/python/stdlib/ftplib_unverified_context.py
@@ -56,6 +56,13 @@ with ftplib.FTP_TLS(
     ftp.retrlines("LIST")
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/hashlib_improper_prng.py
+++ b/precli/rules/python/stdlib/hashlib_improper_prng.py
@@ -56,6 +56,13 @@ salt = os.urandom(16)
 hashlib.scrypt(password, salt=salt, n=16384, r=8, p=1)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/hashlib_weak_hash.py
+++ b/precli/rules/python/stdlib/hashlib_weak_hash.py
@@ -69,6 +69,13 @@ hash = hashlib.md5(b"Non-security related text", usedforsecurity=False)
 hash.hexdigest()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -85,8 +92,6 @@ from typing import Optional
 
 from precli.core.argument import Argument
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -111,7 +116,6 @@ class HashlibWeakHash(Rule):
             cwe_id=328,
             message="The hash function '{0}' is vulnerable to collision and "
             "pre-image attacks.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/hmac_timing_attack.py
+++ b/precli/rules/python/stdlib/hmac_timing_attack.py
@@ -69,6 +69,13 @@ digest = hmac.digest(key, password, digest="sha224")
 print(hmac.compare_digest(digest, received_digest))
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -81,8 +88,6 @@ _New in version 0.1.4_
 from typing import Optional
 
 from precli.core.comparison import Comparison
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -106,7 +111,6 @@ class HmacTimingAttack(Rule):
             cwe_id=208,
             message="Comparing digests with the '{0}' operator is vulnerable "
             "to timing attacks.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_comparison_operator(

--- a/precli/rules/python/stdlib/hmac_weak_hash.py
+++ b/precli/rules/python/stdlib/hmac_weak_hash.py
@@ -60,6 +60,13 @@ message = b"Hello, world!"
 hmac.new(key, msg=message, digestmod="sha256")
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -75,8 +82,6 @@ _Changed in version 0.4.1: Added md5-sha1_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -101,7 +106,6 @@ class HmacWeakHash(Rule):
             cwe_id=328,
             message="The hash function '{0}' is vulnerable to collision and "
             "pre-image attacks.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/hmac_weak_key.py
+++ b/precli/rules/python/stdlib/hmac_weak_key.py
@@ -57,6 +57,13 @@ message = b"Hello, world!"
 hmac.new(key, msg=message, digestmod=hashlib.sha3_384)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/http_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/http_server_unrestricted_bind.py
@@ -63,6 +63,13 @@ if __name__ == "__main__":
     run(HTTPServer)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -50,6 +50,20 @@ conn.request("GET", "/path?otherParam=123", headers=headers)
 response = conn.getresponse()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+parameters.sensitive_params = [
+  "apiKey",
+  "pass",
+  "password",
+  "user",
+  "username",
+]
+```
+
 # See also
 
 !!! info
@@ -65,14 +79,9 @@ from urllib.parse import parse_qs
 from urllib.parse import urlsplit
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
-
-
-SENSITIVE_PARAMS = ("apiKey", "pass", "password", "user", "username")
 
 
 class HttpUrlSecret(Rule):
@@ -83,7 +92,6 @@ class HttpUrlSecret(Rule):
             description=__doc__,
             cwe_id=598,
             message="Secrets in URLs are vulnerable to unauthorized access.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:
@@ -103,7 +111,8 @@ class HttpUrlSecret(Rule):
         params = parse_qs(query)
 
         if split_url.username or any(
-            key in params for key in SENSITIVE_PARAMS
+            key in params
+            for key in self.config.parameters.get("sensitive_params")
         ):
             return Result(
                 rule_id=self.id,

--- a/precli/rules/python/stdlib/imaplib_cleartext.py
+++ b/precli/rules/python/stdlib/imaplib_cleartext.py
@@ -60,6 +60,13 @@ M.close()
 M.logout()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -72,8 +79,6 @@ _New in version 0.1.9_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -88,7 +93,6 @@ class ImapCleartext(Rule):
             cwe_id=319,
             message="The IMAP protocol can transmit data in cleartext without "
             "encryption.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/imaplib_no_timeout.py
+++ b/precli/rules/python/stdlib/imaplib_no_timeout.py
@@ -59,6 +59,13 @@ imap = imaplib.IMAP4("imap.example.com", timeout=5)
 imap.starttls(ssl.create_default_context())
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/imaplib_unverified_context.py
+++ b/precli/rules/python/stdlib/imaplib_unverified_context.py
@@ -66,6 +66,13 @@ imap4.close()
 imap4.logout()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/json_load.py
+++ b/precli/rules/python/stdlib/json_load.py
@@ -32,6 +32,13 @@ To avoid this vulnerability, it is important to only parse JSON data from
 trusted sources. If you are parsing JSON data from an untrusted source, you
 should first sanitize the data to remove any potential malicious code.
 
+# Default Configuration
+
+```toml
+enabled = false
+level = "warning"
+```
+
 # See also
 
 !!! info
@@ -44,7 +51,6 @@ _New in version 0.1.0_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -59,7 +65,6 @@ class JsonLoad(Rule):
             cwe_id=502,
             message="Potential unsafe usage of '{0}' that can allow "
             "instantiation of arbitrary objects.",
-            config=Config(enabled=False),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/logging_insecure_listen_config.py
+++ b/precli/rules/python/stdlib/logging_insecure_listen_config.py
@@ -44,6 +44,13 @@ def validate(recv: bytes):
 thread = logging.config.listen(verify=validate)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/marshal_load.py
+++ b/precli/rules/python/stdlib/marshal_load.py
@@ -37,6 +37,13 @@ To avoid this vulnerability, it is important to only deserialize data from
 trusted sources. If you are deserializing data from an untrusted source,
 you should first sanitize the data to remove any potential malicious code.
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/nntplib_cleartext.py
+++ b/precli/rules/python/stdlib/nntplib_cleartext.py
@@ -46,6 +46,13 @@ with nntplib.NNTP_SSL('news.gmane.io') as n:
     n.group('gmane.comp.python.committers')
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -58,8 +65,6 @@ _New in version 0.1.9_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -74,7 +79,6 @@ class NntpCleartext(Rule):
             cwe_id=319,
             message="The NNTP protocol can transmit data in cleartext without "
             "encryption.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/nntplib_no_timeout.py
+++ b/precli/rules/python/stdlib/nntplib_no_timeout.py
@@ -59,6 +59,13 @@ nntp = nntplib.NNTP("nntp.example.com", timeout=5)
 nntp.starttls(ssl.create_default_context())
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/nntplib_unverified_context.py
+++ b/precli/rules/python/stdlib/nntplib_unverified_context.py
@@ -56,6 +56,13 @@ s.post(f)
 s.quit()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/os_loose_file_perm.py
+++ b/precli/rules/python/stdlib/os_loose_file_perm.py
@@ -72,6 +72,14 @@ os.chmod(
 )
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+parameters.umask = 0o022
+```
+
 ## See also
 
 !!! info
@@ -99,7 +107,6 @@ DEFAULT_MODE = {
     "os.mkfifo": 0o666,
     "os.mknod": 0o600,
 }
-UMASK = 0o022
 
 
 class OsLooseFilePermissions(Rule):
@@ -165,6 +172,8 @@ class OsLooseFilePermissions(Rule):
             location = Location(node=argument.node)
             message = self.message
         elif call.name_qualified in ("os.mkdir", "os.open", "os.mkfifo"):
+            UMASK = self.config.parameters.get("umask")
+
             if argument.node is not None and isinstance(mode, int):
                 # mode argument passed
                 location = Location(node=argument.node)

--- a/precli/rules/python/stdlib/os_setuid_root.py
+++ b/precli/rules/python/stdlib/os_setuid_root.py
@@ -54,6 +54,13 @@ import os
 os.setuid(1000)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 ## See also
 
 !!! info
@@ -67,8 +74,6 @@ _New in version 0.6.6_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -83,7 +88,6 @@ class OsSetuidRoot(Rule):
             cwe_id=250,
             message="The function '{0}(0)' escalates the process to run with "
             "root (superuser) privileges.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/pathlib_loose_file_perm.py
+++ b/precli/rules/python/stdlib/pathlib_loose_file_perm.py
@@ -72,6 +72,14 @@ file_path.chmod(
 )
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+parameters.umask = 0o022
+```
+
 ## See also
 
 !!! info
@@ -97,7 +105,6 @@ DEFAULT_MODE = {
     "pathlib.Path.mkdir": 0o777,
     "pathlib.Path.touch": 0o666,
 }
-UMASK = 0o022
 
 
 class PathlibLooseFilePermissions(Rule):
@@ -164,6 +171,8 @@ class PathlibLooseFilePermissions(Rule):
             "pathlib.Path.mkdir",
             "pathlib.Path.touch",
         ):
+            UMASK = self.config.parameters.get("umask")
+
             if argument.node is not None and isinstance(mode, int):
                 # mode argument passed
                 location = Location(node=argument.node)

--- a/precli/rules/python/stdlib/pickle_load.py
+++ b/precli/rules/python/stdlib/pickle_load.py
@@ -48,6 +48,13 @@ Alternatively if you need to serialize sensitive data, you could use a
 secure serialization format, such as JSON or XML. These formats are designed
 to be secure and cannot be used to execute malicious code.
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/poplib_cleartext.py
+++ b/precli/rules/python/stdlib/poplib_cleartext.py
@@ -55,6 +55,13 @@ for i in range(numMessages):
         print(j)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -67,8 +74,6 @@ _New in version 0.1.9_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -83,7 +88,6 @@ class PopCleartext(Rule):
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/poplib_no_timeout.py
+++ b/precli/rules/python/stdlib/poplib_no_timeout.py
@@ -59,6 +59,13 @@ pop = poplib.POP3("mail.my-mail-server.com", timeout=5)
 pop.stls(ssl.create_default_context())
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/poplib_unverified_context.py
+++ b/precli/rules/python/stdlib/poplib_unverified_context.py
@@ -62,6 +62,13 @@ for i in range(numMessages):
         print(j)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/re_denial_of_service.py
+++ b/precli/rules/python/stdlib/re_denial_of_service.py
@@ -50,6 +50,13 @@ reg = re.compile(IPv6address)
 reg.search("http://[:::::::::::::::::::::::::::::::::::::::]/path")
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -64,8 +71,6 @@ from typing import Optional
 
 from precli.core import redos
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -81,7 +86,6 @@ class ReDenialOfService(Rule):
             message="The call to '{0}'' with regex pattern '{1}'' is "
             "susceptible to catastrophic backtracking and may cause "
             "performance degradation.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/shelve_open.py
+++ b/precli/rules/python/stdlib/shelve_open.py
@@ -36,6 +36,13 @@ with data from trusted sources. If you are using the shelve module with
 data from an untrusted source, you should first sanitize the data to remove
 any potential malicious code.
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/smtplib_cleartext.py
+++ b/precli/rules/python/stdlib/smtplib_cleartext.py
@@ -91,6 +91,13 @@ server.sendmail(fromaddr, toaddrs, msg)
 server.quit()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -103,8 +110,6 @@ _New in version 0.1.9_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -119,7 +124,6 @@ class SmtpCleartext(Rule):
             cwe_id=319,
             message="The POP protocol can transmit data in cleartext without "
             "encryption.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/smtplib_no_timeout.py
+++ b/precli/rules/python/stdlib/smtplib_no_timeout.py
@@ -60,6 +60,13 @@ server = smtplib.SMTP("smtp.example.com", 587, timeout=10)
 server.starttls(context=ssl.create_default_context())
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/smtplib_unverified_context.py
+++ b/precli/rules/python/stdlib/smtplib_unverified_context.py
@@ -98,6 +98,13 @@ server.sendmail(fromaddr, toaddrs, msg)
 server.quit()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/socket_no_timeout.py
+++ b/precli/rules/python/stdlib/socket_no_timeout.py
@@ -57,6 +57,13 @@ s.recv(1024)
 s.close()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/socket_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socket_unrestricted_bind.py
@@ -53,6 +53,13 @@ s.bind(("127.0.0.1", 8080))
 s.listen()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/socketserver_unrestricted_bind.py
@@ -67,6 +67,13 @@ with socketserver.UDPServer((HOST, PORT), MyUDPHandler) as server:
     server.serve_forever()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/ssl_create_unverified_context.py
+++ b/precli/rules/python/stdlib/ssl_create_unverified_context.py
@@ -46,6 +46,13 @@ import ssl
 context = ssl.create_default_context()
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/ssl_insecure_tls_version.py
+++ b/precli/rules/python/stdlib/ssl_insecure_tls_version.py
@@ -59,6 +59,13 @@ import ssl
 ssl.get_server_certificate(("localhost", 443), ssl_version=ssl.PROTOCOL_TLSv1_2)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -72,8 +79,6 @@ from typing import Optional
 
 from precli.core.argument import Argument
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -95,7 +100,6 @@ class InsecureTlsVersion(Rule):
             description=__doc__,
             cwe_id=326,
             message="The '{0}' protocol has insufficient encryption strength.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/ssl_no_timeout.py
+++ b/precli/rules/python/stdlib/ssl_no_timeout.py
@@ -52,6 +52,13 @@ import ssl
 cert = ssl.get_server_certificate(("example.com", 443), timeout=5)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/telnetlib_cleartext.py
+++ b/precli/rules/python/stdlib/telnetlib_cleartext.py
@@ -96,6 +96,13 @@ These alternatives include:
    network protocols, including SSH. Twisted can be used to create secure
    SSH clients and servers.
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "error"
+```
+
 # See also
 
 !!! info
@@ -110,8 +117,6 @@ _New in version 0.1.0_
 from typing import Optional
 
 from precli.core.call import Call
-from precli.core.config import Config
-from precli.core.level import Level
 from precli.core.location import Location
 from precli.core.result import Result
 from precli.rules import Rule
@@ -126,7 +131,6 @@ class TelnetlibCleartext(Rule):
             cwe_id=319,
             message="The '{0}' module transmits data in cleartext without "
             "encryption.",
-            config=Config(level=Level.ERROR),
         )
 
     def analyze_call(self, context: dict, call: Call) -> Optional[Result]:

--- a/precli/rules/python/stdlib/telnetlib_no_timeout.py
+++ b/precli/rules/python/stdlib/telnetlib_no_timeout.py
@@ -54,6 +54,13 @@ import telnetlib
 telnet = telnetlib.Telnet("example.com", 23, timeout=5)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
+++ b/precli/rules/python/stdlib/tempfile_mktemp_race_condition.py
@@ -49,6 +49,13 @@ with open(
     f.write(b"Hello World!\n")
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
+++ b/precli/rules/python/stdlib/xmlrpc_server_unrestricted_bind.py
@@ -63,6 +63,13 @@ if __name__ == "__main__":
     run(DocXMLRPCServer)
 ```
 
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
 # See also
 
 !!! info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Copyright 2024 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
 typing-extensions==4.12.2;python_version<"3.11"
+tomli>=1.1.0; python_version<"3.11"
 rich==13.9.3
 tree-sitter==0.23.1
 ignorelib==0.3.0

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_cipher.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_cipher.py
@@ -33,9 +33,9 @@ class TestCryptoWeakCipher(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 327
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_hash.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_hash.py
@@ -33,9 +33,9 @@ class TestCryptoWeakHash(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 328
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_key.py
+++ b/tests/unit/rules/go/stdlib/crypto/test_crypto_weak_key.py
@@ -33,9 +33,9 @@ class TestCryptoWeakKey(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/go/stdlib/syscall/test_syscall_setuid_root.py
+++ b/tests/unit/rules/go/stdlib/syscall/test_syscall_setuid_root.py
@@ -33,9 +33,9 @@ class TestSyscallSetuidRoot(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 250
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/java/stdlib/java_net/test_insecure_cookie.py
+++ b/tests/unit/rules/java/stdlib/java_net/test_insecure_cookie.py
@@ -33,9 +33,9 @@ class TestInsecureCookie(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 614
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_hash.py
@@ -33,9 +33,9 @@ class TestMessageDigestWeakHash(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 328
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_key.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_key.py
@@ -33,9 +33,9 @@ class TestKeyPairGeneratorWeakkey(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
+++ b/tests/unit/rules/java/stdlib/java_security/test_weak_random.py
@@ -33,9 +33,9 @@ class TestSecureRandomWeakRandom(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 338
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/java/stdlib/javax_crypto/test_weak_cipher.py
+++ b/tests/unit/rules/java/stdlib/javax_crypto/test_weak_cipher.py
@@ -33,9 +33,9 @@ class TestWeakCipher(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 327
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/java/stdlib/javax_servlet_http/test_insecure_cookie.py
+++ b/tests/unit/rules/java/stdlib/javax_servlet_http/test_insecure_cookie.py
@@ -33,9 +33,9 @@ class TestInsecureCookie(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 614
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
+++ b/tests/unit/rules/python/stdlib/argparse/test_argparse_sensitive_info.py
@@ -33,9 +33,9 @@ class TestArgparseSensitiveInfo(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 214
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/assert/test_assert.py
+++ b/tests/unit/rules/python/stdlib/assert/test_assert.py
@@ -33,9 +33,9 @@ class TestAssert(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is False
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is False
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 703
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/crypt/test_crypt_weak_hash.py
@@ -33,9 +33,9 @@ class TestCryptWeakHash(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 328
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_cleartext.py
@@ -34,9 +34,9 @@ class TestFtpCleartext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 319
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_no_timeout.py
@@ -33,9 +33,9 @@ class TestFtplibNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/ftplib/test_ftplib_unverified_context.py
@@ -33,9 +33,9 @@ class TestFtplibUnverifiedContext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 295
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_improper_prng.py
@@ -33,9 +33,9 @@ class TestHashlibImproperPrng(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 330
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hashlib/test_hashlib_weak_hash.py
@@ -33,9 +33,9 @@ class TestHashlibWeakHash(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 328
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_timing_attack.py
@@ -33,9 +33,9 @@ class TestHmacTimingAttack(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 208
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_hash.py
@@ -33,9 +33,9 @@ class TestHmacWeakHash(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 328
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
+++ b/tests/unit/rules/python/stdlib/hmac/test_hmac_weak_key.py
@@ -33,9 +33,9 @@ class TestHmacWeakKey(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_server_unrestricted_bind.py
@@ -33,9 +33,9 @@ class TestHttpServerUnrestrictedBind(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1327
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
+++ b/tests/unit/rules/python/stdlib/http/test_http_url_secret.py
@@ -33,9 +33,9 @@ class TestHttpUrlSecret(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 598
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_cleartext.py
@@ -33,9 +33,9 @@ class TestImapCleartext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 319
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_no_timeout.py
@@ -33,9 +33,9 @@ class TestImaplibNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/imaplib/test_imaplib_unverified_context.py
@@ -33,9 +33,9 @@ class TestImaplibUnverifiedContext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 295
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/json/test_json_load.py
+++ b/tests/unit/rules/python/stdlib/json/test_json_load.py
@@ -33,9 +33,9 @@ class TestJsonLoad(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is False
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is False
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 502
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
+++ b/tests/unit/rules/python/stdlib/logging/test_logging_insecure_listen_config.py
@@ -33,9 +33,9 @@ class TestInsecureListenConfig(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 94
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
+++ b/tests/unit/rules/python/stdlib/marshal/test_marshal_load.py
@@ -33,9 +33,9 @@ class TestMarshalLoad(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 502
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_cleartext.py
@@ -33,9 +33,9 @@ class TestNntpCleartext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 319
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_no_timeout.py
@@ -33,9 +33,9 @@ class TestNntplibNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/nntplib/test_nntplib_unverified_context.py
@@ -33,9 +33,9 @@ class TestNntplibUnverifiedContext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 295
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/os/test_os_loose_file_perm.py
@@ -33,9 +33,9 @@ class TestOsLooseFilePermissions(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 732
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/os/test_os_setuid_root.py
+++ b/tests/unit/rules/python/stdlib/os/test_os_setuid_root.py
@@ -33,9 +33,9 @@ class TestOsSetuidRoot(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 250
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
+++ b/tests/unit/rules/python/stdlib/pathlib/test_pathlib_loose_file_perm.py
@@ -33,9 +33,9 @@ class TestPathlibLooseFilePermissions(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 732
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
+++ b/tests/unit/rules/python/stdlib/pickle/test_pickle_load.py
@@ -33,9 +33,9 @@ class TestPickleLoad(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 502
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_cleartext.py
@@ -33,9 +33,9 @@ class TestPopCleartext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 319
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_no_timeout.py
@@ -33,9 +33,9 @@ class TestPoplibNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/poplib/test_poplib_unverified_context.py
@@ -33,9 +33,9 @@ class TestPoplibUnverifiedContext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 295
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
+++ b/tests/unit/rules/python/stdlib/re/test_re_denial_of_service.py
@@ -33,9 +33,9 @@ class TestReDenialOfService(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1333
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
+++ b/tests/unit/rules/python/stdlib/secrets/test_secrets_weak_token.py
@@ -33,9 +33,9 @@ class TestSecretsWeakToken(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
+++ b/tests/unit/rules/python/stdlib/shelve/test_shelve_open.py
@@ -33,9 +33,9 @@ class TestShelveOpen(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 502
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_cleartext.py
@@ -33,9 +33,9 @@ class TestSmtpCleartext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 319
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_no_timeout.py
@@ -33,9 +33,9 @@ class TestSmtplibNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
+++ b/tests/unit/rules/python/stdlib/smtplib/test_smtplib_unverified_context.py
@@ -33,9 +33,9 @@ class TestSmtplibUnverifiedContext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 295
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_no_timeout.py
@@ -33,9 +33,9 @@ class TestSocketNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socket/test_socket_unrestricted_bind.py
@@ -33,9 +33,9 @@ class TestSocketUnrestrictedBind(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1327
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/socketserver/test_socketserver_unrestricted_bind.py
@@ -33,9 +33,9 @@ class TestSocketserverUnrestrictedBind(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1327
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_tls_version.py
@@ -33,9 +33,9 @@ class TestSslSocketTlsVersion(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_context_weak_key.py
@@ -33,9 +33,9 @@ class TestSslSocketWeakKey(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_create_context.py
@@ -33,9 +33,9 @@ class TestSslCreateContext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 295
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_get_server_certificate_tls_version.py
@@ -33,9 +33,9 @@ class TestGetServerCertificate(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_no_timeout.py
@@ -33,9 +33,9 @@ class TestSslNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
+++ b/tests/unit/rules/python/stdlib/ssl/test_ssl_wrap_socket_tls_version.py
@@ -33,9 +33,9 @@ class TestWrapSocket(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 326
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_cleartext.py
@@ -33,9 +33,9 @@ class TestTelnetlibCleartext(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.ERROR
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.ERROR
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 319
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
+++ b/tests/unit/rules/python/stdlib/telnetlib/test_telnetlib_no_timeout.py
@@ -33,9 +33,9 @@ class TestTelnetlibNoTimeout(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1088
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
+++ b/tests/unit/rules/python/stdlib/tempfile/test_tempfile_mktemp_race_condition.py
@@ -33,9 +33,9 @@ class TestMktempRaceCondition(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 377
 
     @pytest.mark.parametrize(

--- a/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
+++ b/tests/unit/rules/python/stdlib/xmlrpc/test_xmlrpc_server_unrestricted_bind.py
@@ -33,9 +33,9 @@ class TestXmlrpcServerUnrestrictedBind(test_case.TestCase):
             rule.help_url
             == f"https://docs.securesauce.dev/rules/{self.rule_id}"
         )
-        assert rule.default_config.enabled is True
-        assert rule.default_config.level == Level.WARNING
-        assert rule.default_config.rank == -1.0
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
         assert rule.cwe.id == 1327
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
For convenience and for more clarity to end users, having the configuration in the docs themselves can aid how each rule is configured.

Later, when precli handles a configuration file mechanism, a user can customize rules based on this config noted in the docs in each rule.