### PR TITLE
Fix up the CLI main unit tests

### DIFF
--- a/precli/__main__.py
+++ b/precli/__main__.py
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: BUSL-1.1
 from precli.cli import main
 
+
 main.main()

--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -298,6 +298,8 @@ def main():
     if args.gist is True:
         create_gist(file, renderer)
 
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
* Add unit test of the recursive flag
* Be sure to call sys.exit in main, even when 0
* replace the need to chdir by passing full paths in tests