### PR TITLE
Add unit test of the version argument to the CLI

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -63,7 +63,7 @@ def setup_arg_parser():
         metavar="targets",
         type=str,
         nargs="*",
-        help="source file(s) or directory(s) to be tested",
+        help="source file(s) or directory(s) to be analyzed",
     )
     parser.add_argument(
         "-r",


### PR DESCRIPTION
This change introduces unit test function for the output of the "precli --version" command.