### PR TITLE
Slight naming change to the weak key rules config

### DIFF
--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -124,8 +124,10 @@ func main() {
 ```toml
 enabled = true
 level = "warning"
-parameters.warning_key_size = 2048
-parameters.error_key_size = 1024
+parameters.warning_dsa_key_size = 2048
+parameters.error_dsa_key_size = 1024
+parameters.warning_rsa_key_size = 2048
+parameters.error_rsa_key_size = 1024
 ```
 
 # See also
@@ -161,10 +163,10 @@ class WeakKey(Rule):
     def analyze_call_expression(
         self, context: dict, call: Call
     ) -> Optional[Result]:
-        WARN_SIZE = self.config.parameters.get("warning_key_size")
-        ERR_SIZE = self.config.parameters.get("error_key_size")
-
         if call.name_qualified in ["crypto/dsa.GenerateParameters"]:
+            WARN_SIZE = self.config.parameters.get("warning_dsa_key_size")
+            ERR_SIZE = self.config.parameters.get("error_dsa_key_size")
+
             argument = call.get_argument(position=2)
             sizes = argument.value
 
@@ -185,6 +187,9 @@ class WeakKey(Rule):
                     fixes=fixes,
                 )
         elif call.name_qualified in ["crypto/rsa.GenerateKey"]:
+            WARN_SIZE = self.config.parameters.get("warning_rsa_key_size")
+            ERR_SIZE = self.config.parameters.get("error_rsa_key_size")
+
             argument = call.get_argument(position=1)
             bits = argument.value
 

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -54,8 +54,8 @@ context.set_ecdh_curve("prime256v1")
 ```toml
 enabled = true
 level = "warning"
-parameters.warning_key_size = 224
-parameters.error_key_size = 160
+parameters.warning_ec_key_size = 224
+parameters.error_ec_key_size = 160
 ```
 
 # See also
@@ -97,8 +97,8 @@ class SslContextWeakKey(Rule):
         ]:
             return
 
-        WARN_SIZE = self.config.parameters.get("warning_key_size")
-        ERR_SIZE = self.config.parameters.get("error_key_size")
+        WARN_SIZE = self.config.parameters.get("warning_ec_key_size")
+        ERR_SIZE = self.config.parameters.get("error_ec_key_size")
 
         arg = call.get_argument(position=0, name="curve_name")
         curve_name = arg.value


### PR DESCRIPTION
To be more consistent, this commit changes the config names of some of the weak key parameters. This enables customization based on the algorithm, RSA, DSA, EC the thresholds on the key size.