### PR TITLE
Use mkdocs plugin to put last update time on pages

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,3 @@ repos:
 ```
 
 Then run `pre-commit install` and you're ready to go.
-
-
-_Last updated on {{ git.date.strftime("%b %d, %Y") }}_

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,5 +40,3 @@ vulnerabilities.
     [:octicons-arrow-right-24: License](https://github.com/securesauce/precli/blob/main/LICENSE)
 
 </div>
-
-_Last updated on {{ git.date.strftime("%b %d, %Y") }}_

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 # Copyright 2024 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
 mkdocs
-mkdocstrings[python]
-mkdocs-material
 mkdocs-macros-plugin
+mkdocs-material
+mkdocs-git-revision-date-localized-plugin
+mkdocstrings[python]

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -70,5 +70,3 @@
 | PY044 | [telnetlib — no timeout](rules/python/stdlib/telnetlib-no-timeout.md) | Synchronous Access of `Telnet` without Timeout |
 | PY045 | [ftplib — no timeout](rules/python/stdlib/ftplib-no-timeout.md) | Synchronous Access of `FTP` without Timeout |
 | PY046 | [ssl — no timeout](rules/python/stdlib/ssl-no-timeout.md) | Synchronous Access of `ssl` without Timeout |
-
-_Last updated on {{ git.date.strftime("%b %d, %Y") }}_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ plugins:
   - mkdocstrings
   - search
   - macros
+  - git-revision-date-localized
 
 nav:
   - Home: index.md


### PR DESCRIPTION
The git-revision-date-localized plugin will automatically add the last update date to each markdown page based on the date of the last change in git to the file.