### PR TITLE
Ability to define custom rules via a YAML file

### DIFF
--- a/custom/requests-insecure-verify.yaml
+++ b/custom/requests-insecure-verify.yaml
@@ -1,0 +1,23 @@
+id: CU001
+name: requests-insecure-verify
+language: python
+description: >
+  The 'verify=False' option disables TLS certificate validation when using requests.
+  This can expose the application to man-in-the-middle (MITM) attacks by allowing
+  untrusted or malicious servers to masquerade as legitimate ones.
+cwe: 295
+severity: error
+message: "Setting 'verify=False' disables SSL certificate verification"
+query: |
+  (call
+    function: (attribute
+                object: (identifier) @module
+                attribute: (identifier) @method)
+    arguments: (argument_list
+      (keyword_argument
+        name: (identifier) @kw
+        value: (false) @vuln_val)))
+  (#eq? @module "requests")
+  (#any-of? @method "get" "post" "put" "delete" "head" "options")
+  (#eq? @kw "verify")
+location_node: vuln_val

--- a/docs/man/precli.md
+++ b/docs/man/precli.md
@@ -3,9 +3,10 @@
 ## **SYNOPSIS**
 
 ```
-precli [-h] [-d] [-c CONFIG] [-r] [--enable ENABLE | --disable DISABLE]
-       [--json | --plain | --markdown] [--gist] [-o OUTPUT] [--no-color] [-q]
-       [--version] [targets ...]
+precli [-h] [-d] [-c CONFIG] [--custom-rules CUSTOM_RULES] [-r] [--enable ENABLE |
+       --disable DISABLE] [--json | --plain | --markdown] [--gist] [-o OUTPUT] [--no-color]
+       [-q] [--version]
+       [targets ...]
 ```
 
 ## **COPYRIGHT**
@@ -25,6 +26,8 @@ certificate validation, and more.
   -h, --help            show this help message and exit
   -d, --debug           turn on debug mode
   -c, --config CONFIG   configuration file
+  --custom-rules CUSTOM_RULES
+                        path to directory containing custom rules
   -r, --recursive       find and process files in subdirectories
   --enable ENABLE       comma-separated list of rule IDs or names to enable
   --disable DISABLE     comma-separated list of rule IDs or names to disable

--- a/precli/rules/__init__.py
+++ b/precli/rules/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Secure Sauce LLC
+# Copyright 2025 Secure Sauce LLC
 import re
 import sys
 from abc import ABC
@@ -29,6 +29,8 @@ class Rule(ABC):
         wildcards: Optional[dict[str, list[str]]] = None,
         config: Optional[Config] = None,
         help_url: Optional[str] = None,
+        query: Optional[str] = None,
+        location_node: Optional[str] = None,
     ):
         self._id = id
         self._name = name
@@ -69,6 +71,8 @@ class Rule(ABC):
             self._config = Config() if not config else config
         self._enabled = self._config.enabled
         self._help_url = f"https://docs.securesauce.dev/rules/{id}"
+        self._query = query
+        self._location_node = location_node
         Rule._rules[id] = self
 
     @property
@@ -150,6 +154,16 @@ class Rule(ABC):
         for rule matching.
         """
         return self._wildcards
+
+    @property
+    def query(self) -> str:
+        """Tree-sitter query for a custom rule."""
+        return self._query
+
+    @property
+    def location_node(self) -> str:
+        """Tree-sitter Node of the vulnerability location."""
+        return self._location_node
 
     @staticmethod
     def get_fixes(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright 2024 Secure Sauce LLC
+# Copyright 2025 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
 typing-extensions==4.13.2;python_version<"3.11"
 tomli==2.2.1; python_version<"3.11"
@@ -12,3 +12,4 @@ jschema-to-python==1.2.3
 tree-sitter-go==0.23.4
 tree-sitter-java==0.23.5
 tree-sitter-python==0.23.6
+pyyaml==6.0.2


### PR DESCRIPTION
This change adds a new ability to create rules via a simple YAML file instead of in pure Python code.

A YAML file defines some metadata and a query string. The query string is used to do a tree-sitter query and capture. If captures are found, the issue is added as a result like normal.

Note: this method is not as accurate as the pure Python rules as it doesn not track data flow. However, it could be easier plugin model for stakeholders wishing to write their own rules.

Closes: #769