### PR TITLE
Use unset timeout to test global timeout set

### DIFF
--- a/tests/unit/rules/python/stdlib/imaplib/examples/imaplib_imap4_timeout_global.py
+++ b/tests/unit/rules/python/stdlib/imaplib/examples/imaplib_imap4_timeout_global.py
@@ -5,5 +5,5 @@ import ssl
 
 
 socket.setdefaulttimeout(5.0)
-imap = imaplib.IMAP4("imap.example.com", timeout=5)
+imap = imaplib.IMAP4("imap.example.com")
 imap.starttls(ssl.create_default_context())


### PR DESCRIPTION
This testcase was setting a timeout on the function rather than relying on the global timeout. That doesn't test the global timeout function much.