### PR TITLE
Command line to create a .precli.toml default config file

### DIFF
--- a/precli/cli/init.py
+++ b/precli/cli/init.py
@@ -1,0 +1,72 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
+import argparse
+import sys
+from argparse import Namespace
+
+import tomli_w
+
+from precli.core import loader
+
+
+def setup_arg_parser() -> Namespace:
+    parser = argparse.ArgumentParser(
+        description="precli-init - create default configuration file",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        action="store",
+        default=".precli.toml",
+        help="output the config to given file",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def get_config() -> dict:
+    parsers = loader.load_extension(group="precli.parsers")
+    rules = [r for p in parsers.values() for r in p.rules.values()]
+
+    config = {"rule": {}}
+
+    for rule in rules:
+        config["rule"][rule.id] = {
+            "enabled": rule.config.enabled,
+            "level": rule.config.level,
+        }
+        if rule.config.parameters:
+            for parameter, value in rule.config.parameters.items():
+                config["rule"][rule.id][parameter] = value
+
+    return config
+
+
+def main():
+    # Setup the command line arguments
+    args = setup_arg_parser()
+
+    # Fetch the default configuration
+    config = get_config()
+
+    # Write to the given file
+    try:
+        # TODO: check if file already exists and prompt to overwrite
+        with open(args.output, "wb") as f:
+            tomli_w.dump(config, f)
+    except OSError:
+        print(f"Error writing to file: {args.output}")
+        return 1
+    else:
+        print(f"Default config written to file: {args.output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -58,7 +58,10 @@ class Rule(ABC):
                 self._config = Config()
                 self._config.enabled = metadata.get("enabled")
                 self._config.level = Level(metadata.get("level"))
-                self._config.parameters = metadata.get("parameters")
+                self._config.parameters = {}
+                for parameter, value in metadata.items():
+                    if parameter not in ("enabled", "level"):
+                        self._config.parameters[parameter] = value
             except tomllib.TOMLDecodeError as err:
                 print(err)
                 print("Invalid config in documentation")

--- a/precli/rules/go/stdlib/crypto_weak_key.py
+++ b/precli/rules/go/stdlib/crypto_weak_key.py
@@ -124,10 +124,10 @@ func main() {
 ```toml
 enabled = true
 level = "warning"
-parameters.warning_dsa_key_size = 2048
-parameters.error_dsa_key_size = 1024
-parameters.warning_rsa_key_size = 2048
-parameters.error_rsa_key_size = 1024
+warning_dsa_key_size = 2048
+error_dsa_key_size = 1024
+warning_rsa_key_size = 2048
+error_rsa_key_size = 1024
 ```
 
 # See also

--- a/precli/rules/java/stdlib/java_security_weak_hash.py
+++ b/precli/rules/java/stdlib/java_security_weak_hash.py
@@ -63,7 +63,7 @@ public class MessageDigestSHA256 {
 ```toml
 enabled = true
 level = "error"
-parameters.weak_hashes = [
+weak_hashes = [
   "MD2",
   "MD5",
   "SHA",

--- a/precli/rules/java/stdlib/java_security_weak_key.py
+++ b/precli/rules/java/stdlib/java_security_weak_key.py
@@ -82,8 +82,8 @@ public class KeyPairGeneratorRSA {
 ```toml
 enabled = true
 level = "warning"
-parameters.warning_key_size = 2048
-parameters.error_key_size = 1024
+warning_key_size = 2048
+error_key_size = 1024
 ```
 
 # See also

--- a/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
+++ b/precli/rules/java/stdlib/javax_crypto_weak_cipher.py
@@ -117,7 +117,7 @@ public class Example {
 ```toml
 enabled = true
 level = "error"
-parameters.weak_ciphers = [
+weak_ciphers = [
   "ARCFOUR",
   "Blowfish",
   "DES",

--- a/precli/rules/python/stdlib/argparse_sensitive_info.py
+++ b/precli/rules/python/stdlib/argparse_sensitive_info.py
@@ -70,7 +70,7 @@ parser.add_argument(
 ```toml
 enabled = true
 level = "error"
-parameters.sensitive_arguments = [
+sensitive_arguments = [
   "--api-key",
   "--password",
   "--token"

--- a/precli/rules/python/stdlib/http_url_secret.py
+++ b/precli/rules/python/stdlib/http_url_secret.py
@@ -55,7 +55,7 @@ response = conn.getresponse()
 ```toml
 enabled = true
 level = "error"
-parameters.sensitive_params = [
+sensitive_params = [
   "apiKey",
   "pass",
   "password",

--- a/precli/rules/python/stdlib/os_loose_file_perm.py
+++ b/precli/rules/python/stdlib/os_loose_file_perm.py
@@ -77,7 +77,7 @@ os.chmod(
 ```toml
 enabled = true
 level = "warning"
-parameters.umask = 0o022
+umask = 0o022
 ```
 
 ## See also

--- a/precli/rules/python/stdlib/pathlib_loose_file_perm.py
+++ b/precli/rules/python/stdlib/pathlib_loose_file_perm.py
@@ -77,7 +77,7 @@ file_path.chmod(
 ```toml
 enabled = true
 level = "warning"
-parameters.umask = 0o022
+umask = 0o022
 ```
 
 ## See also

--- a/precli/rules/python/stdlib/secrets_weak_token.py
+++ b/precli/rules/python/stdlib/secrets_weak_token.py
@@ -50,8 +50,8 @@ token = secrets.token_bytes()
 ```toml
 enabled = true
 level = "warning"
-parameters.warning_token_size = 32
-parameters.error_token_size = 16
+warning_token_size = 32
+error_token_size = 16
 ```
 
 # See also

--- a/precli/rules/python/stdlib/ssl_context_weak_key.py
+++ b/precli/rules/python/stdlib/ssl_context_weak_key.py
@@ -54,8 +54,8 @@ context.set_ecdh_curve("prime256v1")
 ```toml
 enabled = true
 level = "warning"
-parameters.warning_ec_key_size = 224
-parameters.error_ec_key_size = 160
+warning_ec_key_size = 224
+error_ec_key_size = 160
 ```
 
 # See also

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Copyright 2024 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
 typing-extensions==4.12.2;python_version<"3.11"
-tomli>=1.1.0; python_version<"3.11"
+tomli==1.1.0; python_version<"3.11"
+tomli_w==1.1.0
 rich==13.9.3
 tree-sitter==0.23.2
 ignorelib==0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ project_urls =
 [entry_points]
 console_scripts =
     precli = precli.cli.main:main
+    precli-init = precli.cli.init:main
 
 precli.renderers =
     # precli/renderers/detailed.py


### PR DESCRIPTION
This new CLI enables a user to create a default config file (default to .precli.toml) in the current directory.

This config file is available for users to customize the precli tool and its rules.