### PR TITLE
Do not try to fetch last modified date if remote file

### DIFF
--- a/precli/core/artifact.py
+++ b/precli/core/artifact.py
@@ -15,7 +15,7 @@ class Artifact:
         self._encoding = "utf-8"
         self._language = None
 
-        if file_name != "-" or not uri:
+        if file_name != "-" and not uri:
             modified_time = os.path.getmtime(file_name)
             self._last_modified = datetime.fromtimestamp(
                 modified_time, tz=timezone.utc


### PR DESCRIPTION
If the file given in the artifact is not local, then the code should not attempt to fetch the last modified date.

This applies to cases where the file is "-" meaning standard input and artifacts with a URL when targeting GitHub repos and such.