### PR TITLE
Fix the output option

### DIFF
--- a/precli/cli/init.py
+++ b/precli/cli/init.py
@@ -25,21 +25,11 @@ def setup_arg_parser() -> Namespace:
         "--output",
         dest="output",
         action="store",
-        type=argparse.FileType("w", encoding="utf-8"),
+        type=argparse.FileType("x", encoding="utf-8"),
         default=".precli.toml",
         help="output the config to given file",
     )
     args = parser.parse_args()
-
-    if args.output:
-        path = pathlib.Path(args.output.name)
-        if path.exists():
-            overwrite = input(
-                f"The file '{path}' already exists. Overwrite? (y/N): "
-            )
-            if overwrite.lower() != "y":
-                print("Operation cancelled.")
-                sys.exit(1)
 
     return args
 

--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -116,7 +116,7 @@ def setup_arg_parser():
         "--output",
         dest="output",
         action="store",
-        type=argparse.FileType("w", encoding="utf-8"),
+        type=argparse.FileType("x", encoding="utf-8"),
         default=sys.stdout,
         help="output the results to a file",
     )
@@ -158,16 +158,6 @@ def setup_arg_parser():
             parser.error(
                 f"argument -c/--config: can't load '{args.config.name}': {err}"
             )
-
-    if args.output:
-        path = pathlib.Path(args.output.name)
-        if path.exists():
-            overwrite = input(
-                f"The file '{path}' already exists. Overwrite? (y/N): "
-            )
-            if overwrite.lower() != "y":
-                print("Operation cancelled.")
-                sys.exit(1)
 
     if not args.targets:
         parser.print_usage()

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -26,7 +26,7 @@ class TestInit:
         assert excinfo.value.code == 2
 
     @mock.patch("builtins.input", lambda _: "no")
-    def test_main_output_already_exists(self, monkeypatch):
+    def test_main_output_already_exists(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["precli-init", "-o", "output.txt"])
         temp_dir = tempfile.mkdtemp()
         os.chdir(temp_dir)
@@ -35,4 +35,6 @@ class TestInit:
 
         with pytest.raises(SystemExit) as excinfo:
             init.main()
-        assert excinfo.value.code == 1
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "[Errno 17] File exists" in captured.err

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -65,7 +65,7 @@ class TestMain:
         assert excinfo.value.code == 2
 
     @mock.patch("builtins.input", lambda _: "no")
-    def test_main_output_already_exists(self, monkeypatch):
+    def test_main_output_already_exists(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["precli", "-o", "output.txt"])
         temp_dir = tempfile.mkdtemp()
         os.chdir(temp_dir)
@@ -74,7 +74,9 @@ class TestMain:
 
         with pytest.raises(SystemExit) as excinfo:
             main.main()
-        assert excinfo.value.code == 1
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "[Errno 17] File exists" in captured.err
 
     def test_main_more_than_one_renderer(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["precli", "--json", "--markdown"])


### PR DESCRIPTION
The output option was broken in such that argparse would create the file if it didn't exist, then the code would additionally check if the file exist, which it would.

This change removes the overwrite checking code and simply changes argparse to error if the file already exists. It will be up to the user to specify a different file or delete the existing.