### PR TITLE
Custom rule example with Ruby language

### DIFF
--- a/custom/eval.rb
+++ b/custom/eval.rb
@@ -1,0 +1,5 @@
+# Simulated user input
+user_code = gets.chomp
+
+# Dangerous: evaluates user-supplied input as Ruby code
+eval(user_code)

--- a/custom/python-requests-insecure-verify.yaml
+++ b/custom/python-requests-insecure-verify.yaml
@@ -1,10 +1,10 @@
-id: CU001
+id: PY001C
 name: requests-insecure-verify
 language: python
 description: >
-  The 'verify=False' option disables TLS certificate validation when using requests.
-  This can expose the application to man-in-the-middle (MITM) attacks by allowing
-  untrusted or malicious servers to masquerade as legitimate ones.
+  The 'verify=False' option disables TLS certificate validation when using
+  requests. This can expose the application to man-in-the-middle (MITM) attacks
+  by allowing untrusted or malicious servers to masquerade as legitimate ones.
 cwe: 295
 severity: error
 message: "Setting 'verify=False' disables SSL certificate verification"

--- a/custom/ruby-eval-usage.yaml
+++ b/custom/ruby-eval-usage.yaml
@@ -1,0 +1,16 @@
+id: RB001C
+name: ruby-eval-usage
+language: ruby
+description: >
+  The `eval` method executes a string as Ruby code at runtime. If the string
+  includes or originates from user-controlled input, this creates a critical
+  code injection risk.
+cwe: 94
+severity: error
+message: "Avoid using `eval` with untrusted input"
+query: |
+  (call
+    method: (identifier) @method
+    arguments: (argument_list (_) @vuln_arg))
+  (#eq? @method "eval")
+location_node: vuln_arg

--- a/precli/core/run.py
+++ b/precli/core/run.py
@@ -26,6 +26,7 @@ from precli.core.location import Location
 from precli.core.metrics import Metrics
 from precli.core.result import Result
 from precli.core.tool import Tool
+from precli.parsers.basic import Basic
 from precli.rules import Rule
 
 
@@ -129,6 +130,10 @@ class Run:
 
         if custom_rules:
             for custom_rule in custom_rules:
+                if custom_rule["language"] not in parsers:
+                    parsers[custom_rule["language"]] = Basic(
+                        custom_rule["language"]
+                    )
                 parser = parsers[custom_rule["language"]]
 
                 default_config = Config()

--- a/precli/parsers/basic.py
+++ b/precli/parsers/basic.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Secure Sauce LLC
+# SPDX-License-Identifier: BUSL-1.1
+import re
+
+from precli.parsers import Parser
+
+
+# Language map to [file extensions, rule prefix, comment]
+LANG_MAP = {
+    "cpp": [
+        [".cpp", ".cc", ".cxx", ".hpp", ".h"],
+        "CPP",
+    ],
+    "c-sharp": [[".cs"], "CS"],
+    "css": [[".css"], "CSS"],
+    "haskell": [[".hs", ".lhs"], "HS"],
+    "javascript": [[".js"], "JS"],
+    "perl": [[".pl", ".pm", ".t"], "PL"],
+    "php": [[".php", ".phtml", ".php3", ".php4", ".php5"], "PHP"],
+    "ruby": [[".rb"], "RB"],
+    "scala": [[".scala"], "SCA"],
+    "swift": [[".swift"], "SW"],
+    "typescript": [[".ts", ".tsx"], "TS"],
+    # Incompatible Language version 15. Must be between 13 and 14
+    # "c": [[".c", ".h"], "C",],
+    # "rust": [[".rs"], "RS"],
+}
+
+
+class Basic(Parser):
+    def __init__(self, lang: str, **config):
+        super().__init__(lang)
+        self.SUPPRESS_COMMENT = re.compile(r"suppress:? (?P<rules>[^#]+)?#?")
+        self.SUPPRESSED_RULES = re.compile(
+            rf"(?:({LANG_MAP[self.lexer][1]}\d\d\dC|[a-z_]+),?)+"
+        )
+
+        if "skip_tests" in config:
+            self.skip_tests = config["skip_tests"]
+
+        self.suppressions = {}
+
+    def file_extensions(self) -> list[str]:
+        return LANG_MAP[self.lexer][0]
+
+    def rule_prefix(self) -> str:
+        return LANG_MAP[self.lexer][1]
+
+    def get_file_encoding(self, file_contents: str) -> str:
+        return "utf-8"
+
+    def is_test_code(self) -> bool:
+        """
+        Determine if analyzing test code.
+
+        This function determines if the current position of the analysis
+        is within unit test code. The purpose of which is to potentially
+        ignore rules in test code.
+        """
+        return False

--- a/precli/parsers/go.py
+++ b/precli/parsers/go.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Secure Sauce LLC
+# Copyright 2025 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
 import ast
 import re
@@ -16,9 +16,7 @@ from precli.parsers.node_types import NodeTypes
 class Go(Parser):
     def __init__(self):
         super().__init__("go")
-        self.SUPPRESS_COMMENT = re.compile(
-            r"// suppress:? (?P<rules>[^#]+)?#?"
-        )
+        self.SUPPRESS_COMMENT = re.compile(r"suppress:? (?P<rules>[^#]+)?#?")
         self.SUPPRESSED_RULES = re.compile(r"(?:(GO\d\d\d|[a-z_]+),?)+")
 
     def file_extensions(self) -> list[str]:

--- a/precli/parsers/java.py
+++ b/precli/parsers/java.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Secure Sauce LLC
+# Copyright 2025 Secure Sauce LLC
 # SPDX-License-Identifier: BUSL-1.1
 import re
 from typing import Optional
@@ -15,9 +15,7 @@ from precli.parsers.node_types import NodeTypes
 class Java(Parser):
     def __init__(self):
         super().__init__("java")
-        self.SUPPRESS_COMMENT = re.compile(
-            r"// suppress:? (?P<rules>[^#]+)?#?"
-        )
+        self.SUPPRESS_COMMENT = re.compile(r"suppress:? (?P<rules>[^#]+)?#?")
         self.SUPPRESSED_RULES = re.compile(r"(?:(JAV\d\d\d|[a-z_]+),?)+")
 
     def file_extensions(self) -> list[str]:

--- a/precli/parsers/python.py
+++ b/precli/parsers/python.py
@@ -26,7 +26,7 @@ Import = namedtuple("Import", "module alias")
 class Python(Parser):
     def __init__(self, **config):
         super().__init__("python")
-        self.SUPPRESS_COMMENT = re.compile(r"# suppress:? (?P<rules>[^#]+)?#?")
+        self.SUPPRESS_COMMENT = re.compile(r"suppress:? (?P<rules>[^#]+)?#?")
         self.SUPPRESSED_RULES = re.compile(r"(?:(PY\d\d\d|[a-z_]+),?)+")
 
         if "skip_tests" in config:

--- a/precli/targets/__init__.py
+++ b/precli/targets/__init__.py
@@ -7,7 +7,35 @@ from precli.core.artifact import Artifact
 
 class Target(ABC):
     def __init__(self):
-        self.FILE_EXTS = (".go", ".java", ".py", ".pyw")
+        self.FILE_EXTS = (
+            ".cpp",
+            ".cc",
+            ".cxx",
+            ".hpp",
+            ".h",
+            ".cs",
+            ".css",
+            ".hs",
+            ".lhs",
+            ".js",
+            ".go",
+            ".java",
+            ".pl",
+            ".pm",
+            ".t",
+            ".php",
+            ".phtml",
+            ".php3",
+            ".php4",
+            ".php5",
+            ".py",
+            ".pyw",
+            ".rb",
+            ".scala",
+            ".swift",
+            ".ts",
+            ".tsx",
+        )
 
     @abstractmethod
     def discover(self, target: str, recursive: bool) -> list[Artifact]:


### PR DESCRIPTION
This is an example of using the custom rule function with an unsupported language such as Ruby. The prerequiste is the user needs to install tree_sitter_ruby for this to work.

Note: this doesn't work for all tree-sitter parsers available since the tree-sitter in use by precli requires language version 15 to work. So C and Rust currently do not work, possibly others.

Closes: #773