### PR TITLE
Add validation on the specified output file

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -168,11 +168,21 @@ def setup_arg_parser():
                 f"argument -c/--config: can't load '{args.config.name}': {err}"
             )
 
+    if args.output:
+        path = pathlib.Path(args.output.name)
+        if path.exists():
+            overwrite = input(
+                f"The file '{path}' already exists. Overwrite? (y/N): "
+            )
+            if overwrite.lower() != "y":
+                print("Operation cancelled.")
+                sys.exit(1)
+
     if not args.targets:
         parser.print_usage()
         sys.exit(2)
 
-    return args, args.config
+    return args
 
 
 def find_config(targets: list[str]) -> dict:
@@ -376,11 +386,13 @@ def main():
     logging.getLogger("urllib3").setLevel(debug)
 
     # Setup the command line arguments
-    args, config = setup_arg_parser()
+    args = setup_arg_parser()
 
     # Attempt to find config files if one not provided
-    if not config:
+    if not args.config:
         config = find_config(args.targets)
+    else:
+        config = args.config
 
     # CLI enabled/disabled override any config in files
     config["enabled"] = (

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -45,3 +45,21 @@ class TestMain:
         with pytest.raises(SystemExit) as excinfo:
             main.main()
         assert str(excinfo.value) == "2"
+
+    @mock.patch("sys.argv", ["precli", "-o", "../does/not/exists"])
+    def test_main_invalid_output(self):
+        with pytest.raises(SystemExit) as excinfo:
+            main.main()
+        assert str(excinfo.value) == "2"
+
+    @mock.patch("sys.argv", ["precli", "-o", "output.txt"])
+    @mock.patch("builtins.input", lambda _: "no")
+    def test_main_output_already_exists(self):
+        temp_dir = tempfile.mkdtemp()
+        os.chdir(temp_dir)
+        with open("output.txt", "w") as fd:
+            fd.write("This file already exists. Do not overwrite.")
+
+        with pytest.raises(SystemExit) as excinfo:
+            main.main()
+        assert str(excinfo.value) == "1"


### PR DESCRIPTION
A user should be prompted if they attempt to overwrite an existing file that was specified as part of the -o output file.

There should also be unit testing around this behavior.