### PR TITLE
Go rule to check function that do not permit a timeout

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -10,6 +10,7 @@
 | GO004 | [syscall — unnecessary privileges](rules/go/stdlib/syscall-setuid-root.md) | Execution with Unnecessary Privileges using `syscall` Package |
 | GO005 | [crypto — unrestricted bind](rules/go/stdlib/crypto-unrestricted-bind.md) | Binding to an Unrestricted IP Address in `crypto` Package |
 | GO006 | [net — unrestricted bind](rules/go/stdlib/net-unrestricted-bind.md) | Binding to an Unrestricted IP Address in `net` Package |
+| GO007 | [net — no timeout](rules/go/stdlib/net-http-no-timeout.md) | Resource Allocation Without Limits in `net/http` Package |
 
 ## Java Standard Library
 

--- a/docs/rules/go/stdlib/net-http-no-timeout.md
+++ b/docs/rules/go/stdlib/net-http-no-timeout.md
@@ -1,0 +1,10 @@
+---
+id: GO007
+title: net — no timeout
+hide_title: true
+pagination_prev: null
+pagination_next: null
+slug: /rules/GO007
+---
+
+::: precli.rules.go.stdlib.net_http_no_timeout

--- a/precli/core/cwe.py
+++ b/precli/core/cwe.py
@@ -32,6 +32,7 @@ class Cwe:
         614: _("Sensitive Cookie in HTTPS Session Without 'Secure' Attribute"),
         703: _("Improper Check or Handling of Exceptional Conditions"),
         732: _("Incorrect Permission Assignment for Critical Resource"),
+        770: _("Allocation of Resources Without Limits or Throttling"),
         1088: _("Synchronous Access of Remote Resource without Timeout"),
         1327: _("Binding to an Unrestricted IP Address"),
         1333: _("Inefficient Regular Expression Complexity"),

