### PR TITLE
Add config files to the CLI reference page

### DIFF
--- a/docs/man/precli.md
+++ b/docs/man/precli.md
@@ -36,9 +36,21 @@ certificate validation, and more.
 
 ## FILES
 
-.preignore
+`.preignore`
 
   file that specifies which files and directories can be ignored
+
+`.precli.toml`
+
+  file that specifies custom configuration
+
+`precli.toml`
+
+  same as `.precli.toml`
+
+`pyproject.toml`
+
+  standard Python configuration file where precli can read configuration
 
 ## ENVIRONMENT VARIABLES
 


### PR DESCRIPTION
The CLI reference or man page for precli contains a list of files that precli will work with. This change adds files that precli will attempt to read for configuration information. Namely, .precli.toml, precli.toml, and pyproject.toml.