### PR TITLE
Fix --gist argument failure

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -22,6 +22,7 @@ import precli
 from precli.core import loader
 from precli.core.artifact import Artifact
 from precli.core.run import Run
+from precli.renderers import Renderer
 
 
 BUSL_URL = "https://spdx.org/licenses/BUSL-1.1.html"
@@ -174,6 +175,11 @@ def setup_arg_parser():
                 f"file or directory: '{target}'"
             )
 
+    if args.gist and not os.getenv("GITHUB_TOKEN"):
+        parser.error(
+            "argument --gist: environment variable GITHUB_TOKEN undefined"
+        )
+
     return args
 
 
@@ -214,15 +220,8 @@ def discover_files(targets: list[str], recursive: bool) -> list[Artifact]:
     return artifacts
 
 
-def create_gist(file, renderer: str):
-    if renderer == "json":
-        filename = "results.json"
-    elif renderer == "plain":
-        filename = "results.txt"
-    elif renderer == "markdown":
-        filename = "results.md"
-    elif renderer == "detailed":
-        filename = "results.txt"
+def create_gist(file, renderer: Renderer):
+    filename = f"results.{renderer.file_extension()}"
 
     with open(file.name, encoding="utf-8") as f:
         file_content = f.read()

--- a/precli/renderers/__init__.py
+++ b/precli/renderers/__init__.py
@@ -13,5 +13,9 @@ class Renderer(ABC):
         self.quiet = quiet
 
     @abstractmethod
+    def file_extension(self) -> str:
+        pass
+
+    @abstractmethod
     def render(self, run: Run):
         pass

--- a/precli/renderers/detailed.py
+++ b/precli/renderers/detailed.py
@@ -12,6 +12,9 @@ from precli.rules import Rule
 
 
 class Detailed(Renderer):
+    def file_extension(self) -> str:
+        return ".txt"
+
     def render(self, run: Run):
         for result in run.results:
             if result.level == Level.ERROR:

--- a/precli/renderers/json.py
+++ b/precli/renderers/json.py
@@ -131,6 +131,9 @@ class Json(Renderer):
                 )
         return precli_exts
 
+    def file_extension(self) -> str:
+        return ".json"
+
     def render(self, run: Run):
         log = sarif_om.SarifLog(
             schema_uri=SCHEMA_URI,

--- a/precli/renderers/markdown.py
+++ b/precli/renderers/markdown.py
@@ -16,6 +16,9 @@ logging.getLogger("markdown_it").setLevel(logging.INFO)
 
 
 class Markdown(Renderer):
+    def file_extension(self) -> str:
+        return ".md"
+
     def render(self, run: Run):
         output = ""
         for result in run.results:

--- a/precli/renderers/plain.py
+++ b/precli/renderers/plain.py
@@ -9,6 +9,9 @@ from precli.rules import Rule
 
 
 class Plain(Renderer):
+    def file_extension(self) -> str:
+        return ".txt"
+
     def render(self, run: Run):
         for result in run.results:
             rule = Rule.get_by_id(result.rule_id)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -86,6 +86,14 @@ class TestMain:
         captured = capsys.readouterr()
         assert "not allowed with argument" in captured.err
 
+    def test_main_gist_no_github_token(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["precli", ".", "--gist"])
+        with pytest.raises(SystemExit) as excinfo:
+            main.main()
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "environment variable GITHUB_TOKEN undefined" in captured.err
+
     def test_main_version(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["precli", "--version"])
         with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
This change fixes --gist argument which was raising a traceback. Also adds a unit test of the condition where --gist is specified but GITHUB_TOKEN is undefined.

```
Traceback (most recent call last):
  File "/Users/ericwb/workspace/precli/.tox/py313/bin/precli", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/ericwb/workspace/precli/precli/cli/main.py", line 306, in main
    create_gist(file, renderer)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/Users/ericwb/workspace/precli/precli/cli/main.py", line 238, in create_gist
    "files": {filename: {"content": file_content}},
              ^^^^^^^^
UnboundLocalError: cannot access local variable 'filename' where it is not associated with a value
```