### PR TITLE
Ensure msgfmt is installed for publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,7 +24,9 @@ jobs:
         python-version: 3.12
 
     - name: Install dependencies
-      run: pip install setuptools wheel
+      run: |
+        sudo apt-get install gettext
+        pip install setuptools wheel
 
     - name: Build a binary wheel and a source tarball
       run: |

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -24,7 +24,9 @@ jobs:
         python-version: 3.12
 
     - name: Install dependencies
-      run: pip install setuptools wheel
+      run: |
+        sudo apt-get install gettext
+        pip install setuptools wheel
 
     - name: Build a binary wheel and a source tarball
       run: |

--- a/.github/workflows/upload-asset.yml
+++ b/.github/workflows/upload-asset.yml
@@ -26,7 +26,9 @@ jobs:
         python-version: 3.12
 
     - name: Install dependencies
-      run: pip install setuptools wheel
+      run: |
+        sudo apt-get install gettext
+        pip install setuptools wheel
 
     - name: Build a binary wheel and a source tarball
       run: |


### PR DESCRIPTION
In order to compile po files to mo, msgfmt command must be installed on the ubuntu build machine.