### PR TITLE
Fix CLI fails when running on the tests

### DIFF
--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -70,9 +70,11 @@ class Python(Parser):
         path = pathlib.Path(self.context["artifact"].file_name)
 
         return all(
-            "tests" in path.parts,
-            path.name.startswith("test_"),
-            self.current_symtab.name().startswith("test_"),
+            [
+                "tests" in path.parts,
+                path.name.startswith("test_"),
+                self.current_symtab.name().startswith("test_"),
+            ]
         )
 
     def visit_module(self, nodes: list[Node]):


### PR DESCRIPTION
Running:
  precli -r tests

Yields the following error:

  TypeError: all() takes exactly one argument (3 given)

The recent change to is_test_code() is not using a collection passed to the all() function.