### PR TITLE
Set exit code to 0 or 1 based on results

### DIFF
--- a/precli/cli/main.py
+++ b/precli/cli/main.py
@@ -298,7 +298,10 @@ def main():
     if args.gist is True:
         create_gist(file, renderer)
 
-    sys.exit(0)
+    if run.results:
+        sys.exit(1)
+    else:
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -97,6 +97,13 @@ class TestMain:
             main.main()
         assert excinfo.value.code == 0
 
+    def test_main_exit_code_0(self, monkeypatch):
+        temp_dir = tempfile.mkdtemp()
+        monkeypatch.setattr("sys.argv", ["precli", temp_dir])
+        with pytest.raises(SystemExit) as excinfo:
+            main.main()
+        assert excinfo.value.code == 0
+
     def test_main_version(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["precli", "--version"])
         with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
If results are found, return an exit code of 1. Return 0 otherwise.