### PR TITLE
Improve the look of the man page

### DIFF
--- a/docs/man/precli.md
+++ b/docs/man/precli.md
@@ -1,21 +1,25 @@
-# precli
+# **PRECLI**
 
-## SYNOPSIS
+## **SYNOPSIS**
 
 ```
-precli [-h] [-d] [-c CONFIG] [-r] [--enable ENABLE | --disable DISABLE] [--json | --plain |
-       --markdown] [--gist] [-o OUTPUT] [--no-color] [-q] [--version]
-       [targets ...]
+precli [-h] [-d] [-c CONFIG] [-r] [--enable ENABLE | --disable DISABLE]
+       [--json | --plain | --markdown] [--gist] [-o OUTPUT] [--no-color] [-q]
+       [--version] [targets ...]
 ```
 
-## DESCRIPTION
+## **COPYRIGHT**
 
-`precli` is a tool designed to find security issues in code. It finds issues
+Copyright 2024 Secure Sauce LLC
+
+## **DESCRIPTION**
+
+**Precli** is a tool designed to find security issues in code. It finds issues
 such as injection, weak hashes, cleartext transmission of data, timing
 attacks, weak encryption, deserialization of untrusted data, improper
 certificate validation, and more.
 
-## OPTIONS
+## **OPTIONS**
 
 ```
   -h, --help            show this help message and exit
@@ -34,25 +38,21 @@ certificate validation, and more.
   --version             show program's version number and exit
 ```
 
-## FILES
+## **FILES**
 
-`.preignore`
+<ins>.preignore</ins>
 
-  file that specifies which files and directories can be ignored
+&nbsp;&nbsp;&nbsp;&nbsp;file that specifies which files and directories can be ignored
 
-`.precli.toml`
+<ins>.precli.toml</ins> or <ins>precli.toml</ins>
+  
+&nbsp;&nbsp;&nbsp;&nbsp;file that specifies custom configuration
 
-  file that specifies custom configuration
+<ins>pyproject.toml</ins>
+  
+&nbsp;&nbsp;&nbsp;&nbsp;standard Python configuration file where precli can read configuration
 
-`precli.toml`
-
-  same as `.precli.toml`
-
-`pyproject.toml`
-
-  standard Python configuration file where precli can read configuration
-
-## ENVIRONMENT VARIABLES
+## **ENVIRONMENT**
 
 DEBUG
 
@@ -62,21 +62,28 @@ GITHUB_TOKEN
 
   Set to your GitHub token. This is required to use the `--gist` argument.
 
-## EXAMPLES
+## **EXIT STATUS**
 
-Example usage across a code tree:
+The **precli** tool exits with one of the following values:
+
+0&nbsp;&nbsp;&nbsp;&nbsp;No errors or results found  
+1&nbsp;&nbsp;&nbsp;&nbsp;One or more results found  
+2&nbsp;&nbsp;&nbsp;&nbsp;Incorrect command usage  
+
+## **EXAMPLES**
+
+Recursively analyze an entire project code tree:
 
     precli -r ~/your-repos/project
 
-Precli supports passing lines of code to scan using standard input. To
-run Precli with standard input:
+Analyze code passed as standard input:
 
     cat examples/imports.py | precli -
 
-## REPORTING BUGS
+## **REPORTING BUGS**
 
 Report issues at the following link: [https://github.com/securesauce/precli/issues](https://github.com/securesauce/precli/issues)
 
-## SEE ALSO
+## **SEE ALSO**
 
-`pylint(1)`
+<ins>pylint(1)</ins>


### PR DESCRIPTION
These changes try to make the CLI reference or man page look more closely like a true man page.

* Added section for the exit status to describe expect exit codes
* Added section for copyright