### PR TITLE
Add unit test for precli-init command

### DIFF
--- a/precli/cli/init.py
+++ b/precli/cli/init.py
@@ -25,11 +25,23 @@ def setup_arg_parser() -> Namespace:
         "--output",
         dest="output",
         action="store",
+        type=argparse.FileType("w", encoding="utf-8"),
         default=".precli.toml",
         help="output the config to given file",
     )
+    args = parser.parse_args()
 
-    return parser.parse_args()
+    if args.output:
+        path = pathlib.Path(args.output.name)
+        if path.exists():
+            overwrite = input(
+                f"The file '{path}' already exists. Overwrite? (y/N): "
+            )
+            if overwrite.lower() != "y":
+                print("Operation cancelled.")
+                sys.exit(1)
+
+    return args
 
 
 def get_config() -> dict:
@@ -68,15 +80,6 @@ def main():
     # Write to the given file
     try:
         path = pathlib.Path(args.output)
-
-        # Check if the file already exists and prompt for overwrite
-        if path.exists():
-            overwrite = input(
-                f"The file '{args.output}' already exists. Overwrite? (y/N): "
-            )
-            if overwrite.lower() != "y":
-                print("Operation cancelled.")
-                return 1
 
         # Check if the target file is pyproject.toml and prepare the structure
         if path.name == "pyproject.toml":

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -1,0 +1,38 @@
+# Copyright 2024 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
+import json
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+from precli.cli import init
+
+
+class TestInit:
+    @classmethod
+    def setup_class(cls):
+        cls.current_dir = os.getcwd()
+
+    @classmethod
+    def teardown_class(cls):
+        os.chdir(cls.current_dir)
+
+    def test_main_invalid_output(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["precli-init", "-o", "../does/not/exists"])
+        with pytest.raises(SystemExit) as excinfo:
+            init.main()
+        assert excinfo.value.code == 2
+
+    @mock.patch("builtins.input", lambda _: "no")
+    def test_main_output_already_exists(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["precli-init", "-o", "output.txt"])
+        temp_dir = tempfile.mkdtemp()
+        os.chdir(temp_dir)
+        with open("output.txt", "w") as fd:
+            fd.write("This file already exists. Do not overwrite.")
+
+        with pytest.raises(SystemExit) as excinfo:
+            init.main()
+        assert excinfo.value.code == 1

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -15,12 +15,6 @@ from precli.cli import main
 class TestMain:
     @classmethod
     def setup_class(cls):
-        cls.base_path = os.path.join(
-            "tests",
-            "unit",
-            "cli",
-            "examples",
-        )
         cls.current_dir = os.getcwd()
 
     @classmethod


### PR DESCRIPTION
This change tests some of the output of precli-init, specifically around the -o argument to ensure the file doesn't already exist or can't be written to.