### PR TITLE
Add PyPI example to Getting Started documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,12 @@ Run precli against all the python test examples:
 precli -r tests/unit/rules/python/
 ```
 
+Run precli against an entire PyPI repository:
+
+```
+precli -r https://pypi.org/project/precli/
+```
+
 Run precli against an entire GitHub repository:
 
 ```


### PR DESCRIPTION
As the title describes, adds a PyPI example as a target for the analysis.