### PR TITLE
Add msgfmt step to unit-test build

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -67,6 +67,28 @@ jobs:
     - name: Run tox
       run: tox run -e docs
 
+  msgfmt:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get install gettext
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Run tox
+      run: tox run -e msgfmt
+
   tests:
     strategy:
       matrix:


### PR DESCRIPTION
The unit test workflow runs various tests as defined in tox. This change adds a step for msgfmt that compiles the *.po files to *.mo files.