### PR TITLE
get_file_encoding inconsistent parameters

### DIFF
--- a/precli/parsers/__init__.py
+++ b/precli/parsers/__init__.py
@@ -74,7 +74,7 @@ class Parser(ABC):
         """The prefix for the rule ID"""
 
     @abstractmethod
-    def get_file_encoding(self, file_path: str) -> str:
+    def get_file_encoding(self, file_contents: str) -> str:
         """The prefix for the rule ID"""
 
     def is_valid_code(self, code: str) -> bool:


### PR DESCRIPTION
The base class version of get_file_encoding didn't match the subclasses. This change corrects that.