### PR TITLE
Prevent precli-init overwriting configuration settings

### DIFF
--- a/precli/cli/init.py
+++ b/precli/cli/init.py
@@ -33,11 +33,20 @@ def setup_arg_parser() -> Namespace:
 
     # Prevent overwriting output files except appending to pyproject.toml
     path = pathlib.Path(args.output)
-    if path.exists() and path.name != "pyproject.toml":
-        parser.error(
-            f"argument -o/--output: can't open '{args.output}': [Errno 17] "
-            f"File exists: '{args.output}'"
-        )
+    if path.exists():
+        if path.name == "pyproject.toml":
+            with open(path, "rb") as f:
+                doc = tomllib.load(f)
+            if "tool" in doc and "precli" in doc.get("tool"):
+                parser.error(
+                    f"argument -o/--output: can't write '{args.output}': "
+                    f"[Errno 17] Configuration already exist: '[tool.precli]'"
+                )
+        else:
+            parser.error(
+                f"argument -o/--output: can't write '{args.output}': "
+                f"[Errno 17] File exists: '{args.output}'"
+            )
 
     return args
 

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -1,11 +1,11 @@
 # Copyright 2024 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
-import json
 import os
 import tempfile
 from unittest import mock
 
 import pytest
+import tomli_w
 
 from precli.cli import init
 
@@ -24,3 +24,17 @@ class TestInit:
         assert excinfo.value.code == 2
         captured = capsys.readouterr()
         assert "[Errno 17] File exists" in captured.err
+
+    def test_main_pyproject_config_already_exists(self, monkeypatch, capsys):
+        temp_dir = tempfile.mkdtemp()
+        output_path = os.path.join(temp_dir, "pyproject.toml")
+        config = {"tool": {"precli": {"rule": {}}}}
+        with open(output_path, "wb") as fd:
+            tomli_w.dump(config, fd)
+
+        monkeypatch.setattr("sys.argv", ["precli-init", "-o", output_path])
+        with pytest.raises(SystemExit) as excinfo:
+            init.main()
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "argument -o/--output: can't write" in captured.err

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -3,8 +3,6 @@
 import json
 import os
 import tempfile
-from io import StringIO
-from unittest import mock
 
 import pytest
 


### PR DESCRIPTION
This change modifies precli-init to only write to the output config file (including pyproject.toml) if the configuration settings are not already present.