### PR TITLE
Start unit testing with pre-release Python 3.14

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -95,6 +95,7 @@ jobs:
           ["3.11", "311"],
           ["3.12", "312"],
           ["3.13", "313"],
+          ["3.14.0-alpha - 3.14", "314"],
         ]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
In order to find issues before the official release of 3.14, start testing with pre-release versions now