--- a/precli/rules/go/stdlib/net_http_no_timeout.py
+++ b/precli/rules/go/stdlib/net_http_no_timeout.py
@@ -1,0 +1,173 @@
+# Copyright 2025 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
+r"""
+# Resource Allocation Without Limits in `net/http` Package
+
+The Go standard library provides convenient functions such as
+`net/http.ListenAndServe`, `net/http.ListenAndServeTLS`, `net/http.Serve`, and
+`net/http.ServeTLS` to quickly start HTTP and HTTPS servers. However, a
+significant security issue with these functions is that they do not allow
+developers to specify critical timeout values—such as ReadTimeout,
+WriteTimeout, or IdleTimeout—on the server. By default, these timeouts are
+unset (zero), meaning the server will wait indefinitely for clients to
+send or receive data. This behavior can be exploited by malicious actors
+using techniques like Slowloris attacks, where an attacker intentionally
+opens many connections and sends data very slowly to exhaust server
+resources. Without timeouts, each connection can tie up a goroutine and
+file descriptor, leading to resource exhaustion and making the server
+susceptible to denial-of-service (DoS) attacks.
+
+Beyond malicious intent, the absence of timeouts also increases the risk
+from buggy or misbehaving clients that inadvertently leave connections open,
+potentially causing the same resource exhaustion problem. In production
+environments, it is critical to protect against both unintentional and
+intentional abuse by configuring sensible timeouts on all HTTP servers.
+Since the shortcut functions (`ListenAndServe`, etc.) do not provide any
+parameters for timeout configuration, developers must instead use an
+http.Server struct and explicitly set the timeout fields. Failing to do so
+can compromise both the availability and stability of the server, making
+this an important security and operational concern.
+
+# Example
+
+```go linenums="1" hl_lines="15" title="net_http_listenandserve.go"
+package main
+
+import (
+    "io"
+    "log"
+    "net/http"
+)
+
+func main() {
+    helloHandler := func(w http.ResponseWriter, req *http.Request) {
+        io.WriteString(w, "Hello, world!\n")
+    }
+
+    http.HandleFunc("/hello", helloHandler)
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}
+```
+
+??? example "Example Output"
+    ```
+    > precli tests/unit/rules/go/stdlib/net/examples/net_http_listenandserve.go
+    ⚠️  Error on line 15 in tests/unit/rules/go/stdlib/net/examples/net_http_listenandserve.go
+    GO007: Allocation of Resources Without Limits or Throttling
+    The function 'net/http.ListenAndServe' does not allow timeout values to be set, which may leave the server vulnerable to resource exhaustion or denial-of-service attacks.
+    ```
+
+# Remediation
+
+To mitigate resource exhaustion risks, replace with http.Server or similar
+with proper timeout values.
+
+```go linenums="1" hl_lines="18-24 26" title="net_http_listenandserve.go"
+package main
+
+import (
+    "io"
+    "log"
+    "net/http"
+    "time"
+)
+
+func main() {
+    helloHandler := func(w http.ResponseWriter, req *http.Request) {
+        io.WriteString(w, "Hello, world!\n")
+    }
+
+    mux := http.NewServeMux()
+    mux.HandleFunc("/hello", helloHandler)
+
+    server := &http.Server{
+        Addr:         ":8080",
+        Handler:      mux,
+        ReadTimeout:  10 * time.Second,
+        WriteTimeout: 10 * time.Second,
+        IdleTimeout:  60 * time.Second,
+    }
+
+    log.Fatal(server.ListenAndServe())
+}
+```
+
+# Default Configuration
+
+```toml
+enabled = true
+level = "warning"
+```
+
+# See also
+
+!!! info
+    - [http package - net_http - Go Packages](https://pkg.go.dev/net/http#ListenAndServe)
+    - [http package - net_http - Go Packages](https://pkg.go.dev/net/http#ListenAndServeTLS)
+    - [http package - net_http - Go Packages](https://pkg.go.dev/net/http#Serve)
+    - [http package - net_http - Go Packages](https://pkg.go.dev/net/http#ServeTLS)
+    - [CWE-770: Allocation of Resources Without Limits or Throttling](https://cwe.mitre.org/data/definitions/770.html)
+
+_New in version 0.8.1_
+
+"""  # noqa: E501
+from typing import Optional
+
+from precli.core.call import Call
+from precli.core.location import Location
+from precli.core.result import Result
+from precli.i18n import _
+from precli.rules import Rule
+
+
+class NetHttpNoTimeout(Rule):
+    def __init__(self, id: str):
+        super().__init__(
+            id=id,
+            name="resource_allocation_without_limits",
+            description=__doc__,
+            cwe_id=770,
+            message=_(
+                "The function '{0}' does not allow timeout values to be set, "
+                "which may leave the server vulnerable to resource exhaustion "
+                "or denial-of-service attacks."
+            ),
+        )
+
+    def analyze_call_expression(
+        self, context: dict, call: Call
+    ) -> Optional[Result]:
+        if call.name_qualified not in (
+            "net/http.ListenAndServe",
+            "net/http.ListenAndServeTLS",
+            "net/http.Serve",
+            "net/http.ServeTLS",
+        ):
+            return
+
+        """
+        TODO: Fix should be:
+        server := &http.Server{
+            Addr: ":8080",
+            Handler: handler,
+            ReadTimeout: 10 * time.Second,
+            WriteTimeout: 10 * time.Second,
+            IdleTimeout: 60 * time.Second,
+        }
+        server.ListenAndServe()
+        fixes = Rule.get_fixes(
+            context=context,
+            deleted_location=Location(node=call.function_node),
+            description=_(
+                "To mitigate resource exhaustion risks, replace with "
+                "http.Server or similar with proper timeout values."
+            ),
+            inserted_content="aes.NewCipher",
+        )
+        """
+        return Result(
+            rule_id=self.id,
+            location=Location(node=call.function_node),
+            message=self.message.format(call.name),
+            # fixes=fixes,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,6 +93,9 @@ precli.rules.go =
     # precli/rules/go/stdlib/net_unrestricted_bind.py
     GO006 = precli.rules.go.stdlib.net_unrestricted_bind:NetUnrestrictedBind
 
+    # precli/rules/go/stdlib/net_http_no_timeout.py
+    GO007 = precli.rules.go.stdlib.net_http_no_timeout:NetHttpNoTimeout
+
 precli.rules.java =
     # precli/rules/java/stdlib/javax_crypto_weak_cipher.py
     JAV001 = precli.rules.java.stdlib.javax_crypto_weak_cipher:WeakCipher

--- a/tests/unit/rules/go/stdlib/net/examples/net_http_listenandserve.go
+++ b/tests/unit/rules/go/stdlib/net/examples/net_http_listenandserve.go
@@ -1,0 +1,21 @@
+// level: WARNING
+// start_line: 20
+// end_line: 20
+// start_column: 14
+// end_column: 33
+package main
+
+import (
+    "io"
+    "log"
+    "net/http"
+)
+
+func main() {
+    helloHandler := func(w http.ResponseWriter, req *http.Request) {
+        io.WriteString(w, "Hello, world!\n")
+    }
+
+    http.HandleFunc("/hello", helloHandler)
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/tests/unit/rules/go/stdlib/net/examples/net_http_listenandservetls.go
+++ b/tests/unit/rules/go/stdlib/net/examples/net_http_listenandservetls.go
@@ -1,0 +1,21 @@
+// level: WARNING
+// start_line: 20
+// end_line: 20
+// start_column: 14
+// end_column: 36
+package main
+
+import (
+    "io"
+    "log"
+    "net/http"
+)
+
+func main() {
+    helloHandler := func(w http.ResponseWriter, req *http.Request) {
+        io.WriteString(w, "Hello, world!\n")
+    }
+
+    http.HandleFunc("/hello", helloHandler)
+    log.Fatal(http.ListenAndServeTLS(":8443", "server.crt", "server.key", nil))
+}

--- a/tests/unit/rules/go/stdlib/net/examples/net_http_serve.go
+++ b/tests/unit/rules/go/stdlib/net/examples/net_http_serve.go
@@ -1,0 +1,26 @@
+// level: WARNING
+// start_line: 25
+// end_line: 25
+// start_column: 14
+// end_column: 24
+package main
+
+import (
+    "io"
+    "log"
+    "net"
+    "net/http"
+)
+
+func main() {
+    helloHandler := func(w http.ResponseWriter, req *http.Request) {
+        io.WriteString(w, "Hello, world!\n")
+    }
+
+    http.HandleFunc("/hello", helloHandler)
+    ln, err := net.Listen("tcp", "127.0.0.1:8080")
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Fatal(http.Serve(ln, nil))
+}

--- a/tests/unit/rules/go/stdlib/net/examples/net_http_servetls.go
+++ b/tests/unit/rules/go/stdlib/net/examples/net_http_servetls.go
@@ -1,0 +1,26 @@
+// level: WARNING
+// start_line: 25
+// end_line: 25
+// start_column: 14
+// end_column: 27
+package main
+
+import (
+    "io"
+    "log"
+    "net"
+    "net/http"
+)
+
+func main() {
+    helloHandler := func(w http.ResponseWriter, req *http.Request) {
+        io.WriteString(w, "Hello, world!\n")
+    }
+
+    http.HandleFunc("/hello", helloHandler)
+    ln, err := net.Listen("tcp", "127.0.0.1:8443")
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Fatal(http.ServeTLS(ln, nil, "server.crt", "server.key"))
+}

--- a/tests/unit/rules/go/stdlib/net/test_net_http_no_timeout.py
+++ b/tests/unit/rules/go/stdlib/net/test_net_http_no_timeout.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
+import os
+
+import pytest
+
+from precli.core.level import Level
+from precli.parsers import go
+from precli.rules import Rule
+from tests.unit.rules import test_case
+
+
+class TestNetHttpNoTimeout(test_case.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.rule_id = "GO007"
+        cls.parser = go.Go()
+        cls.base_path = os.path.join(
+            "tests",
+            "unit",
+            "rules",
+            "go",
+            "stdlib",
+            "net",
+            "examples",
+        )
+
+    def test_rule_meta(self):
+        rule = Rule.get_by_id(self.rule_id)
+        assert rule.id == self.rule_id
+        assert rule.name == "resource_allocation_without_limits"
+        assert (
+            rule.help_url
+            == f"https://docs.securesauce.dev/rules/{self.rule_id}"
+        )
+        assert rule.config.enabled is True
+        assert rule.config.level == Level.WARNING
+        assert rule.config.rank == -1.0
+        assert rule.cwe.id == 770
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "net_http_listenandserve.go",
+            "net_http_listenandservetls.go",
+            "net_http_serve.go",
+            "net_http_servetls.go",
+        ],
+    )
+    def test(self, filename):
+        self.check(filename)


### PR DESCRIPTION
Several functions in the net/http package allow starting an http server but do not permit a way to set timeouts. This opens up the server to clients that might abuse it.

Rule ID: GO007