### PR TITLE
Honor all configuration passed via toml files

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -392,7 +392,7 @@ def main():
     )
 
     # Invoke the run
-    run = Run(config["enabled"], config["disabled"], artifacts, debug)
+    run = Run(config, artifacts, debug)
     run.invoke()
 
     # Render the results

--- a/tests/unit/rules/test_case.py
+++ b/tests/unit/rules/test_case.py
@@ -43,7 +43,11 @@ class TestCase:
             end_column,
         ) = self.expected(filename)
         artifact = Artifact(os.path.join(self.base_path, filename))
-        results = self.parser.parse(artifact, enabled, disabled)
+        config = {
+            "enabled": enabled,
+            "disabled": disabled,
+        }
+        results = self.parser.parse(artifact, config)
         if level == Level.NONE:
             assert len(results) == 0
         else:


### PR DESCRIPTION
This change fully implements the processing of custom configuration given via toml files. So in effect, not just the enabled or disabled, but also the level and parameters can be overwritten.