### PR TITLE
Remove cwe2 from dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,5 +13,4 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
-          allow-dependencies-licenses: 'pkg:pypi/cwe2'
           deny-licenses: GPL-2.0-only, GPL-2.0-or-later, GPL-3.0, GPL-3.0-or-later, LGPL-2.1-only, LGPL-2.1-or-later, LGPL-3.0-only, LGPL-3.0-or-later


### PR DESCRIPTION
There was an allowance for using cwe2 as part of the dependency review previously, but now cwe2 is not a dependency so this line isn't needed in dep-review.