### PR TITLE
Lower tree-sitter language libraries to work with PyOdide.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ ignorelib==0.3.0
 requests==2.32.3
 sarif-om==1.0.4
 jschema-to-python==1.2.3
-tree-sitter-go==0.23.4
+tree-sitter-go==0.23.3
 tree-sitter-java==0.23.4
-tree-sitter-python==0.23.5
+tree-sitter-python==0.23.4


### PR DESCRIPTION
In order to support running precli within a browser using PyScript, the tree-sitter libraries which are not pure Python need to match what is available on PyOdide. Current 0.27.0 version of PyOdide has:
  tree-sitter==0.23.2
  tree-sitter-go==0.23.3
  tree-sitter-java==0.23.4
  tree-sitter-python==0.23.4

So this change lowsers precli dependency on the python and go libraries to match PyOdide. This should enable PyScript to work, but that requires further testing.