### PR TITLE
Publish translation binary files with release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -28,6 +28,7 @@ jobs:
 
     - name: Build a binary wheel and a source tarball
       run: |
+        sh -c 'for lang in de en_GB es fr it ja ko pt_BR ru zh_CN zh_TW; do msgfmt -o precli/locale/$lang/LC_MESSAGES/messages.mo precli/locale/$lang/LC_MESSAGES/messages.po; done'
         python setup.py sdist bdist_wheel
 
     - name: Publish distribution to PyPI

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -28,6 +28,7 @@ jobs:
 
     - name: Build a binary wheel and a source tarball
       run: |
+        sh -c 'for lang in de en_GB es fr it ja ko pt_BR ru zh_CN zh_TW; do msgfmt -o precli/locale/$lang/LC_MESSAGES/messages.mo precli/locale/$lang/LC_MESSAGES/messages.po; done'
         python setup.py sdist bdist_wheel
 
     - name: Publish distribution to Test PyPI

--- a/.github/workflows/upload-asset.yml
+++ b/.github/workflows/upload-asset.yml
@@ -30,6 +30,7 @@ jobs:
 
     - name: Build a binary wheel and a source tarball
       run: |
+        sh -c 'for lang in de en_GB es fr it ja ko pt_BR ru zh_CN zh_TW; do msgfmt -o precli/locale/$lang/LC_MESSAGES/messages.mo precli/locale/$lang/LC_MESSAGES/messages.po; done'
         python setup.py sdist bdist_wheel
 
     - name: Release

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
-# Copyright 2024 Secure Sauce LLC
+# Copyright 2025 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
 import setuptools
 
 
 setuptools.setup(
-    python_requires=">=3.9", setup_requires=["pbr>=2.0.0"], pbr=True
+    python_requires=">=3.9",
+    setup_requires=["pbr>=2.0.0"],
+    pbr=True,
+    package_data={
+        "precli": ["locale/*/LC_MESSAGES/*.mo"],
+    },
 )


### PR DESCRIPTION
Upon release to PyPI or Test PyPI, the translation binary files (*.mo) should also be included so that the strings get translated depending on locale.