### PR TITLE
Add checking for files given that don't exist

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -182,6 +182,13 @@ def setup_arg_parser():
         parser.print_usage()
         sys.exit(2)
 
+    for target in args.targets:
+        if target != "-" and not pathlib.Path(target).exists():
+            parser.error(
+                f"argument targets: can't open '{target}': [Errno 2] No such "
+                f"file or directory: '{target}'"
+            )
+
     return args
 
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -21,6 +21,12 @@ class TestMain:
     def teardown_class(cls):
         os.chdir(cls.current_dir)
 
+    def test_main_target_not_found(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["precli", "missing_file.py"])
+        with pytest.raises(SystemExit) as excinfo:
+            main.main()
+        assert excinfo.value.code == 2
+
     def test_main_config_not_found(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["precli", "-c", "missing_file.toml"])
         with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
This change nicely checks for non-existant files and directories given as targets to precli. It utilizes argparse error() function for consistency with other validation mechanisms.

Fixes: #497