### PR TITLE
Add custom rule for the swift language

### DIFF
--- a/custom/swift/HomeDirectory.swift
+++ b/custom/swift/HomeDirectory.swift
@@ -1,0 +1,2 @@
+
+let path = NSHomeDirectory() + "/.ssh/config"

--- a/custom/swift/swift-nshomedirectory-path-concat.yaml
+++ b/custom/swift/swift-nshomedirectory-path-concat.yaml
@@ -1,0 +1,16 @@
+id: SW001C
+name: swift-nshomedirectory-path-concat
+language: swift
+description: >
+  Directly using `NSHomeDirectory()` and string concatenation can result in
+  insecure path constructions. Use `FileManager` with `.documentDirectory`,
+  `.applicationSupportDirectory`, etc. for secure, platform-correct behavior.
+cwe: 22
+query: |
+  (call_expression
+    (simple_identifier) @func
+    (call_suffix (value_arguments)))
+  (#eq? @func "NSHomeDirectory")
+message: "Avoid using `NSHomeDirectory()` for sensitive file paths."
+severity: warning
+location_node: func

--- a/precli/core/cwe.py
+++ b/precli/core/cwe.py
@@ -5,6 +5,10 @@ from precli.i18n import _
 
 class Cwe:
     _cwe_names = {
+        22: _(
+            "Improper Limitation of a Pathname to a Restricted Directory "
+            "('Path Traversal')"
+        ),
         78: _(
             "Improper Neutralization of Special Elements used in an OS "
             "Command ('OS Command Injection')"

--- a/precli/parsers/basic.py
+++ b/precli/parsers/basic.py
@@ -14,6 +14,7 @@ LANG_MAP = {
     "javascript": [[".js"], "JS"],
     "ruby": [[".rb"], "RB"],
     "scala": [[".scala"], "SC"],
+    "swift": [[".swift"], "SW"],
     # Incompatible Language version 15. Must be between 13 and 14
     # "bash": [[".sh"], "SH"],
     # "c": [[".c", ".h"], "C",],
@@ -24,7 +25,6 @@ LANG_MAP = {
     # Query returns nothing
     # "objc": [[".m", ".mm", ".h"], "OB"],
     # "perl": [[".pl", ".pm", ".t"], "PL"],
-    # "swift": [[".swift"], "SW"],
     # "html": [[".html", ".htm"], "HTM"],
 }
 


### PR DESCRIPTION
Now that tree-sitter-swift is available on PyPI, we can add a custom rule for swift.

This change adds the custom yaml and example.

To try:
```
.tox/py313/bin/precli --custom-rules=custom/swift/ custom/swift/HomeDirectory.swift 
```