### PR TITLE
Metadata rename classifier to classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ description_file =
 author = Secure Sauce
 author_email = info@securesauce.dev
 license = Other/Proprietary License
-classifier =
+classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Information Technology


### PR DESCRIPTION
Not sure if this metadata object changed names over time but some tooling such as LicenseCheck trips up if it's defined as classifier and not classifiers. This also matches current documentation:

https://setuptools.pypa.io/en/latest/userguide/declarative_config.html